### PR TITLE
✨ Lazily create sdk-util logger for testing purposes

### DIFF
--- a/packages/sdk-utils/index.js
+++ b/packages/sdk-utils/index.js
@@ -1,5 +1,4 @@
 const logger = require('@percy/logger');
-const log = logger('util');
 
 // Maybe get the CLI API address from the environment
 const { PERCY_CLI_API = 'http://localhost:5338' } = process.env;
@@ -60,6 +59,7 @@ function toVersionTuple(s) {
 // Check if Percy is enabled using the healthcheck endpoint
 async function isPercyEnabled() {
   if (isPercyEnabled.result == null) {
+    let log = logger('util');
     let error;
 
     try {


### PR DESCRIPTION
## What is this?

A logger is a singleton, but tests teardown and recreate that singleton for a clean environment. When a logging group is created, it is bound to the singleton instance at the time of creation. Creating a group at the root level, like in the sdk-utils, causes it to forever be bound to that initial instance and not be effected by test setup. By lazily creating the logging group, we can be assured that the test environment will be cleaned up without requiring a re-require of the file where the logger is created.