### PR TITLE
🐛 Upload Percy CSS as a root asset

### DIFF
--- a/packages/core/src/percy-css.js
+++ b/packages/core/src/percy-css.js
@@ -14,7 +14,7 @@ export default function injectPercyCSS(rootUrl, originalDOM, percyCSS, meta) {
   log.debug(`-> filename: ${filename}`, meta);
   log.debug(`-> content: ${percyCSS}`, meta);
 
-  let url = `${rootUrl}/${filename}`;
+  let url = `${new URL(rootUrl).origin}/${filename}`;
   let resource = createLocalResource(url, percyCSS, 'text/css', null, meta);
   let link = `<link data-percy-specific-css rel="stylesheet" href="/${filename}"/>`;
   let dom = originalDOM.replace(/(<\/body>)(?!.*\1)/is, link + '$&');

--- a/packages/core/test/percy-css.test.js
+++ b/packages/core/test/percy-css.test.js
@@ -45,7 +45,8 @@ describe('Percy CSS', () => {
       .body.data.relationships.resources.data;
 
     expect(resources[1].id).toBe(sha256hash('p { color: purple; }'));
-    expect(resources[1].attributes['resource-url']).toMatch(/\/percy-specific\.\d+\.css$/);
+    expect(resources[1].attributes['resource-url'])
+      .toMatch(/localhost\/percy-specific\.\d+\.css$/);
   });
 
   it('creates a percy-specific CSS file for the snapshot option', async () => {
@@ -62,7 +63,8 @@ describe('Percy CSS', () => {
       .body.data.relationships.resources.data;
 
     expect(resources[1].id).toBe(sha256hash('body { color: purple; }'));
-    expect(resources[1].attributes['resource-url']).toMatch(/\/percy-specific\.\d+\.css$/);
+    expect(resources[1].attributes['resource-url'])
+      .toMatch(/localhost\/percy-specific\.\d+\.css$/);
   });
 
   it('combines snapshot and global percy-specific CSS', async () => {
@@ -79,5 +81,21 @@ describe('Percy CSS', () => {
 
     expect(resources[1].id).toBe(sha256hash('p { color: purple; }\np { font-size: 2rem; }'));
     expect(resources[1].attributes['resource-url']).toMatch(/\/percy-specific\.\d+\.css$/);
+  });
+
+  it('correctly uploads CSS as a root asset', async () => {
+    await percy.snapshot({
+      name: 'test snapshot',
+      url: 'http://localhost/pathname',
+      domSnapshot: testDOM
+    });
+
+    await percy.idle();
+    let resources = mockAPI.requests['/builds/123/snapshots'][0]
+      .body.data.relationships.resources.data;
+
+    expect(resources[1].id).toBe(sha256hash('p { color: purple; }'));
+    expect(resources[1].attributes['resource-url'])
+      .toMatch(/localhost\/percy-specific\.\d+\.css$/);
   });
 });


### PR DESCRIPTION
## Purpose

When the Percy CSS file is injected into the DOM, it is injected as a root-level asset. However, when uploaded, the resource URL is defined relative to the root resource URL which may contain an additional pathname. 

## Approach

Construct the Percy CSS file's URL from the root URL's origin rather than the entire root URL.