### PR TITLE
🐛 Fix wait-for helper idle option

### DIFF
--- a/packages/core/src/utils/wait-for.js
+++ b/packages/core/src/utils/wait-for.js
@@ -4,7 +4,7 @@
 // `percy#capture()` method's `execute` option.
 /* istanbul ignore next: no instrumenting injected code */
 export default function waitFor(predicate, timeoutOrOptions) {
-  let { poll = 10, timeout, ensure } =
+  let { poll = 10, timeout, idle } =
     Number.isInteger(timeoutOrOptions)
       ? { timeout: timeoutOrOptions }
       : (timeoutOrOptions || {});
@@ -15,8 +15,8 @@ export default function waitFor(predicate, timeoutOrOptions) {
         if (Date.now() - start >= timeout) {
           throw new Error(`Timeout of ${timeout}ms exceeded.`);
         } else if (predicate()) {
-          if (ensure && !done) {
-            setTimeout(check, ensure, start, true);
+          if (idle && !done) {
+            setTimeout(check, idle, start, true);
           } else {
             resolve();
           }


### PR DESCRIPTION
## What is this?

The `waitFor` helper inside of `@percy/core` didn't appear to have any issues, however the option `ensure` was actually meant to be `idle` as evidence by uses of an `idle` option elsewhere in the codebase. This caused those options to be ignored when they should not have been. This was likely missed due to requiring coverage ignore the function as it gets injected into the browser where coverage variables are lost.

Fixing this might help with some flakey tests. 🤔 