### PR TITLE
✨ Retry specific request error codes

### DIFF
--- a/packages/client/test/helper.js
+++ b/packages/client/test/helper.js
@@ -70,6 +70,11 @@ const mockAPI = {
     this.replies[path] = this.replies[path] || [];
     this.replies[path].push(handler);
     return this;
+  },
+
+  cleanAll() {
+    nock.cleanAll();
+    return this;
   }
 };
 


### PR DESCRIPTION
## What is this?

The old `percy-js/client` library had retry handlers for specific request error codes. Unsure how/why they were dropped during the transition, but this PR adds them back with a `shouldRetryRequest` helper that is utilized within request error handlers.