### PR TITLE
✨ @percy/sdk-utils

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "packages": [
     "packages/*"
   ],

--- a/packages/cli-build/package.json
+++ b/packages/cli-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-build",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
@@ -31,9 +31,9 @@
     }
   },
   "dependencies": {
-    "@percy/cli-command": "^1.0.0-beta.18",
-    "@percy/client": "^1.0.0-beta.18",
-    "@percy/env": "^1.0.0-beta.18",
-    "@percy/logger": "^1.0.0-beta.18"
+    "@percy/cli-command": "^1.0.0-beta.19",
+    "@percy/client": "^1.0.0-beta.19",
+    "@percy/env": "^1.0.0-beta.19",
+    "@percy/logger": "^1.0.0-beta.19"
   }
 }

--- a/packages/cli-command/package.json
+++ b/packages/cli-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-command",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -25,7 +25,7 @@
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
     "@oclif/plugin-help": "^3.2.0",
-    "@percy/config": "^1.0.0-beta.18",
-    "@percy/logger": "^1.0.0-beta.18"
+    "@percy/config": "^1.0.0-beta.19",
+    "@percy/logger": "^1.0.0-beta.19"
   }
 }

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-config",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
@@ -33,8 +33,8 @@
   "dependencies": {
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
-    "@percy/config": "^1.0.0-beta.18",
-    "@percy/logger": "^1.0.0-beta.18",
+    "@percy/config": "^1.0.0-beta.19",
+    "@percy/logger": "^1.0.0-beta.19",
     "path-type": "^4.0.0"
   }
 }

--- a/packages/cli-exec/package.json
+++ b/packages/cli-exec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/cli-exec",
   "description": "capture and upload snapshots",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
@@ -34,9 +34,9 @@
     }
   },
   "dependencies": {
-    "@percy/cli-command": "^1.0.0-beta.18",
-    "@percy/core": "^1.0.0-beta.18",
-    "@percy/logger": "^1.0.0-beta.18",
+    "@percy/cli-command": "^1.0.0-beta.19",
+    "@percy/core": "^1.0.0-beta.19",
+    "@percy/logger": "^1.0.0-beta.19",
     "cross-spawn": "^7.0.3",
     "which": "^2.0.2"
   }

--- a/packages/cli-snapshot/package.json
+++ b/packages/cli-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-snapshot",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
@@ -31,11 +31,11 @@
     }
   },
   "dependencies": {
-    "@percy/cli-command": "^1.0.0-beta.18",
-    "@percy/config": "^1.0.0-beta.18",
-    "@percy/core": "^1.0.0-beta.18",
-    "@percy/dom": "^1.0.0-beta.18",
-    "@percy/logger": "^1.0.0-beta.18",
+    "@percy/cli-command": "^1.0.0-beta.19",
+    "@percy/config": "^1.0.0-beta.19",
+    "@percy/core": "^1.0.0-beta.19",
+    "@percy/dom": "^1.0.0-beta.19",
+    "@percy/logger": "^1.0.0-beta.19",
     "globby": "^11.0.1",
     "serve-handler": "^6.1.3",
     "yaml": "^1.10.0"

--- a/packages/cli-upload/package.json
+++ b/packages/cli-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-upload",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
@@ -29,10 +29,10 @@
     }
   },
   "dependencies": {
-    "@percy/cli-command": "^1.0.0-beta.18",
-    "@percy/client": "^1.0.0-beta.18",
-    "@percy/config": "^1.0.0-beta.18",
-    "@percy/logger": "^1.0.0-beta.18",
+    "@percy/cli-command": "^1.0.0-beta.19",
+    "@percy/client": "^1.0.0-beta.19",
+    "@percy/config": "^1.0.0-beta.19",
+    "@percy/logger": "^1.0.0-beta.19",
     "globby": "^11.0.1",
     "image-size": "^0.9.1"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "index.js",
   "bin": {
@@ -33,10 +33,10 @@
   "dependencies": {
     "@oclif/plugin-help": "^3.2.0",
     "@oclif/plugin-plugins": "^1.9.0",
-    "@percy/cli-build": "^1.0.0-beta.18",
-    "@percy/cli-config": "^1.0.0-beta.18",
-    "@percy/cli-exec": "^1.0.0-beta.18",
-    "@percy/cli-snapshot": "^1.0.0-beta.18",
-    "@percy/cli-upload": "^1.0.0-beta.18"
+    "@percy/cli-build": "^1.0.0-beta.19",
+    "@percy/cli-config": "^1.0.0-beta.19",
+    "@percy/cli-exec": "^1.0.0-beta.19",
+    "@percy/cli-snapshot": "^1.0.0-beta.19",
+    "@percy/cli-upload": "^1.0.0-beta.19"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/client",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
@@ -23,6 +23,6 @@
     "mock-require": "^3.0.3"
   },
   "dependencies": {
-    "@percy/env": "^1.0.0-beta.18"
+    "@percy/env": "^1.0.0-beta.19"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/config",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -22,7 +22,7 @@
     "require": "../../scripts/babel-register"
   },
   "dependencies": {
-    "@percy/logger": "^1.0.0-beta.18",
+    "@percy/logger": "^1.0.0-beta.19",
     "ajv": "^6.12.5",
     "cosmiconfig": "^7.0.0",
     "deepmerge": "^4.2.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/core",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -25,9 +25,9 @@
     "timeout": 10000
   },
   "dependencies": {
-    "@percy/client": "^1.0.0-beta.18",
-    "@percy/dom": "^1.0.0-beta.18",
-    "@percy/logger": "^1.0.0-beta.18",
+    "@percy/client": "^1.0.0-beta.19",
+    "@percy/dom": "^1.0.0-beta.19",
+    "@percy/logger": "^1.0.0-beta.19",
     "node-fetch": "^2.6.1",
     "progress": "^2.0.3",
     "puppeteer-core": "^5.3.1"

--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -51,7 +51,7 @@ export function createServer(routes) {
     });
 
     request.on('end', async () => {
-      try { request.body = JSON.parse(request.body); } catch {}
+      try { request.body = JSON.parse(request.body); } catch (e) {}
       let [status, headers, body] = await getReply(context, request);
       response.writeHead(status, headers).end(body);
     });

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/dom",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/env",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/logger",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "index.js",
   "files": [

--- a/packages/sdk-utils/LICENSE
+++ b/packages/sdk-utils/LICENSE
@@ -1,0 +1,18 @@
+Copyright © Perceptual Inc.
+
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/sdk-utils/README.md
+++ b/packages/sdk-utils/README.md
@@ -1,0 +1,117 @@
+# @percy/sdk-utils
+
+Common Node SDK utils
+
+## Usage
+
+### `log(level, message)`
+
+Logs colored output and stack traces based on the loglevel defined by the `PERCY_LOGLEVEL`
+environment variable.
+
+``` js
+const { log } = require('@percy/sdk-utils');
+
+// logs unless loglevel is quiet or silent
+log('info', 'foobar');
+// [percy] foobar
+
+// logs a red error message unless the loglevel is silent
+log('error', 'bad');
+// [percy] bad
+
+// logs the stack trace when loglevel is debug
+log('error', new Error('some error'));
+// [percy] Error: some error
+//     at example (/path/to/example.js:2:10)
+//     at ...
+
+// only logs when the loglevel is debug
+log('debug', 'debug message');
+// [percy] debug message
+```
+
+### `getInfo()`
+
+Returns information about any running Percy CLI server. Some information is only available after
+[`isPercyEnabled`](#isPercyEnabled) has been called.
+
+``` js
+const { getInfo } = require('@percy/sdk-utils');
+
+let info = getInfo();
+
+// CLI API address
+info.cliAPI === (process.env.PERCY_CLI_API || 'http://localhost:5338/percy')
+
+// CLI loglevel
+info.loglevel === (process.env.PERCY_LOGLEVEL || 'info')
+
+// CLI version parts (requires isPercyEnabled call)
+info.version === (['1', '0', '0'] || undefined)
+
+// CLI config options (requires isPercyEnableld calll)
+info.config === {}
+```
+
+### `isPercyEnabled()`
+
+Returns `true` or `false` if the Percy CLI API server is running. Calls the server's `/healthcheck`
+endpoint and populates information for [`getInfo`](#getInfo). The result of this function is cached
+and subsequent calls will return the first cached result. If the healthcheck fails, will log a
+message unless the CLI loglevel is `quiet` or `silent`.
+
+``` js
+const { isPercyEnabled } = require('@percy/sdk-utils');
+
+// CLI API not running
+await isPercyEnabled() === false
+// [percy] Percy is not running, disabling snapshots
+
+// CLI API is running
+await isPercyEnabled() === true
+```
+
+### `fetchPercyDOM()`
+
+Fetches and returns the `@percy/dom` serialization script hosted by the CLI API server. The
+resulting string can be evaulated within a browser context to add the `PercyDOM.serialize` function
+to the global scope. Subsequent calls return the first cached result.
+
+``` js
+const { fetchPercyDOM } = require('@percy/sdk-utils');
+
+let script = await fetchPercyDOM();
+
+// selenium-webdriver
+driver.executeScript(script);
+// webdriverio
+browser.execute(script);
+// puppeteer
+page.evaluate(script);
+// protractor
+browser.executeScript(script);
+// etc...
+```
+
+### `postSnapshot(options)`
+
+Posts snapshot options to the CLI API server.
+
+``` js
+const { postSnapshot } = require('@percy/sdk-utils');
+
+await postSnapshot({
+  // required
+  name: 'Snapshot Name',
+  url: 'http://localhost:8000/',
+  domSnapshot: 'result from PercyDOM.serialize()'
+  // optional
+  environmentInfo: ['<lib>/<version>', '<lang>/<version>'],
+  clientInfo: '<sdk>/<version>',
+  widths: [475, 1280],
+  minHeight: 1024,
+  enableJavaScript: false,
+  requestHeaders: {}
+});
+```

--- a/packages/sdk-utils/README.md
+++ b/packages/sdk-utils/README.md
@@ -50,7 +50,7 @@ info.loglevel === (process.env.PERCY_LOGLEVEL || 'info')
 // CLI version parts (requires isPercyEnabled call)
 info.version === (['1', '0', '0'] || undefined)
 
-// CLI config options (requires isPercyEnableld calll)
+// CLI config options (requires isPercyEnabled call)
 info.config === {}
 ```
 

--- a/packages/sdk-utils/index.js
+++ b/packages/sdk-utils/index.js
@@ -1,0 +1,129 @@
+// Maybe get the CLI API address and loglevel from the environment
+const {
+  PERCY_CLI_API = 'http://localhost:5338/percy',
+  PERCY_LOGLEVEL = 'info'
+} = process.env;
+
+// Helper to send a request to the local CLI API
+function request(path, { body, ...options } = {}) {
+  let { protocol, hostname, port, pathname, search } = new URL(PERCY_CLI_API + path);
+  options = { ...options, protocol, hostname, port, path: pathname + search };
+
+  return new Promise((resolve, reject) => {
+    require('http').request(options)
+      .on('response', res => {
+        let { statusCode, statusMessage, headers } = res;
+        let raw = '';
+
+        res.setEncoding('utf8');
+        res.on('data', chunk => (raw += chunk));
+        res.on('end', () => {
+          let r = { statusCode, statusMessage, headers, body: raw };
+
+          if (headers['content-type'] === 'application/json') {
+            try { r.body = JSON.parse(raw); } catch (e) {}
+          }
+
+          if (statusCode >= 200 && statusCode < 300) {
+            resolve(r);
+          } else {
+            reject(Object.assign(new Error(), {
+              message: r.body.error || `${statusCode} ${statusMessage}`,
+              response: r
+            }));
+          }
+        });
+      })
+      .on('error', reject)
+      .end(body);
+  });
+}
+
+// Log colored labels and errors using loglevels
+let linereg = /^.*$/gm;
+function log(level, msg) {
+  let l = { debug: 0, info: 1, warn: 2, error: 3 };
+  if (l[PERCY_LOGLEVEL] == null || l[level] < l[PERCY_LOGLEVEL]) return;
+  let c = (n, s) => s.replace(linereg, l => `\u001b[${n}m${l}\u001b[39m`);
+
+  if (level === 'error' || msg.stack) {
+    msg = (PERCY_LOGLEVEL === 'debug' && msg.stack) || msg.toString();
+    console.error(`[${c(35, 'percy')}] ${c(31, msg)}`);
+  } else if (level === 'warn') {
+    console.warn(`[${c(35, 'percy')}] ${c(33, msg)}`);
+  } else {
+    console.log(`[${c(35, 'percy')}] ${msg}`);
+  }
+}
+
+// Returns CLI information
+function getInfo() {
+  return {
+    cliApi: PERCY_CLI_API,
+    loglevel: PERCY_LOGLEVEL,
+    version: getInfo.version,
+    config: getInfo.config
+  };
+}
+
+// Helper to create a tuple from the version string
+function toVersionTuple(s) {
+  return s ? s.split(/\.|-/).map(p => {
+    let i = parseInt(p, 10);
+    return isNaN(i) ? p : i;
+  }) : [0];
+}
+
+// Check if Percy is enabled using the healthcheck endpoint
+async function isPercyEnabled() {
+  if (isPercyEnabled.result == null) {
+    let error;
+
+    try {
+      let { headers, body } = await request('/healthcheck');
+      getInfo.version = toVersionTuple(headers['x-percy-core-version']);
+      getInfo.config = body.config;
+      isPercyEnabled.result = true;
+    } catch (e) {
+      isPercyEnabled.result = false;
+      error = e;
+    }
+
+    if (getInfo.version && getInfo.version[0] !== 1) {
+      log('info', 'Unsupported Percy CLI version, disabling snapshots');
+      log('debug', `Found version: ${getInfo.version}`);
+      isPercyEnabled.result = false;
+    } else if (!isPercyEnabled.result) {
+      log('info', 'Percy is not running, disabling snapshots');
+      log('debug', error);
+    }
+  }
+
+  return isPercyEnabled.result;
+}
+
+// Fetch and cache the @percy/dom script
+async function fetchPercyDOM() {
+  if (fetchPercyDOM.result == null) {
+    let { body } = await request('/dom.js');
+    fetchPercyDOM.result = body;
+  }
+
+  return fetchPercyDOM.result;
+}
+
+// Post snapshot data to the snapshot endpoint
+async function postSnapshot(options) {
+  await request('/snapshot', {
+    method: 'POST',
+    body: JSON.stringify(options)
+  });
+}
+
+module.exports = {
+  log,
+  getInfo,
+  isPercyEnabled,
+  fetchPercyDOM,
+  postSnapshot
+};

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@percy/sdk-utils",
+  "version": "1.0.0-beta.18",
+  "license": "MIT",
+  "main": "index.js",
+  "files": [
+    "index.js",
+    "test/helper.js"
+  ],
+  "scripts": {
+    "lint": "eslint --ignore-path ../../.gitignore .",
+    "test": "cross-env NODE_ENV=test mocha",
+    "test:coverage": "nyc yarn test"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "mocha": {
+    "require": "../../scripts/babel-register"
+  }
+}

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/sdk-utils",
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "license": "MIT",
   "main": "index.js",
   "files": [

--- a/packages/sdk-utils/test/.eslintrc
+++ b/packages/sdk-utils/test/.eslintrc
@@ -1,0 +1,2 @@
+env:
+  mocha: true

--- a/packages/sdk-utils/test/helper.js
+++ b/packages/sdk-utils/test/helper.js
@@ -1,0 +1,75 @@
+const createTestServer = require('@percy/core/test/helpers/server');
+const sdk = {};
+
+sdk.setup = async function setup() {
+  // mock percy server
+  sdk.server = await createTestServer({
+    '/percy/dom.js': () => [200, 'application/javascript', (
+      `window.PercyDOM = { serialize: ${sdk.serialize.toString()} }`)],
+    '/percy/healthcheck': () => [200, 'application/json', (
+      { success: true, config: { snapshot: { widths: [1280] } } })],
+    '/percy/snapshot': () => [200, 'application/json', { success: true }]
+  }, 5338);
+
+  // reset things
+  delete process.env.PERCY_CLI_API;
+  delete process.env.PERCY_LOGLEVEL;
+  sdk.serialize = () => document.documentElement.outerHTML;
+  sdk.stdio[1] = []; sdk.stdio[2] = [];
+
+  let utils = require('..');
+  delete utils.getInfo.version;
+  delete utils.getInfo.config;
+  delete utils.isPercyEnabled.result;
+  delete utils.fetchPercyDOM.result;
+};
+
+sdk.teardown = async function teardown() {
+  await sdk.server.close();
+};
+
+sdk.rerequire = function rerequire(module) {
+  delete require.cache[require.resolve(module)];
+  return require(module);
+};
+
+sdk.test = {
+  failure: (path, error) => sdk.server.reply(path, () => (
+    [500, 'application/json', { success: false, error }])),
+  error: path => sdk.server.reply(path, r => r.connection.destroy())
+};
+
+sdk.testsite = {
+  mock: async () => {
+    sdk.testsite = await createTestServer({
+      default: () => [200, 'text/html', 'Snapshot Me']
+    });
+  }
+};
+
+sdk.stdio = function stdio(fn, { colors = false } = {}) {
+  // eslint-disable-next-line no-control-regex
+  let format = s => colors ? s : s.replace(/\x1B\[\d+m/g, '');
+  let out = process.stdout.write;
+  let err = process.stderr.write;
+  let r, e;
+
+  let done = (r, e) => {
+    process.stdout.write = out;
+    process.stderr.write = err;
+    if (e) throw e;
+    return r;
+  };
+
+  process.stdout.write = s => stdio[1].push(format(s));
+  process.stderr.write = s => stdio[2].push(format(s));
+  try { r = fn(); } catch (err) { e = err; }
+
+  if (!e && r && typeof r.then === 'function') {
+    return r.then(done, e => done(r, e));
+  } else {
+    return done(r, e);
+  }
+};
+
+module.exports = sdk;

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -1,0 +1,238 @@
+import expect from 'expect';
+import colors from 'colors/safe';
+import sdk from './helper';
+
+describe('SDK Utils', () => {
+  let label = colors.magenta('percy');
+
+  beforeEach(async () => {
+    await sdk.setup();
+  });
+
+  afterEach(async () => {
+    await sdk.teardown();
+  });
+
+  describe('log(level, msg)', () => {
+    let log;
+
+    it('logs info messages by default', () => {
+      ({ log } = sdk.rerequire('..'));
+
+      sdk.stdio(() => {
+        log('info', 'informational');
+        log('warn', 'warning');
+        log('error', new Error('test'));
+        log('debug', 'wat?');
+      }, { colors: true });
+
+      expect(sdk.stdio[1]).toEqual([
+        `[${label}] informational\n`
+      ]);
+      expect(sdk.stdio[2]).toEqual([
+        `[${label}] ${colors.yellow('warning')}\n`,
+        `[${label}] ${colors.red('Error: test')}\n`
+      ]);
+    });
+
+    it('logs warnings and errors when PERCY_LOGLEVEL is "warn"', () => {
+      process.env.PERCY_LOGLEVEL = 'warn';
+      ({ log } = sdk.rerequire('..'));
+
+      sdk.stdio(() => {
+        log('info', 'informational');
+        log('warn', 'warning');
+        log('error', new Error('test'));
+        log('debug', 'wat?');
+      }, { colors: true });
+
+      expect(sdk.stdio[1]).toEqual([]);
+      expect(sdk.stdio[2]).toEqual([
+        `[${label}] ${colors.yellow('warning')}\n`,
+        `[${label}] ${colors.red('Error: test')}\n`
+      ]);
+    });
+
+    it('logs only errors when PERCY_LOGLEVEL is "error"', () => {
+      process.env.PERCY_LOGLEVEL = 'error';
+      ({ log } = sdk.rerequire('..'));
+
+      sdk.stdio(() => {
+        log('info', 'informational');
+        log('warn', 'warning');
+        log('error', new Error('test'));
+        log('debug', 'wat?');
+      }, { colors: true });
+
+      expect(sdk.stdio[1]).toEqual([]);
+      expect(sdk.stdio[2]).toEqual([
+        `[${label}] ${colors.red('Error: test')}\n`
+      ]);
+    });
+
+    it('logs debug messages and errors stacks when PERCY_LOGLEVEL is "debug"', () => {
+      let error = new Error('test');
+      process.env.PERCY_LOGLEVEL = 'debug';
+
+      sdk.stdio(() => {
+        ({ log } = sdk.rerequire('..'));
+        log('info', 'informational');
+        log('warn', 'warning');
+        log('error', error);
+        log('debug', 'wat?');
+      }, { colors: true });
+
+      expect(sdk.stdio[1]).toEqual([
+        `[${label}] informational\n`,
+        `[${label}] wat?\n`
+      ]);
+      expect(sdk.stdio[2]).toEqual([
+        `[${label}] ${colors.yellow('warning')}\n`,
+        `[${label}] ${colors.red(error.stack)}\n`
+      ]);
+    });
+
+    it('does not log when PERCY_LOGLEVEL is unknown', () => {
+      process.env.PERCY_LOGLEVEL = 'silent';
+      ({ log } = sdk.rerequire('..'));
+
+      sdk.stdio(() => {
+        log('info', 'informational');
+        log('warn', 'warning');
+        log('error', new Error('test'));
+        log('debug', 'wat?');
+      }, { colors: true });
+
+      expect(sdk.stdio[1]).toEqual([]);
+      expect(sdk.stdio[2]).toEqual([]);
+    });
+  });
+
+  describe('getInfo()', () => {
+    it('returns the CLI API address as defined by PERCY_CLI_API', () => {
+      expect(process.env.PERCY_CLI_API).toBeUndefined();
+      expect(sdk.rerequire('..').getInfo())
+        .toHaveProperty('cliApi', 'http://localhost:5338/percy');
+      delete require.cache[require.resolve('..')];
+
+      process.env.PERCY_CLI_API = 'http://localhost:1234/percy';
+      expect(sdk.rerequire('..').getInfo())
+        .toHaveProperty('cliApi', 'http://localhost:1234/percy');
+    });
+
+    it('returns the loglevel as defined by PERCY_LOGLEVEL', () => {
+      expect(process.env.PERCY_LOGLEVEL).toBeUndefined();
+      expect(sdk.rerequire('..').getInfo()).toHaveProperty('loglevel', 'info');
+      delete require.cache[require.resolve('..')];
+
+      process.env.PERCY_LOGLEVEL = 'debug';
+      expect(sdk.rerequire('..').getInfo()).toHaveProperty('loglevel', 'debug');
+    });
+
+    describe('after calling isPercyEnabled()', () => {
+      let getInfo, isPercyEnabled;
+
+      beforeEach(async () => {
+        ({ getInfo, isPercyEnabled } = sdk.rerequire('..'));
+
+        sdk.server.reply('/percy/healthcheck', () => [200, 'application/json', {
+          config: { snapshot: { widths: [1080] } },
+          success: true
+        }]);
+
+        await expect(isPercyEnabled()).resolves.toBe(true);
+      });
+
+      it('returns the CLI version', () => {
+        expect(getInfo()).toHaveProperty('version.0', 1);
+      });
+
+      it('returns CLI config', () => {
+        expect(getInfo()).toHaveProperty('config.snapshot.widths', [1080]);
+      });
+    });
+  });
+
+  describe('isPercyEnabled()', () => {
+    let isPercyEnabled;
+
+    beforeEach(() => ({ isPercyEnabled } = sdk.rerequire('..')));
+
+    it('calls the healthcheck endpoint once and caches the result', async () => {
+      await expect(isPercyEnabled()).resolves.toBe(true);
+      await expect(isPercyEnabled()).resolves.toBe(true);
+      await expect(isPercyEnabled()).resolves.toBe(true);
+      expect(sdk.server.requests).toEqual([['/percy/healthcheck']]);
+    });
+
+    it('disables snapshots when the healthcheck fails', async () => {
+      sdk.test.failure('/percy/healthcheck');
+
+      await expect(sdk.stdio(() => isPercyEnabled()))
+        .resolves.toBe(false);
+
+      expect(sdk.stdio[1]).toEqual([
+        '[percy] Percy is not running, disabling snapshots\n'
+      ]);
+    });
+
+    it('disables snapshots when the request errors', async () => {
+      sdk.test.error('/percy/healthcheck');
+
+      await expect(sdk.stdio(() => isPercyEnabled()))
+        .resolves.toBe(false);
+
+      expect(sdk.stdio[1]).toEqual([
+        '[percy] Percy is not running, disabling snapshots\n'
+      ]);
+    });
+
+    it('disables snapshots when the API version is unsupported', async () => {
+      sdk.server.version = '';
+
+      await expect(sdk.stdio(() => isPercyEnabled()))
+        .resolves.toBe(false);
+
+      expect(sdk.stdio[1]).toEqual([
+        '[percy] Unsupported Percy CLI version, disabling snapshots\n'
+      ]);
+    });
+  });
+
+  describe('fetchPercyDOM()', () => {
+    let fetchPercyDOM;
+
+    it('fetches @percy/dom from the CLI API and caches the result', async () => {
+      ({ fetchPercyDOM } = sdk.rerequire('..'));
+      await expect(fetchPercyDOM()).resolves.toEqual(
+        'window.PercyDOM = { serialize: () => document.documentElement.outerHTML }');
+      await expect(fetchPercyDOM()).resolves.toBeDefined();
+      expect(sdk.server.requests).toEqual([['/percy/dom.js']]);
+    });
+  });
+
+  describe('postSnapshot(options)', () => {
+    let postSnapshot;
+
+    it('posts snapshot options to the CLI API snapshot endpoint', async () => {
+      ({ postSnapshot } = sdk.rerequire('..'));
+
+      let options = {
+        name: 'Snapshot Name',
+        url: 'http://localhost:8000/',
+        domSnapshot: '<SERIALIZED_DOM>',
+        clientInfo: 'sdk/version',
+        environmentInfo: ['lib/version', 'lang/version'],
+        enableJavaScript: true
+      };
+
+      await expect(postSnapshot(options)).resolves.toBeUndefined();
+      expect(sdk.server.requests).toEqual([['/percy/snapshot', options]]);
+    });
+
+    it('throws when the snapshot API fails', async () => {
+      sdk.test.failure('/percy/snapshot', 'foobar');
+      await expect(postSnapshot({})).rejects.toThrow('foobar');
+    });
+  });
+});


### PR DESCRIPTION
## What is this?

Node based SDKs have a few common utils that can be abstracted away into their own module. They also perform common setup steps in tests that can also be abstracted away into a common test helper. 

These common utils include talking to the local running Percy CLI API. Rather than have dependencies on libraries like fetch, we can use a shared request helper using native Node methods. Also, rather than including all of the `winston` dependencies of `@percy/logger`, there is a smaller, simple log util that accomplishes the goal of communicating SDK information to the user. 

The consumable utils exported by this package are `log`, `getInfo`, `isPercyEnabled`, `fetchPercyDOM`, and `postSnapshot`. [Their usage docs can be found in the readme](https://github.com/percy/cli/blob/1eedb03c72cedd2263e51d1621f8be2ac82b84bc/packages/sdk-utils/README.md)

### Other changes

I added an argument to the catch clause in the server helper which is eventually required by the new sdk-utils test helper. While testing these utils, I found that some external libraries (like `testcafe`) will attempt to compile required files even if they are compatible with the current version of Node. That compilation failed when it encountered a catch without arguments.