### PR TITLE
🐛 Use absolute path for image upload root URL

### DIFF
--- a/packages/cli-upload/src/resources.js
+++ b/packages/cli-upload/src/resources.js
@@ -27,11 +27,12 @@ function createImageResource(url, content, mimetype) {
 // designed to display an image at it's native size without margins or padding.
 export default function createImageResources(filename, content, width, height) {
   let { name, ext } = path.parse(filename);
-  let url = `/${encodeURIComponent(filename)}`;
+  let rootUrl = `/${encodeURIComponent(name)}`;
+  let imageUrl = `/${encodeURIComponent(filename)}`;
   let mimetype = ext === '.png' ? 'image/png' : 'image/jpeg';
 
   return [
-    createRootResource(encodeURIComponent(name), `
+    createRootResource(rootUrl, `
       <!doctype html>
       <html lang="en">
         <head>
@@ -44,10 +45,10 @@ export default function createImageResources(filename, content, width, height) {
           </style>
         </head>
         <body>
-          <img src="${url}" width="${width}px" height="${height}px"/>
+          <img src="${imageUrl}" width="${width}px" height="${height}px"/>
         </body>
       </html>
     `),
-    createImageResource(url, content, mimetype)
+    createImageResource(imageUrl, content, mimetype)
   ];
 }

--- a/packages/cli-upload/test/upload.test.js
+++ b/packages/cli-upload/test/upload.test.js
@@ -100,6 +100,39 @@ describe('percy upload', () => {
       '[percy] Snapshot uploaded: test-3.jpeg\n',
       '[percy] Finalized build #1: https://percy.io/test/test/123\n'
     ]);
+
+    expect(mockAPI.requests['/builds/123/snapshots'][0].body).toEqual({
+      data: {
+        type: 'snapshots',
+        attributes: {
+          name: 'test-1.png',
+          widths: [10],
+          'minimum-height': 10,
+          'enable-javascript': null
+        },
+        relationships: {
+          resources: {
+            data: expect.arrayContaining([{
+              type: 'resources',
+              id: expect.any(String),
+              attributes: {
+                'resource-url': '/test-1',
+                mimetype: 'text/html',
+                'is-root': true
+              }
+            }, {
+              type: 'resources',
+              id: expect.any(String),
+              attributes: {
+                'resource-url': '/test-1.png',
+                mimetype: 'image/png',
+                'is-root': null
+              }
+            }])
+          }
+        }
+      }
+    });
   });
 
   it('skips unsupported image types', async () => {


### PR DESCRIPTION
## Purpose

The API expects resource URLs to either be a fully qualified URL or an absolute path and does not accept relative URLs.

## Approach

Add a leading `/` to the image upload's root URL and add an expectation for it in the existing success test.