### PR TITLE
➖ Remove path-type dependency

### DIFF
--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -41,7 +41,6 @@
     "@oclif/config": "^1.17.0",
     "@percy/config": "^1.0.0-beta.31",
     "@percy/core": "^1.0.0-beta.31",
-    "@percy/logger": "^1.0.0-beta.31",
-    "path-type": "^4.0.0"
+    "@percy/logger": "^1.0.0-beta.31"
   }
 }

--- a/packages/cli-config/src/commands/config/migrate.js
+++ b/packages/cli-config/src/commands/config/migrate.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import { isDirectorySync } from 'path-type';
 import Command, { flags } from '@oclif/command';
 import PercyConfig from '@percy/config';
 import logger from '@percy/logger';
@@ -43,7 +42,7 @@ export class Migrate extends Command {
     // load config using the explorer directly rather than the load method to
     // better control logs and prevent validation
     try {
-      let result = !input || isDirectorySync(input)
+      let result = !input || fs.statSync(input).isDirectory()
         ? PercyConfig.explorer.search(input)
         : PercyConfig.explorer.load(input);
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -28,7 +28,6 @@
     "@percy/logger": "^1.0.0-beta.31",
     "ajv": "^7.0.3",
     "cosmiconfig": "^7.0.0",
-    "path-type": "^4.0.0",
     "yaml": "^1.10.0"
   },
   "devDependencies": {

--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -1,6 +1,6 @@
 import { relative } from 'path';
+import { statSync } from 'fs';
 import { cosmiconfigSync } from 'cosmiconfig';
-import { isDirectorySync } from 'path-type';
 import logger from '@percy/logger';
 import getDefaults from './defaults';
 import migrate from './migrate';
@@ -49,7 +49,7 @@ export default function load({
   // load config or reload cached config
   if (path !== false && (!config || reload)) {
     try {
-      let result = !path || isDirectorySync(path)
+      let result = !path || statSync(path).isDirectory()
         ? explorer.search(path) : explorer.load(path);
 
       if (result && result.config) {


### PR DESCRIPTION
## What is this?

This dependency has many small helpers based on two single sync and async helpers. In both places we use this dependency, we only use it to check if a filepath is a directory synchronously. This is done by the depdendency wrapping `fs.statSync().isDirectory()` in a try-catch to catch `ENOENT` errors. In both places we use this helper, we are already wrapping calls in a try-catch, so we can swap out this dependency entirely with the native method. 

However this dependency will still exist in our tree, as I believe `cosmiconfig` depends on it.