### PR TITLE
⬆ Upgrade Chromium 78 to 87

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build:watch": "lerna run build --stream -- --watch",
     "bump-version": "lerna version --no-git-tag-version --no-push",
     "clean": "rm -rf packages/**/{dist,.nyc_output,coverage,oclif.manifest.json}",
-    "release-notes": "./scripts/release-notes",
     "lint": "eslint --ignore-path .gitignore .",
     "readme": "lerna run --parallel readme",
     "test": "lerna run --stream --concurrency=1 test -- --colors",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "lerna run build --stream",
     "build:watch": "lerna run build --stream -- --watch",
     "bump-version": "lerna version --no-git-tag-version --no-push",
+    "chromium-revision": "./scripts/chromium-revision",
     "clean": "rm -rf packages/**/{dist,.nyc_output,coverage,oclif.manifest.json}",
     "lint": "eslint --ignore-path .gitignore .",
     "readme": "lerna run --parallel readme",

--- a/packages/core/src/discovery/browser.js
+++ b/packages/core/src/discovery/browser.js
@@ -10,7 +10,7 @@ import install from '../utils/install-browser';
 import Page from './page';
 
 export default class Browser extends EventEmitter {
-  log = logger('core:discovery:browser');
+  log = logger('core:browser');
 
   #pages = new Map();
   #callbacks = new Map();
@@ -250,7 +250,8 @@ export default class Browser extends EventEmitter {
        *   currently does not happen during asset discovery but it's here just in case */
       if (data.error) {
         callback.reject(Object.assign(callback.error, {
-          message: `Protocol error (${callback.method}): ${data.error.message} ${data.error.data}`
+          message: `Protocol error (${callback.method}): ${data.error.message}` +
+            ('data' in data.error ? `: ${data.error.data}` : '')
         }));
       } else {
         callback.resolve(data.result);

--- a/packages/core/src/discovery/browser.js
+++ b/packages/core/src/discovery/browser.js
@@ -11,10 +11,10 @@ import Page from './page';
 
 export default class Browser extends EventEmitter {
   log = logger('core:browser');
+  pages = new Map();
+  closed = false;
 
-  #pages = new Map();
   #callbacks = new Map();
-  #closed = false;
   #lastid = 0;
 
   defaultArgs = [
@@ -96,8 +96,8 @@ export default class Browser extends EventEmitter {
   }
 
   async close() {
-    if (this.#closed) return;
-    this.#closed = true;
+    if (this.closed) return;
+    this.closed = true;
 
     // reject any pending callbacks
     for (let callback of this.#callbacks.values()) {
@@ -107,13 +107,13 @@ export default class Browser extends EventEmitter {
     }
 
     // trigger rejecting pending page callbacks
-    for (let page of this.#pages.values()) {
+    for (let page of this.pages.values()) {
       page._handleClose();
     }
 
     // clear callback and page references
     this.#callbacks.clear();
-    this.#pages.clear();
+    this.pages.clear();
 
     // no executable means the browser never launched
     /* istanbul ignore next: sanity */
@@ -154,7 +154,7 @@ export default class Browser extends EventEmitter {
     // create and attach to a new page target returning the resulting page instance
     let { targetId } = await this.send('Target.createTarget', { url: 'about:blank' });
     let { sessionId } = await this.send('Target.attachToTarget', { targetId, flatten: true });
-    return this.#pages.get(sessionId).init({ meta });
+    return this.pages.get(sessionId).init({ meta });
   }
 
   async send(method, params) {
@@ -180,10 +180,7 @@ export default class Browser extends EventEmitter {
   // stderr and resolves when it emits the devtools protocol address or rejects if the process
   // exits for any reason or if the address does not appear after the timeout.
   async address(timeout = 30000) {
-    /* istanbul ignore next: this is not called twice but might be in the future */
-    if (this._address) return this._address;
-
-    this._address = await new Promise((resolve, reject) => {
+    this._address ||= await new Promise((resolve, reject) => {
       let stderr = '';
 
       let handleData = chunk => {
@@ -229,17 +226,17 @@ export default class Browser extends EventEmitter {
 
     if (data.method === 'Target.attachedToTarget') {
       // create a new page reference when attached to a target
-      this.#pages.set(data.params.sessionId, new Page(this, data));
+      this.pages.set(data.params.sessionId, new Page(this, data));
     } else if (data.method === 'Target.detachedFromTarget') {
       // remove the old page reference when detached from a target
-      let page = this.#pages.get(data.params.sessionId);
-      this.#pages.delete(data.params.sessionId);
+      let page = this.pages.get(data.params.sessionId);
+      this.pages.delete(data.params.sessionId);
       page?._handleClose();
     }
 
     if (data.sessionId) {
       // message was for a specific page that sent it
-      let page = this.#pages.get(data.sessionId);
+      let page = this.pages.get(data.sessionId);
       page?._handleMessage(data);
     } else if (data.id && this.#callbacks.has(data.id)) {
       // resolve or reject a pending promise created with #send()

--- a/packages/core/src/discovery/discoverer.js
+++ b/packages/core/src/discovery/discoverer.js
@@ -12,11 +12,11 @@ const ALLOWED_STATUSES = [200, 201, 301, 302, 304, 307, 308];
 // additional allowed hostnames are defined. Captured resources are cached so future requests
 // resolve much quicker and snapshots can share cached resources.
 export default class PercyDiscoverer {
+  queue = null;
+  browser = null;
   log = logger('core:discovery');
 
-  #queue = null
-  #browser = null
-  #cache = new Map()
+  #cache = new Map();
 
   constructor({
     // asset discovery concurrency
@@ -31,8 +31,8 @@ export default class PercyDiscoverer {
     // browser launch options
     launchOptions
   }) {
-    this.#queue = new Queue(concurrency);
-    this.#browser = new Browser();
+    this.queue = new Queue(concurrency);
+    this.browser = new Browser();
 
     Object.assign(this, {
       allowedHostnames,
@@ -44,18 +44,18 @@ export default class PercyDiscoverer {
 
   // Installs the browser executable if necessary then launches and connects to a browser process.
   async launch() {
-    await this.#browser.launch(this.launchOptions);
+    await this.browser.launch(this.launchOptions);
   }
 
   // Returns true or false when the browser is connected.
   isConnected() {
-    return this.#browser.isConnected();
+    return this.browser.isConnected();
   }
 
   // Clears any unstarted discovery tasks and closes the browser.
   async close() {
-    this.#queue.clear();
-    await this.#browser.close();
+    this.queue.clear();
+    await this.browser.close();
   }
 
   // Returns a new browser page.
@@ -71,7 +71,7 @@ export default class PercyDiscoverer {
     width = 1280,
     meta
   }) {
-    let page = await this.#browser.page({ meta });
+    let page = await this.browser.page({ meta });
     page.network.timeout = this.networkIdleTimeout;
     page.network.authorization = authorization;
 
@@ -102,7 +102,7 @@ export default class PercyDiscoverer {
     assert(this.isConnected(), 'Browser not connected');
 
     // discover assets concurrently
-    return this.#queue.push(async () => {
+    return this.queue.push(async () => {
       this.log.debug(`Discovering resources @${width}px for ${rootUrl}`, { ...meta, url: rootUrl });
       let page;
 

--- a/packages/core/src/discovery/network.js
+++ b/packages/core/src/discovery/network.js
@@ -1,3 +1,4 @@
+import logger from '@percy/logger';
 import waitFor from '../utils/wait-for';
 
 // The Interceptor class creates common handlers for dealing with intercepting asset requests
@@ -7,6 +8,8 @@ export default class Network {
   #requests = new Map();
   #intercepts = new Map();
   #authentications = new Set();
+
+  log = logger('core:network');
 
   constructor(page) {
     this.page = page;
@@ -31,6 +34,8 @@ export default class Network {
 
   // Resolves after the timeout when there are no more in-flight requests.
   async idle(timeout = this.timeout) {
+    this.log.debug(`Wait for ${timeout}ms idle`, this.page.meta);
+
     await waitFor(() => {
       if (this.page.closedReason) {
         throw new Error(`Network error: ${this.page.closedReason}`);

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -313,7 +313,7 @@ export default class Percy {
         // multiple snapshots can be captured on a single page
         for (let { name, execute } of snapshots) {
           if (execute) {
-            this.log.debug('Executing page JS', { ...meta, execute });
+            this.log.debug('Executing JavaScript', { ...meta, execute });
             // accept function bodies as strings
             if (typeof execute === 'string') execute = `async execute({ waitFor }) {\n${execute}\n}`;
             // execute the provided function

--- a/packages/core/src/utils/install-browser.js
+++ b/packages/core/src/utils/install-browser.js
@@ -19,8 +19,13 @@ const platform = (
 export default async function install({
   // default discovery browser is chromium
   browser = 'Chromium',
-  // default chromium version is 78.0.3904.x
-  revision = platform === 'win64' ? /* istanbul ignore next */ '693951' : '693954',
+  // default chromium version is 87.0.4280.xx
+  revision = {
+    linux: '812847',
+    win64: '812845',
+    win32: '812822',
+    darwin: '812851'
+  }[platform],
   // default download directory is in @percy/core root
   directory = path.resolve(__dirname, '../../.local-chromium'),
   // default download url is dependent on platform and revision

--- a/packages/core/test/capture.test.js
+++ b/packages/core/test/capture.test.js
@@ -271,7 +271,7 @@ describe('Percy Capture', () => {
     expect(logger.stderr).toEqual([
       '[percy] Encountered an error taking snapshot: invalid snapshot\n',
       '[percy] Error: Protocol error (Emulation.setDeviceMetricsOverride): ' +
-        'Invalid parameters Failed to deserialize params.width ' +
+        'Invalid parameters: Failed to deserialize params.width ' +
         '- BINDINGS: int32 value expected at position 50\n'
     ]);
   });

--- a/packages/core/test/capture.test.js
+++ b/packages/core/test/capture.test.js
@@ -271,7 +271,8 @@ describe('Percy Capture', () => {
     expect(logger.stderr).toEqual([
       '[percy] Encountered an error taking snapshot: invalid snapshot\n',
       '[percy] Error: Protocol error (Emulation.setDeviceMetricsOverride): ' +
-        'Invalid parameters width: integer value expected\n'
+        'Invalid parameters Failed to deserialize params.width ' +
+        '- BINDINGS: int32 value expected at position 50\n'
     ]);
   });
 

--- a/packages/core/test/capture.test.js
+++ b/packages/core/test/capture.test.js
@@ -331,11 +331,17 @@ describe('Percy Capture', () => {
   });
 
   it('handles page crashes', async () => {
-    await percy.capture({
+    let capture = percy.capture({
       name: 'crash snapshot',
       url: 'http://localhost:8000',
-      execute: () => window.location.replace('chrome://crash')
+      execute: () => new Promise(r => setTimeout(r, 1000))
     });
+
+    // wait for page creation
+    await new Promise(r => setTimeout(r, 500));
+    let [[, page]] = percy.discoverer.browser.pages;
+    await page.send('Page.crash').catch(() => {});
+    await capture;
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([

--- a/scripts/chromium-revision
+++ b/scripts/chromium-revision
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+const SCRIPT_NAME = require('path').basename(__filename);
+
+// Usage/help output
+if (!process.argv[2]) (console.log(`\
+Print a Chromium version's revision for each major platform
+
+USAGE
+  $ ${SCRIPT_NAME} VERSION
+
+ARGUMENTS
+  VERSION  A Chromium release version
+
+EXAMPLE
+ $ ${SCRIPT_NAME} 87.0.4280.88
+`), process.exit());
+
+// Required after usage for speedy help output
+const readline = require('readline');
+const { request } = require('@percy/client/dist/utils');
+const logger = require('@percy/logger');
+const log = logger('script');
+
+// Chromium GitHub constants
+const GH_API_URL = 'https://api.github.com/repos/chromium/chromium';
+const GH_TAGS_URL = 'https://github.com/chromium/chromium/branch_commits';
+const GH_HEADERS = {
+  'Accept': 'application/vnd.github.v3+json',
+  'User-Agent': '@percy/cli; ${SCRIPT_NAME}'
+};
+
+// Google Storage constants
+const G_STORAGE_API_URL = 'https://www.googleapis.com/storage/v1/b/chromium-browser-snapshots/o';
+const G_STORAGE_PREFIXES = {
+  darwin: 'Mac',
+  linux: 'Linux_x64',
+  win64: 'Win_x64',
+  win32: 'Win'
+};
+
+// Runs a stateful async function repeatedly until it returns a truthy value while updating a log
+// message with ellipses for each iteration of the task function
+async function task({ message, state: init, function: fn }) {
+  try {
+    return await (async function run(state) {
+      let i = state.i = (state.i || 0) + 1;
+
+      // clear the current line
+      readline.clearLine(logger.instance.stdout);
+      readline.cursorTo(logger.instance.stdout, 0);
+      // log the message with an additional period for each iteration
+      logger.instance.stdout.write(
+        logger.format(message(state, '.'.repeat(i)), 'script')
+      );
+
+      // if the function does not return, run again
+      return await fn(state) || run(state);
+    })((init?.() || {}));
+  } finally {
+    // this ensures errors will log on their own line
+    logger.instance.stdout.write('\n');
+  }
+}
+
+// The actual script that prints a revision corresponding to the provided version for each platform
+async function printVersionRevisions(version) {
+  // tags cannot be queried for by name with github's rest api; so query as many tags as we can
+  // until a matching one is found
+  let commit = await task({
+    message: (state, dots) => state.value
+      ? `Tagged commit: ${state.value.sha}`
+      : `Searching for tagged version: ${version}${dots}`,
+    async function(state) {
+      if (state.value) return state.value;
+      // this can be slow - the newer the browser, the less queries are needed
+      let tags = await request(`${GH_API_URL}/tags?page=${state.i}&per_page=100`, { headers: GH_HEADERS });
+      let match = tags.find(tag => tag.name === version);
+      state.value = match && match.commit;
+    }
+  });
+
+  // a bot likely published the release, so find the first human-authored commit
+  let authored = await task({
+    state: () => ({ value: commit }),
+    message: (state, dots) => state.authored
+      ? `Authored commit: ${state.value.sha}`
+      : `Fetching authored commit${dots}`,
+    async function(state) {
+      // get each parent commit until the authored commit is found
+      if (state.authored) return state.value;
+      let { parents } = await request(state.value.url, { headers: GH_HEADERS });
+      let parent = await request(parents[0].url, { headers: GH_HEADERS });
+      state.value = parent.commit ? parent.commit : parent;
+      // an author name ending in "-bot" is likely an automated commit
+      state.authored = !state.value.author.name.endsWith('-bot');
+    }
+  });
+
+  // parse the authored commit's message for the revision number; relies on the message format
+  // ending in "refs/head/master@{000000}" where zeros are the revision number
+  let revision = parseInt(authored.message.match(/refs\/heads\/master@\{#(\d+)}$/)[1], 10);
+  log.info(`Commit position: ${revision}`);
+
+  // for each platform, find the first suitable revision matching the desired version spanning back
+  // 50 revisions (not all platforms release at the same time)
+  let revisions = await task({
+    state: () => ({
+      platforms: ['linux', 'win64', 'win32', 'darwin'],
+      range: [revision - 50, revision],
+      value: {}
+    }),
+    message: (state, dots) => state.i <= state.platforms.length
+      ? `Determining platform revisions: ${state.platforms[state.i - 1]}${dots}`
+      : 'Matching revisions:',
+    async function(state) {
+      let platform = state.platforms[state.i - 1];
+      if (!platform) return state.value;
+
+      for (let rev = state.range[1]; rev >= state.range[0]; rev--) {
+        // query google's storage api for the platform revision
+        let { items } = await request((
+          `${G_STORAGE_API_URL}?fields=items(name,metadata)&` +
+            `prefix=${G_STORAGE_PREFIXES[platform]}/${rev}`
+        ), {});
+
+        // no matching revision for this platform
+        if (!items) continue;
+
+        // check if the revision's commit is included in the desired release version
+        let sha = items[0]['metadata']['cr-git-commit'];
+        let tags = (await request(`${GH_TAGS_URL}/${sha}`, {}))
+          .match(/\/releases\/tag\/[\d.]+/g)
+          .map(t => t.replace('/releases/tag/', ''));
+
+        // no matching version for this revision
+        if (!tags.includes(version)) continue;
+
+        // found a suitable revision for this platform
+        state.value[platform] = {
+          version: tags[tags.length - 1],
+          revision: rev,
+          sha
+        };
+
+        break;
+      }
+
+      // no suitable revision was found for this platform
+      state.value[platform] ||= {
+        revision: '-'.repeat(String(rev).length),
+        version: 'no match',
+        sha: 'none'
+      };
+    }
+  });
+
+  // log all matching revisions
+  logger.instance.stdout.write('\n' + (
+    Object.entries(revisions).map(([platform, i]) => (
+      `${platform}: ${i.revision} (${i.sha}; ${i.version})`
+    )).join('\n') + '\n\n'));
+}
+
+// call the script with the first provided arg
+printVersionRevisions(process.argv[2])
+  .catch(error => {
+    // request errors have a response body
+    log.error(error.response?.body?.message || error);
+  });

--- a/scripts/release-notes
+++ b/scripts/release-notes
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-rev=${1:-"$(git describe --tags --abbrev=0)..@"}
-ver_reg="^(.+?\s)?(v\d+(\.\d+){2}(-.+\.\d+)?)\s*$"
-
-git log --pretty=format:"%h - %s" $rev \
-  | grep --extended --invert $ver_reg
-


### PR DESCRIPTION
## What is this?

This updates the version of Chromium downloaded and used by asset discovery to Chrome 87.0.4280, which matches the next version that will be used in Percy's own rendering environment.

With this specific version of Chromium, the revisions are varied across all platforms. To make finding these revisions easier than the manual process, I automated it with a script. I also removed the old release-notes script since this repo uses a release-drafting action.

If authenticated with GitHub, the script could be modified to search a range of several versions to find a close match that has only one revision across all platforms. It could also be improved with GitHub's GraphQL API to search for the tag in a single query rather than paginating all tags for the Chromium repo. But that can be a future improvement for the next update.

Two tests needed to be updated:

1. A test in which the error message thrown by Chromium's Dev Tools Protocol has changed.
2. A test which triggers a page crash by navigating to `chrome://crash`. Scripts are no longer allowed to navigate to URLs which crash the page, so a few private properties were un-privated in order to trigger a page crash by issuing a `Page.crash` command over CDP.

While fixing test 2, I updated some discovery logs as well