### PR TITLE
💥 Rename `--disable-asset-cache` flag to `--disable-cache`

### DIFF
--- a/packages/cli-command/README.md
+++ b/packages/cli-command/README.md
@@ -43,7 +43,7 @@ snapshot:
 discovery:
   allowedHostnames: []
   networkIdleTimeout: 100
-  disableAssetCache: false
+  disableCache: false
   concurrency: 5
 ```
 

--- a/packages/cli-command/src/flags.js
+++ b/packages/cli-command/src/flags.js
@@ -31,9 +31,9 @@ const discovery = {
     description: 'asset discovery idle timeout',
     percyrc: 'discovery.networkIdleTimeout'
   }),
-  'disable-asset-cache': flags.boolean({
+  'disable-cache': flags.boolean({
     description: 'disable asset discovery caches',
-    percyrc: 'discovery.disableAssetCache'
+    percyrc: 'discovery.disableCache'
   })
 };
 

--- a/packages/cli-command/test/command.test.js
+++ b/packages/cli-command/test/command.test.js
@@ -43,7 +43,7 @@ describe('PercyCommand', () => {
     await TestPercyCommand.run([
       '--allowed-hostname', '*.percy.io',
       '--network-idle-timeout', '150',
-      '--disable-asset-cache',
+      '--disable-cache',
       'foo', 'bar'
     ]);
 
@@ -52,7 +52,7 @@ describe('PercyCommand', () => {
     expect(results[0]).toHaveProperty('flags', {
       'allowed-hostname': ['*.percy.io'],
       'network-idle-timeout': 150,
-      'disable-asset-cache': true
+      'disable-cache': true
     });
   });
 
@@ -130,7 +130,7 @@ describe('PercyCommand', () => {
       await expect(TestPercyCommand.run([
         '--allowed-hostname', '*.percy.io',
         '--network-idle-timeout', '150',
-        '--disable-asset-cache',
+        '--disable-cache',
         'foo', 'bar'
       ])).resolves.toBeUndefined();
 
@@ -144,7 +144,7 @@ describe('PercyCommand', () => {
         },
         discovery: {
           allowedHostnames: ['*.percy.io'],
-          disableAssetCache: true,
+          disableCache: true,
           networkIdleTimeout: 150,
           concurrency: 5
         }

--- a/packages/cli-command/types/index.d.ts
+++ b/packages/cli-command/types/index.d.ts
@@ -29,7 +29,7 @@ export namespace flags {
   const discovery: {
     ['allowed-hostnames']: PercyOptionFlag<string[]>,
     ['network-idle-timeout']: PercyOptionFlag<number>,
-    ['disable-asset-cache']: PercyOptionFlag<boolean>
+    ['disable-cache']: PercyOptionFlag<boolean>
   };
 
   const config: {

--- a/packages/cli-command/types/index.test-d.ts
+++ b/packages/cli-command/types/index.test-d.ts
@@ -34,7 +34,7 @@ expectType<flags.PercyOptionFlag<boolean>>(flags.logging.quiet);
 expectType<flags.PercyOptionFlag<boolean>>(flags.logging.silent);
 expectType<flags.PercyOptionFlag<string[]>>(flags.discovery['allowed-hostnames']);
 expectType<flags.PercyOptionFlag<number>>(flags.discovery['network-idle-timeout']);
-expectType<flags.PercyOptionFlag<boolean>>(flags.discovery['disable-asset-cache']);
+expectType<flags.PercyOptionFlag<boolean>>(flags.discovery['disable-cache']);
 expectType<flags.PercyOptionFlag<string>>(flags.config.config);
 
 // Command methods and properties

--- a/packages/cli-exec/README.md
+++ b/packages/cli-exec/README.md
@@ -18,13 +18,14 @@ USAGE
   $ percy exec
 
 OPTIONS
+  -P, --port=port                                  [default: 5338] server port
   -c, --config=config                              configuration file path
   -h, --allowed-hostname=allowed-hostname          allowed hostnames
-  -p, --port=port                                  [default: 5338] server port
+  -p, --parallel                                   marks the build as one of many parallel builds
   -q, --quiet                                      log errors only
   -t, --network-idle-timeout=network-idle-timeout  asset discovery idle timeout
   -v, --verbose                                    log everything
-  --disable-asset-cache                            disable asset discovery caches
+  --disable-cache                                  disable asset discovery caches
   --silent                                         log nothing
 
 EXAMPLES
@@ -41,7 +42,7 @@ USAGE
   $ percy exec:ping
 
 OPTIONS
-  -p, --port=port  [default: 5338] server port
+  -P, --port=port  [default: 5338] server port
   -q, --quiet      log errors only
   -v, --verbose    log everything
   --silent         log nothing
@@ -56,13 +57,13 @@ USAGE
   $ percy exec:start
 
 OPTIONS
+  -P, --port=port                                  [default: 5338] server port
   -c, --config=config                              configuration file path
   -h, --allowed-hostname=allowed-hostname          allowed hostnames
-  -p, --port=port                                  [default: 5338] server port
   -q, --quiet                                      log errors only
   -t, --network-idle-timeout=network-idle-timeout  asset discovery idle timeout
   -v, --verbose                                    log everything
-  --disable-asset-cache                            disable asset discovery caches
+  --disable-cache                                  disable asset discovery caches
   --silent                                         log nothing
 
 EXAMPLES
@@ -79,7 +80,7 @@ USAGE
   $ percy exec:stop
 
 OPTIONS
-  -p, --port=port  [default: 5338] server port
+  -P, --port=port  [default: 5338] server port
   -q, --quiet      log errors only
   -v, --verbose    log everything
   --silent         log nothing

--- a/packages/cli-snapshot/README.md
+++ b/packages/cli-snapshot/README.md
@@ -35,7 +35,7 @@ OPTIONS
 
   -v, --verbose                                    log everything
 
-  --disable-asset-cache                            disable asset discovery caches
+  --disable-cache                                  disable asset discovery caches
 
   --silent                                         log nothing
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,7 +23,7 @@ const percy = new Percy({
   discovery: {               // asset discovery options
     allowedHostnames: [],      // list of hostnames allowed to capture from
     networkIdleTimeout: 100,   // how long before network is considered idle
-    disableAssetCache: false,  // disable discovered asset caching
+    disableCache: false,  // disable discovered asset caching
     concurrency: 5,            // asset discovery concurrency
     launchOptions: {}          // browser launch options
   },

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -40,7 +40,7 @@ export const schema = {
         type: 'integer',
         default: 100
       },
-      disableAssetCache: {
+      disableCache: {
         type: 'boolean',
         default: false
       },

--- a/packages/core/src/discoverer.js
+++ b/packages/core/src/discoverer.js
@@ -30,7 +30,7 @@ export default class PercyDiscoverer {
     // are determined to be fully discovered
     networkIdleTimeout,
     // disable resource caching, the cache is still used but overwritten for each resource
-    disableAssetCache,
+    disableCache,
     // browser launch options
     launchOptions
   }) {
@@ -39,7 +39,7 @@ export default class PercyDiscoverer {
     Object.assign(this, {
       allowedHostnames,
       networkIdleTimeout,
-      disableAssetCache,
+      disableCache,
       launchOptions
     });
   }
@@ -169,7 +169,7 @@ export default class PercyDiscoverer {
           // root resource
           log.debug(`Serving root resource for ${url}`, meta);
           request.respond({ status: 200, body: rootDom, contentType: 'text/html' });
-        } else if (!this.disableAssetCache && this.#cache.has(url)) {
+        } else if (!this.disableCache && this.#cache.has(url)) {
           // respond with cached response
           log.debug(`Response cache hit for ${url}`, meta);
           request.respond(this.#cache.get(url).response);
@@ -206,7 +206,7 @@ export default class PercyDiscoverer {
         if (url === rootUrl || url.startsWith('data:')) return;
 
         // process and cache the response and resource
-        if (this.disableAssetCache || !this.#cache.has(url)) {
+        if (this.disableCache || !this.#cache.has(url)) {
           log.debug(`Processing resource - ${url}`, meta);
           let response = await this._parseRequestResponse(url, request, meta);
 

--- a/packages/core/test/asset-discovery.test.js
+++ b/packages/core/test/asset-discovery.test.js
@@ -314,7 +314,7 @@ describe('Asset Discovery', () => {
     });
 
     it('does not cache resource requests when disabled', async () => {
-      percy.discoverer.disableAssetCache = true;
+      percy.discoverer.disableCache = true;
 
       // repeat above test
       await snapshot(1);
@@ -335,7 +335,7 @@ describe('Asset Discovery', () => {
   describe('with unhandled errors', async () => {
     it('logs unhandled request errors gracefully', async () => {
       // sabotage this property to trigger unexpected error handling
-      Object.defineProperty(percy.discoverer, 'disableAssetCache', {
+      Object.defineProperty(percy.discoverer, 'disableCache', {
         get() { throw new Error('some unhandled request error'); }
       });
 

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -15,7 +15,7 @@ export interface SnapshotOptions {
 interface DiscoveryOptions {
   allowedHostnames?: string[];
   networkIdleTimeout?: number;
-  disableAssetCache?: boolean;
+  disableCache?: boolean;
   concurrency?: number;
   launchOptions?: Pojo;
 }

--- a/packages/core/types/index.test-d.ts
+++ b/packages/core/types/index.test-d.ts
@@ -21,7 +21,7 @@ const percyOptions: PercyOptions = {
   discovery: {
     allowedHostnames: ['*.percy.io'],
     networkIdleTimeout: 100,
-    disableAssetCache: false,
+    disableCache: false,
     concurrency: 1,
     launchOptions: {
       devtools: true


### PR DESCRIPTION
## What is this?

As we hone in on the final v1 of the CLI, we're working out the last breaking changes we want to live with. None of the other flags mention `asset`, so we decided to align this flag with the others (since it's already breaking for `@percy/agent`'s `--cache-responses` flag). 