### PR TITLE
✨ Add elapsed time to debug messages

### DIFF
--- a/packages/logger/src/colors.js
+++ b/packages/logger/src/colors.js
@@ -10,5 +10,6 @@ export default {
   red: str => colorize(31, str),
   yellow: str => colorize(33, str),
   blue: str => colorize(34, str),
-  magenta: str => colorize(35, str)
+  magenta: str => colorize(35, str),
+  grey: str => colorize(90, str)
 };

--- a/packages/logger/test/index.test.js
+++ b/packages/logger/test/index.test.js
@@ -138,6 +138,10 @@ describe('logger', () => {
 
     logger.loglevel('debug');
 
+    expect(logger.format('wat')).toEqual(
+      `[${colors.magenta('percy')}] wat`
+    );
+
     expect(logger.format('debugging', 'test')).toEqual(
       `[${colors.magenta('percy:test')}] debugging`
     );
@@ -236,6 +240,30 @@ describe('logger', () => {
 
       expect(helper.stderr).toEqual([
         `[${colors.magenta('percy:test')}] ${colors.red('ERROR')}\n`
+      ]);
+    });
+
+    it('logs elapsed time when loglevel is "debug"', async () => {
+      // it is hard to escape ansi colors with `stringMatching`, which is needed because the time
+      // between logs can vary by a few milliseconds
+      helper.mock({ elapsed: true });
+      logger.loglevel('debug');
+      log = logger('test');
+
+      log.info('Info log');
+      log.warn('Warn log');
+      log.error('Error log');
+      await new Promise(r => setTimeout(r, 100));
+      log.debug('Debug log');
+
+      expect(helper.stdout).toEqual([
+        expect.stringMatching('Info log \\(\\dms\\)\\n')
+      ]);
+
+      expect(helper.stderr).toEqual([
+        expect.stringMatching('Warn log \\(\\dms\\)\\n'),
+        expect.stringMatching('Error log \\(\\dms\\)\\n'),
+        expect.stringMatching('Debug log \\(10\\dms\\)\\n')
       ]);
     });
   });


### PR DESCRIPTION
## What is this?

This adds an additional detail to debug logs which can come in handy when debugging: elapsed time. The time between debug logs can be a useful clue in finding the root cause of issues.

![image](https://user-images.githubusercontent.com/5005153/106493850-508d6500-647f-11eb-83ab-1a7fec5829c9.png)

The logger test helper will automatically remove the elapsed time so other debug tests do not need to be updated. However, there is an option to leave elapsed time alone in case it is something that needs to be tested (such as within logger tests themselves). The log dump test helper was also updated to include the elapsed time between log entries.