### PR TITLE
✨ Allow failing of waited builds when changes are present

### DIFF
--- a/packages/cli-build/README.md
+++ b/packages/cli-build/README.md
@@ -35,6 +35,7 @@ USAGE
 OPTIONS
   -b, --build=build        build id
   -c, --commit=commit      build's commit sha for a project
+  -f, --fail-on-changes    exits with an error when diffs are found in snapshots
   -i, --interval=interval  interval, in milliseconds, at which to poll for updates, defaults to 1000
   -p, --project=project    build's project slug, required with --commit
   -q, --quiet              log errors only

--- a/packages/cli-build/src/commands/build/wait.js
+++ b/packages/cli-build/src/commands/build/wait.js
@@ -37,6 +37,11 @@ export class Wait extends Command {
         'interval, in milliseconds, at which to poll for updates, ',
         'defaults to 1000'
       ].join('')
+    }),
+    'fail-on-changes': flags.boolean({
+      char: 'f',
+      default: false,
+      description: 'exits with an error when diffs are found in snapshots'
     })
   };
 
@@ -105,6 +110,10 @@ export class Wait extends Command {
     if (state === 'finished') {
       log.info(`Build #${number} finished! ${url}`);
       log.info(`Found ${diffs} changes`);
+
+      if (this.flags['fail-on-changes'] && diffs > 0) {
+        return this.exit(1);
+      }
     } else if (state === 'failed') {
       log.error(`Build #${number} failed! ${url}`);
       log.error(this.failure(failReason, failDetails));

--- a/packages/cli-snapshot/README.md
+++ b/packages/cli-snapshot/README.md
@@ -21,13 +21,22 @@ OPTIONS
   -b, --base-url=base-url                          [default: /] the url path to serve the static directory from
   -c, --config=config                              configuration file path
   -d, --dry-run                                    prints a list of pages to snapshot without snapshotting
-  -f, --files=files                                [default: **/*.{html,htm}] one or more globs matching static file paths to snapshot
+
+  -f, --files=files                                [default: **/*.{html,htm}] one or more globs matching static file
+                                                   paths to snapshot
+
   -h, --allowed-hostname=allowed-hostname          allowed hostnames
+
   -i, --ignore=ignore                              one or more globs matching static file paths to ignore
+
   -q, --quiet                                      log errors only
+
   -t, --network-idle-timeout=network-idle-timeout  asset discovery idle timeout
+
   -v, --verbose                                    log everything
+
   --disable-asset-cache                            disable asset discovery caches
+
   --silent                                         log nothing
 
 EXAMPLES


### PR DESCRIPTION
## What is this?

This adds a new flag (`--fail-on-changes`) that will exit `1` (fail) if there are changes found in the build that's being waited on. 