### PR TITLE
🐛 Fix config merging

### DIFF
--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -24,6 +24,9 @@
   "oclif": {
     "bin": "percy",
     "commands": "./dist/commands",
+    "hooks": {
+      "init": "./dist/hooks/init"
+    },
     "topics": {
       "config": {
         "description": "manage Percy config files"
@@ -34,6 +37,7 @@
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
     "@percy/config": "^1.0.0-beta.20",
+    "@percy/core": "^1.0.0-beta.20",
     "@percy/logger": "^1.0.0-beta.20",
     "path-type": "^4.0.0"
   }

--- a/packages/cli-config/src/hooks/init.js
+++ b/packages/cli-config/src/hooks/init.js
@@ -1,0 +1,7 @@
+import PercyConfig from '@percy/config';
+import { schema } from '@percy/core/dist/config';
+
+// ensures the core schema is loaded
+export default function() {
+  PercyConfig.addSchema(schema);
+}

--- a/packages/cli-config/test/validate.test.js
+++ b/packages/cli-config/test/validate.test.js
@@ -68,8 +68,8 @@ describe('percy config:validate', () => {
     expect(stdio[1]).toEqual([
       '[percy] Found config file: .invalid.yml\n',
       '[percy] Invalid config:\n',
-      '[percy] - unknown property \'bar\'\n',
-      '[percy] - \'test.value\' should be a string, received a boolean\n'
+      '[percy] - bar: unknown property\n',
+      '[percy] - test.value: should be a string, received a boolean\n'
     ]);
   });
 });

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -25,7 +25,6 @@
     "@percy/logger": "^1.0.0-beta.20",
     "ajv": "^6.12.5",
     "cosmiconfig": "^7.0.0",
-    "deepmerge": "^4.2.2",
     "path-type": "^4.0.0",
     "yaml": "^1.10.0"
   },

--- a/packages/config/src/defaults.js
+++ b/packages/config/src/defaults.js
@@ -1,33 +1,30 @@
-import merge from 'deepmerge';
+import { merge } from './normalize';
 import { getSchema } from './validate';
 
-const { assign, entries, freeze } = Object;
+const { assign, entries } = Object;
 
 // Recursively walks a schema and collects defaults. When no schema is provided,
-// the default config schema is used. Returned defaults are frozen.
+// the default config schema is used.
 function getDefaultFromSchema(schema) {
   if (!schema || typeof schema.$ref === 'string') {
     // get the schema from ajv
     return getDefaultFromSchema(getSchema(schema?.$ref ?? 'config'));
   } else if (schema.default != null) {
-    // return the frozen default for this schema
-    return freeze(schema.default);
+    // return the default for this schema
+    return schema.default;
   } else if (schema.type === 'object' && schema.properties) {
-    // return a frozen object of default properties
-    return freeze(
-      entries(schema.properties).reduce((acc, [prop, schema]) => {
-        let def = getDefaultFromSchema(schema);
-        return def != null ? assign(acc || {}, { [prop]: def }) : acc;
-      }, undefined)
-    );
+    // return an object of default properties
+    return entries(schema.properties).reduce((acc, [prop, schema]) => {
+      let def = getDefaultFromSchema(schema);
+      return def != null ? assign(acc || {}, { [prop]: def }) : acc;
+    }, undefined);
   } else {
     return undefined;
   }
 }
 
 export default function getDefaults(overrides = {}) {
-  return merge.all([getDefaultFromSchema(), overrides], {
-    // overwrite default arrays, do not merge
-    arrayMerge: (_, arr) => arr
+  return merge(getDefaultFromSchema(), overrides, {
+    replaceArrays: true
   });
 }

--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -1,7 +1,6 @@
 import { relative } from 'path';
 import { cosmiconfigSync } from 'cosmiconfig';
 import { isDirectorySync } from 'path-type';
-import merge from 'deepmerge';
 import log from '@percy/logger';
 import getDefaults from './defaults';
 import normalize from './normalize';
@@ -58,8 +57,7 @@ export default function load({
               : 'unsupported version'
           ));
         } else {
-          // normalize to remove empty values and convert snake-case to camelCase
-          config = normalize(result.config);
+          config = result.config;
           cache.set(path, config);
         }
       } else {
@@ -72,7 +70,7 @@ export default function load({
   }
 
   // merge found config with overrides and validate
-  config = merge(config || {}, overrides);
+  config = normalize(config || {}, overrides);
   if (!validate(config, { scrub: true }) && bail) return;
 
   // normalize again to remove empty values from overrides and validation scrubbing

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -1,25 +1,5 @@
-// recursively reduces config objects and arrays to remove undefined and empty
-// values and rename kebab-case properties to camelCase.
-export default function normalize(subject) {
-  if (typeof subject === 'object') {
-    let isArray = Array.isArray(subject);
-
-    return Object.entries(subject)
-      .reduce((result, [key, value]) => {
-        value = normalize(value);
-
-        if (typeof value !== 'undefined') {
-          return isArray
-            ? (result || []).concat(value)
-            : Object.assign(result || {}, { [camelize(key)]: value });
-        } else {
-          return result;
-        }
-      }, undefined);
-  } else {
-    return subject;
-  }
-}
+const { isArray } = Array;
+const { entries, assign } = Object;
 
 // Edge case camelizations
 const CAMELIZE_MAP = {
@@ -28,8 +8,30 @@ const CAMELIZE_MAP = {
 };
 
 // Converts a kebab-cased string to camelCase.
-function camelize(s) {
-  return s.replace(/-([^-]+)/g, (_, w) => (
+function camelize(str) {
+  return str.replace(/-([^-]+)/g, (_, w) => (
     CAMELIZE_MAP[w] || (w[0].toUpperCase() + w.slice(1))
   ));
+}
+
+// Merges source values into the target object unless empty. When `options.replaceArrays` is truthy,
+// target arrays are replaced by their source arrays rather than concatenated together.
+export function merge(target, source, options) {
+  let isSourceArray = isArray(source);
+  if (options?.replaceArrays && isSourceArray) return source;
+  if (typeof source !== 'object') return source != null ? source : target;
+
+  return entries(source).reduce((result, [key, value]) => {
+    value = merge(result?.[key], value, options);
+
+    return value == null ? result
+      : isSourceArray ? (result || []).concat(value)
+        : assign(result || {}, { [camelize(key)]: value });
+  }, target);
+}
+
+// Recursively reduces config objects and arrays to remove undefined and empty values and rename
+// kebab-case properties to camelCase. Optionally allows deep merging of override values
+export default function normalize(object, overrides) {
+  return merge(merge(undefined, object), overrides);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3973,11 +3973,6 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
-  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
-
 default-require-extensions@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-3.0.0.tgz#e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96"


### PR DESCRIPTION
## Purpose

Some aspects of config merging was broken due to either frozen objects, or strange rules around empty objects.

Additionally, the `config:validate` command did not validate core configuration options because the schema is not yet loaded when that command is run.

## Approach

Remove the deepmerge dependency which seemingly will override objects when merging an empty object. This functionality was easy to replace by utilizing the existing `normalize` util's traversal loop to override values while normalizing them. The core loop was refactored out of the normalize function and is also utilized by the `getDefaults()` function to merge overrides while replacing default arrays (rather than concat arrays with the normal merge behavior).

To validate core configuration options with `config:validate`, the core config schema can be added within a hook similar to how snapshot and upload config options are added.