### PR TITLE
✨ Detect Heroku PR number

### DIFF
--- a/packages/env/src/environment.js
+++ b/packages/env/src/environment.js
@@ -178,6 +178,8 @@ export default class PercyEnvironment {
           return this.vars.PULL_REQUEST_NUMBER || this.vars.SEMAPHORE_GIT_PR_NUMBER;
         case 'buildkite':
           return this.vars.BUILDKITE_PULL_REQUEST !== 'false' && this.vars.BUILDKITE_PULL_REQUEST;
+        case 'heroku':
+          return this.vars.HEROKU_PR_NUMBER;
         case 'gitlab':
           return this.vars.CI_MERGE_REQUEST_IID;
         case 'azure':

--- a/packages/env/test/heroku.test.js
+++ b/packages/env/test/heroku.test.js
@@ -9,8 +9,7 @@ describe('Heroku', () => {
       HEROKU_TEST_RUN_COMMIT_VERSION: 'heroku-commit-sha',
       HEROKU_TEST_RUN_BRANCH: 'heroku-branch',
       HEROKU_TEST_RUN_ID: 'heroku-test-run-id',
-      // todo - why was this commented out?
-      // HEROKU_PULL_REQUEST: '123',
+      HEROKU_PR_NUMBER: '123',
       CI_NODE_TOTAL: '3'
     });
   });
@@ -21,7 +20,7 @@ describe('Heroku', () => {
     expect(env).toHaveProperty('branch', 'heroku-branch');
     expect(env).toHaveProperty('target.commit', null);
     expect(env).toHaveProperty('target.branch', null);
-    expect(env).toHaveProperty('pullRequest', null);
+    expect(env).toHaveProperty('pullRequest', '123');
     expect(env).toHaveProperty('parallel.nonce', 'heroku-test-run-id');
     expect(env).toHaveProperty('parallel.total', 3);
   });


### PR DESCRIPTION
## Purpose

This was not previously implemented because this variable only exists in review apps, which have been updated since Heroku support was first added.

## Approach

Found that there is a PR number variable that is injected for review apps. This variable is subject to change: https://devcenter.heroku.com/articles/github-integration-review-apps#injected-environment-variables