### PR TITLE
🐛 Start server after launching a browser and creating a build

### DIFF
--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -90,12 +90,12 @@ export default class Percy {
     this.client.getToken();
 
     try {
-      // if there is a server, start listening
-      await this.server?.listen(this.port);
-
       // launch the discoverer browser and create a percy build
       await this.discoverer.launch();
       await this.client.createBuild();
+
+      // if there is a server, start listening
+      await this.server?.listen(this.port);
 
       // log build details
       let build = this.client.build;
@@ -106,9 +106,9 @@ export default class Percy {
       // mark this process as running
       this.#running = true;
     } catch (error) {
-      // on error, close any running browser or server
-      await this.discoverer.close();
+      // on error, close any running server or browser
       await this.server?.close();
+      await this.discoverer.close();
 
       // throw an easier-to understand error when the port is taken
       if (error.code === 'EADDRINUSE') {

--- a/packages/core/test/.eslintrc
+++ b/packages/core/test/.eslintrc
@@ -1,2 +1,5 @@
 env:
   mocha: true
+rules:
+  no-return-assign: off
+  no-sequences: off


### PR DESCRIPTION
## Purpose

When using the `exec:start` command it downloads a browser if needed just like the `exec` command. However, the `exec` command waits for the start process to resolve directly before calling the provided command while the user/SDK is left to check this themselves when using `exec:start`. The healthcheck endpoint resolves when the server is listening, but the server is actually listening before a browser is downloaded and the process is actually ready.

## Approach

Move the server start process to after the browser launch and build creation processes. This ensures that the server, and therefore the healthcheck endpoint, will only resolve when actually ready.

To test this, the various methods are stubbed to capture a timestamp and the resulting timestamps are compared after starting the whole process.