### PR TITLE
♻ Remove path from cli api address

### DIFF
--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -75,7 +75,7 @@ export default class Percy {
 
   // Snapshot server API address
   apiAddress() {
-    return `http://localhost:${this.port}/percy`;
+    return `http://localhost:${this.port}`;
   }
 
   // Returns a boolean indicating if this instance is running.

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -100,7 +100,7 @@ describe('Percy', () => {
 
   describe('#apiAddress()', () => {
     it('returns the server API address', async () => {
-      expect(percy.apiAddress()).toEqual('http://localhost:5338/percy');
+      expect(percy.apiAddress()).toEqual('http://localhost:5338');
     });
   });
 

--- a/packages/sdk-utils/README.md
+++ b/packages/sdk-utils/README.md
@@ -42,7 +42,7 @@ const { getInfo } = require('@percy/sdk-utils');
 let info = getInfo();
 
 // CLI API address
-info.cliAPI === (process.env.PERCY_CLI_API || 'http://localhost:5338/percy')
+info.cliApi === (process.env.PERCY_CLI_API || 'http://localhost:5338')
 
 // CLI loglevel
 info.loglevel === (process.env.PERCY_LOGLEVEL || 'info')

--- a/packages/sdk-utils/index.js
+++ b/packages/sdk-utils/index.js
@@ -1,6 +1,6 @@
 // Maybe get the CLI API address and loglevel from the environment
 const {
-  PERCY_CLI_API = 'http://localhost:5338/percy',
+  PERCY_CLI_API = 'http://localhost:5338',
   PERCY_LOGLEVEL = 'info'
 } = process.env;
 
@@ -80,7 +80,7 @@ async function isPercyEnabled() {
     let error;
 
     try {
-      let { headers, body } = await request('/healthcheck');
+      let { headers, body } = await request('/percy/healthcheck');
       getInfo.version = toVersionTuple(headers['x-percy-core-version']);
       getInfo.config = body.config;
       isPercyEnabled.result = true;
@@ -105,7 +105,7 @@ async function isPercyEnabled() {
 // Fetch and cache the @percy/dom script
 async function fetchPercyDOM() {
   if (fetchPercyDOM.result == null) {
-    let { body } = await request('/dom.js');
+    let { body } = await request('/percy/dom.js');
     fetchPercyDOM.result = body;
   }
 
@@ -114,7 +114,7 @@ async function fetchPercyDOM() {
 
 // Post snapshot data to the snapshot endpoint
 async function postSnapshot(options) {
-  await request('/snapshot', {
+  await request('/percy/snapshot', {
     method: 'POST',
     body: JSON.stringify(options)
   });

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -112,12 +112,12 @@ describe('SDK Utils', () => {
     it('returns the CLI API address as defined by PERCY_CLI_API', () => {
       expect(process.env.PERCY_CLI_API).toBeUndefined();
       expect(sdk.rerequire('..').getInfo())
-        .toHaveProperty('cliApi', 'http://localhost:5338/percy');
+        .toHaveProperty('cliApi', 'http://localhost:5338');
       delete require.cache[require.resolve('..')];
 
-      process.env.PERCY_CLI_API = 'http://localhost:1234/percy';
+      process.env.PERCY_CLI_API = 'http://localhost:1234';
       expect(sdk.rerequire('..').getInfo())
-        .toHaveProperty('cliApi', 'http://localhost:1234/percy');
+        .toHaveProperty('cliApi', 'http://localhost:1234');
     });
 
     it('returns the loglevel as defined by PERCY_LOGLEVEL', () => {


### PR DESCRIPTION
# What is this?

Removing the path from the address will make it less error-prone to customize by not requiring that the env var ends in `/percy`