### PR TITLE
🐛 Fix CSSOM check

### DIFF
--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -2,7 +2,7 @@
 function isCSSOM(styleSheet) {
   // no href, has a rulesheet, and isn't already in the DOM
   return !styleSheet.href && styleSheet.cssRules &&
-    !styleSheet.ownerNode?.innerText.trim().length;
+    !styleSheet.ownerNode?.innerText?.trim().length;
 }
 
 // Outputs in-memory CSSOM into their respective DOM nodes.


### PR DESCRIPTION
## What is this?

Sometimes `innerText` can be undefined which causes this function to error when it should report true. This check is present in the old serialization script in agent, but it couldn't be confirmed if it was needed since I'm not quite sure how to replicate that behavior to test it.