### PR TITLE
♻ Adjust how the browser download script determines executable path

### DIFF
--- a/packages/core/src/utils/install-browser.js
+++ b/packages/core/src/utils/install-browser.js
@@ -34,15 +34,15 @@ export default async function install({
   extract = (i, o) => require('extract-zip')(i, { dir: o }),
   // default exectuable location within the extracted archive
   executable = {
-    linux: 'chrome',
-    win64: 'chrome.exe',
-    win32: 'chrome.exe',
-    darwin: path.join('Chromium.app', 'Contents', 'MacOS', 'Chromium')
+    linux: path.join('chrome-linux', 'chrome'),
+    win64: path.join('chrome-win', 'chrome.exe'),
+    win32: path.join('chrome-win32', 'chrome.exe'),
+    darwin: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium')
   }[platform]
 } = {}) {
   let outdir = path.join(directory, revision);
   let dlpath = path.join(outdir, decodeURIComponent(url.split('/').pop()));
-  let exec = path.join(outdir, path.parse(dlpath).name, executable);
+  let exec = path.join(outdir, executable);
 
   if (!existsSync(exec)) {
     // always log this for progress bar context


### PR DESCRIPTION
## What is this?

This takes the guesswork out of determining the browser executable path. The current guesswork is accurate for Chromium, but when this script is utilized to download other browsers, the executable location can be difficult to determine based on the filename alone. For example, the archive for Firefox on Linux is `firefox 73.0.tar.bz2` and when getting the executable path it guesses `firefox 73.0.tar/firefox` even though the actual archive unzips to `firefox/firefox`.

By removing the guesswork and being explicit, we can avoid OS/Browser archive name inconsistencies.