### PR TITLE
✨ Export CLI commands

### DIFF
--- a/packages/cli-build/src/index.js
+++ b/packages/cli-build/src/index.js
@@ -1,1 +1,4 @@
-export default {};
+const { Finalize } = require('./commands/build/finalize');
+const { Wait } = require('./commands/build/wait');
+
+module.exports = { Finalize, Wait };

--- a/packages/cli-config/src/index.js
+++ b/packages/cli-config/src/index.js
@@ -1,1 +1,5 @@
-export default {};
+const { Create } = require('./commands/config/create');
+const { Migrate } = require('./commands/build/migrate');
+const { Validate } = require('./commands/build/validate');
+
+module.exports = { Create, Migrate, Validate };

--- a/packages/cli-exec/src/index.js
+++ b/packages/cli-exec/src/index.js
@@ -1,1 +1,9 @@
-export default {};
+const { Exec } = require('./commands/exec');
+const { Ping } = require('./commands/exec/ping');
+const { Start } = require('./commands/exec/start');
+const { Stop } = require('./commands/exec/stop');
+
+module.exports = Exec;
+module.exports.Ping = Ping;
+module.exports.Start = Start;
+module.exports.Stop = Stop;

--- a/packages/cli-snapshot/src/index.js
+++ b/packages/cli-snapshot/src/index.js
@@ -1,1 +1,1 @@
-export default {};
+module.exports = require('./commands/snapshot').Snapshot;

--- a/packages/cli-upload/src/index.js
+++ b/packages/cli-upload/src/index.js
@@ -1,1 +1,1 @@
-export default {};
+module.exports = require('./commands/upload').Upload;


### PR DESCRIPTION
## What is this?

This allows for invoking commands via Node scripts without needing to invoke a subprocess.

These are exported via the commonjs syntax to avoid having to destructure the `default` property when used without ES modules.