### PR TITLE
✨ Backwards compatibility with v1 config

### DIFF
--- a/packages/cli-snapshot/package.json
+++ b/packages/cli-snapshot/package.json
@@ -13,7 +13,7 @@
     "postbuild": "oclif-dev manifest",
     "readme": "oclif-dev readme",
     "pretest": "node ../../scripts/install-browser",
-    "test": "cross-env NODE_ENV=test mocha",
+    "test": "cross-env NODE_ENV=test mocha --recursive",
     "test:coverage": "nyc yarn test"
   },
   "publishConfig": {

--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -24,3 +24,16 @@ export const schema = {
     }
   }
 };
+
+export function migration(input, set) {
+  /* eslint-disable curly */
+  if (input.version < 2) {
+    // static-snapshots and options were renamed
+    if (input.staticSnapshots?.baseUrl != null)
+      set('static.baseUrl', input.staticSnapshots.baseUrl);
+    if (input.staticSnapshots?.snapshotFiles != null)
+      set('static.files', input.staticSnapshots.snapshotFiles);
+    if (input.staticSnapshots?.ignoreFiles != null)
+      set('static.ignore', input.staticSnapshots.ignoreFiles);
+  }
+}

--- a/packages/cli-snapshot/src/hooks/init.js
+++ b/packages/cli-snapshot/src/hooks/init.js
@@ -1,6 +1,7 @@
 import PercyConfig from '@percy/config';
-import { schema } from '../config';
+import { schema, migration } from '../config';
 
 export default function() {
   PercyConfig.addSchema(schema);
+  PercyConfig.addMigration(migration);
 }

--- a/packages/cli-snapshot/test/unit/config.test.js
+++ b/packages/cli-snapshot/test/unit/config.test.js
@@ -1,0 +1,54 @@
+import expect from 'expect';
+import { migration } from '../../src/config';
+
+describe('unit / config', () => {
+  let migrate;
+  let set = (key, value) => (migrate[key] = value);
+
+  beforeEach(() => {
+    migrate = {};
+  });
+
+  it('migrates v1 config', () => {
+    migration({
+      version: 1,
+      staticSnapshots: {
+        baseUrl: 'base-url',
+        snapshotFiles: '*.html',
+        ignoreFiles: '*.htm'
+      }
+    }, set);
+
+    expect(migrate).toEqual({
+      'static.baseUrl': 'base-url',
+      'static.files': '*.html',
+      'static.ignore': '*.htm'
+    });
+  });
+
+  it('only migrates own config options', () => {
+    migration({
+      version: 1,
+      otherOptions: {
+        baseUrl: 'base-url',
+        snapshotFiles: '*.html',
+        ignoreFiles: '*.htm'
+      }
+    }, set);
+
+    expect(migrate).toEqual({});
+  });
+
+  it('does not migrate when not needed', () => {
+    migration({
+      version: 2,
+      static: {
+        baseUrl: 'base-url',
+        files: '*.html',
+        ignore: '*.htm'
+      }
+    }, set);
+
+    expect(migrate).toEqual({});
+  });
+});

--- a/packages/cli-upload/package.json
+++ b/packages/cli-upload/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --ignore-path ../../.gitignore .",
     "postbuild": "oclif-dev manifest",
     "readme": "oclif-dev readme",
-    "test": "cross-env NODE_ENV=test mocha",
+    "test": "cross-env NODE_ENV=test mocha --recursive",
     "test:coverage": "nyc yarn test"
   },
   "publishConfig": {

--- a/packages/cli-upload/src/config.js
+++ b/packages/cli-upload/src/config.js
@@ -20,3 +20,14 @@ export const schema = {
     }
   }
 };
+
+export function migration(input, set) {
+  /* eslint-disable curly */
+  if (input.version < 2) {
+    // image-snapshots and options were renamed
+    if (input.imageSnapshots?.files != null)
+      set('upload.files', input.imageSnapshots.files);
+    if (input.imageSnapshots?.ignore != null)
+      set('upload.ignore', input.imageSnapshots.ignore);
+  }
+}

--- a/packages/cli-upload/src/hooks/init.js
+++ b/packages/cli-upload/src/hooks/init.js
@@ -1,6 +1,7 @@
 import PercyConfig from '@percy/config';
-import { schema } from '../config';
+import { schema, migration } from '../config';
 
 export default function() {
   PercyConfig.addSchema(schema);
+  PercyConfig.addMigration(migration);
 }

--- a/packages/cli-upload/test/unit/config.test.js
+++ b/packages/cli-upload/test/unit/config.test.js
@@ -1,0 +1,52 @@
+import expect from 'expect';
+import { migration } from '../../src/config';
+
+describe('unit / config', () => {
+  let migrate;
+  let set = (key, value) => (migrate[key] = value);
+
+  beforeEach(() => {
+    migrate = {};
+  });
+
+  it('migrates v1 config', () => {
+    migration({
+      version: 1,
+      imageSnapshots: {
+        path: '~/pathname/',
+        files: '*.png',
+        ignore: '*.jpg'
+      }
+    }, set);
+
+    expect(migrate).toEqual({
+      'upload.files': '*.png',
+      'upload.ignore': '*.jpg'
+    });
+  });
+
+  it('only migrates own config options', () => {
+    migration({
+      version: 1,
+      otherOptions: {
+        path: '~/pathname/',
+        files: '*.png',
+        ignore: '*.jpg'
+      }
+    }, set);
+
+    expect(migrate).toEqual({});
+  });
+
+  it('does not migrate when not needed', () => {
+    migration({
+      version: 2,
+      upload: {
+        files: '*.png',
+        ignore: '*.jpg'
+      }
+    }, set);
+
+    expect(migrate).toEqual({});
+  });
+});

--- a/packages/config/src/index.js
+++ b/packages/config/src/index.js
@@ -1,5 +1,6 @@
 import load, { cache, explorer } from './load';
 import validate, { addSchema, resetSchema } from './validate';
+import migrate, { addMigration, clearMigrations } from './migrate';
 import getDefaults from './defaults';
 import stringify from './stringify';
 
@@ -11,6 +12,9 @@ export default {
   validate,
   addSchema,
   resetSchema,
+  migrate,
+  addMigration,
+  clearMigrations,
   getDefaults,
   stringify
 };

--- a/packages/config/src/migrate.js
+++ b/packages/config/src/migrate.js
@@ -1,0 +1,38 @@
+import normalize from './normalize';
+
+// Global set of registered migrations
+const migrations = new Set();
+
+// Register a migration function
+export function addMigration(migration) {
+  migrations.add(migration);
+}
+
+// Clear all migration functions
+export function clearMigrations() {
+  migrations.clear();
+}
+
+// Assigns a value to the object at the path creating any necessary nested
+// objects along the way
+function assign(obj, path, value) {
+  path.split('.').reduce((loc, key, i, a) => (
+    loc[key] = i === a.length - 1 ? value : (loc[key] || {})
+  ), obj);
+
+  return obj;
+}
+
+// Calls each registered migration function with a normalize provided config
+// and a `set` function which assigns values to the returned output
+export default function migrate(config) {
+  let output = { version: 2 };
+  let input = normalize(config);
+  let set = assign.bind(null, output);
+
+  migrations.forEach(migration => {
+    migration(input, set);
+  });
+
+  return output;
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "build": "babel --root-mode upward src --out-dir dist",
     "lint": "eslint --ignore-path ../../.gitignore .",
     "pretest": "node ../../scripts/install-browser",
-    "test": "cross-env NODE_ENV=test mocha",
+    "test": "cross-env NODE_ENV=test mocha --recursive",
     "test:coverage": "nyc yarn test",
     "test:types": "tsd"
   },

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -67,3 +67,28 @@ export const schema = {
     }
   }
 };
+
+// Migration function
+export function migration(input, set) {
+  /* eslint-disable curly */
+  if (input.version < 2) {
+    // previous snapshot options map 1:1
+    if (input.snapshot != null)
+      set('snapshot', input.snapshot);
+    // request-headers option moved
+    if (input.agent?.assetDiscovery?.requestHeaders != null)
+      set('snapshot.requestHeaders', input.agent.assetDiscovery.requestHeaders);
+    // allowed-hostnames moved
+    if (input.agent?.assetDiscovery?.allowedHostnames != null)
+      set('discovery.allowedHostnames', input.agent.assetDiscovery.allowedHostnames);
+    // network-idle-timeout moved
+    if (input.agent?.assetDiscovery?.networkIdleTimeout != null)
+      set('discovery.networkIdleTimeout', input.agent.assetDiscovery.networkIdleTimeout);
+    // page pooling was rewritten to be a concurrent task queue
+    if (input.agent?.assetDiscovery?.pagePoolSizeMax != null)
+      set('discovery.concurrency', input.agent.assetDiscovery.pagePoolSizeMax);
+    // cache-responses was renamed to match the CLI flag
+    if (input.agent?.assetDiscovery?.cacheResponses != null)
+      set('discovery.disableCache', !input.agent.assetDiscovery.cacheResponses);
+  }
+}

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,1 +1,9 @@
+// Register core config options
+const { default: PercyConfig } = require('@percy/config');
+const CoreConfig = require('./config');
+
+PercyConfig.addSchema(CoreConfig.schema);
+PercyConfig.addMigration(CoreConfig.migration);
+
+// Export the Percy class with commonjs compatibility
 module.exports = require('./percy').default;

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -2,7 +2,6 @@ import { promises as fs } from 'fs';
 import PercyClient from '@percy/client';
 import PercyConfig from '@percy/config';
 import logger from '@percy/logger';
-import { schema } from './config';
 import Queue from './queue';
 import Discoverer from './discovery/discoverer';
 import createPercyServer from './server';
@@ -11,9 +10,6 @@ import assert from './utils/assert';
 import injectPercyCSS from './utils/percy-css';
 import { createRootResource, createLogResource } from './utils/resources';
 import { normalizeURL } from './utils/url';
-
-// Register core config options
-PercyConfig.addSchema(schema);
 
 // A Percy instance will create a new build when started, handle snapshot
 // creation, asset discovery, and resource uploads, and will finalize the build

--- a/packages/core/test/unit/config.test.js
+++ b/packages/core/test/unit/config.test.js
@@ -1,0 +1,63 @@
+import expect from 'expect';
+import { migration } from '../../src/config';
+
+describe('Unit / Config', () => {
+  let migrate;
+  let set = (key, value) => (migrate[key] = value);
+
+  beforeEach(() => {
+    migrate = {};
+  });
+
+  it('migrates v1 config', () => {
+    migration({
+      version: 1,
+      snapshot: {
+        widths: [1000]
+      },
+      agent: {
+        assetDiscovery: {
+          requestHeaders: { foo: 'bar' },
+          allowedHostnames: ['allowed'],
+          networkIdleTimeout: 150,
+          pagePoolSizeMin: 1,
+          pagePoolSizeMax: 5,
+          cacheResponses: false
+        }
+      }
+    }, set);
+
+    expect(migrate).toEqual({
+      snapshot: { widths: [1000] },
+      'snapshot.requestHeaders': { foo: 'bar' },
+      'discovery.allowedHostnames': ['allowed'],
+      'discovery.networkIdleTimeout': 150,
+      'discovery.concurrency': 5,
+      'discovery.disableCache': true
+    });
+  });
+
+  it('only migrates own config options', () => {
+    migration({
+      version: 1,
+      otherOptions: {
+        baseUrl: 'base-url',
+        snapshotFiles: '*.html',
+        ignoreFiles: '*.htm'
+      }
+    }, set);
+
+    expect(migrate).toEqual({});
+  });
+
+  it('does not migrate when not needed', () => {
+    migration({
+      version: 2,
+      discovery: {
+        allowedHostnames: ['allowed']
+      }
+    }, set);
+
+    expect(migrate).toEqual({});
+  });
+});

--- a/packages/core/test/unit/queue.test.js
+++ b/packages/core/test/unit/queue.test.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import Queue from '../src/queue';
+import Queue from '../../src/queue';
 
 function task(timeout = 0, cb) {
   return async function t() {
@@ -11,7 +11,7 @@ function task(timeout = 0, cb) {
   };
 }
 
-describe('Tasks Queue', () => {
+describe('Unit / Tasks Queue', () => {
   let q;
 
   beforeEach(() => {


### PR DESCRIPTION
## Purpose

Currently, if a v1 config file is detected, it's configuration options are discarded. In order for config files to work with `@percy/cli`, the config file needs to be in a v2 format which can be migrated to using the `config:migrate` command. This PR breaks up the migration logic from the command and moves it alongside respective config schemas, allowing the `@percy/config` package to migrate configuration options on-the-fly.

## Approach

- The `config:migrate` command no longer houses it's own migration logic. This has been split alongside respective schemas. This allows migration and the migrate command to be extensible just like the schema and validate command is.
- The new migration function can be registered with `PercyConfig.addMigration` which mirrors `PercyConfig.addSchema`. The migration function accepts the `input` config as the first parameter, and a `set` function as the second parameter which can be called with the desired path and value to set on the migrated config.
- For each respective package that now has an additional migration function, a unit test suite was added to account for additional required code coverage.
- When `PercyConfig.load` encounters an older config version, a warning is logged before auto-migrating the config: ``Found older config file version, please run `percy config:migrate` to update to the latest version``