### PR TITLE
✨ Accept all option syntax styles

### DIFF
--- a/packages/config/src/index.js
+++ b/packages/config/src/index.js
@@ -2,6 +2,7 @@ import load, { cache, explorer } from './load';
 import validate, { addSchema, resetSchema } from './validate';
 import migrate, { addMigration, clearMigrations } from './migrate';
 import getDefaults from './defaults';
+import normalize from './normalize';
 import stringify from './stringify';
 
 // Export a single object that can be imported as PercyConfig
@@ -16,5 +17,6 @@ export default {
   addMigration,
   clearMigrations,
   getDefaults,
+  normalize,
   stringify
 };

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -7,10 +7,12 @@ const CAMELIZE_MAP = {
   javascript: 'JavaScript'
 };
 
-// Converts a kebab-cased string to camelCase.
+// Converts kebab-cased and snake_cased strings to camelCase.
+const KEBAB_SNAKE_REG = /(-|_)([^\1]+)/g;
+
 function camelize(str) {
-  return str.replace(/-([^-]+)/g, (_, w) => (
-    CAMELIZE_MAP[w] || (w[0].toUpperCase() + w.slice(1))
+  return str.replace(KEBAB_SNAKE_REG, (match, sep, word) => (
+    CAMELIZE_MAP[word] || (word[0].toUpperCase() + word.slice(1))
   ));
 }
 

--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import http from 'http';
+import PercyConfig from '@percy/config';
 import logger from '@percy/logger';
 import pkg from '../package.json';
 
@@ -117,8 +118,10 @@ export default function createPercyServer(percy) {
       }),
 
     // forward snapshot requests
-    '/percy/snapshot': ({ body }) => percy.snapshot(body)
-      .then(() => [200, 'application/json', { success: true }]),
+    '/percy/snapshot': ({ body }) => (
+      percy.snapshot(PercyConfig.normalize(body))
+        .then(() => [200, 'application/json', { success: true }])
+    ),
 
     // stops the instance async (connections will be closed)
     '/percy/stop': () => percy.stop() && (

--- a/packages/core/test/server.test.js
+++ b/packages/core/test/server.test.js
@@ -97,7 +97,7 @@ describe('Snapshot Server', () => {
     expect(percy.stop.calls).toHaveLength(1);
   });
 
-  it('has a /snapshot endpoint that calls #snapshot()', async () => {
+  it('has a /snapshot endpoint that calls #snapshot() with normalized options', async () => {
     await percy.start();
     percy.snapshot = async data => (
       percy.snapshot.calls = percy.snapshot.calls || []
@@ -105,13 +105,13 @@ describe('Snapshot Server', () => {
 
     let response = await fetch('http://localhost:1337/percy/snapshot', {
       method: 'post',
-      body: '{ "test": true }'
+      body: '{ "test-me": true, "me_too": true }'
     });
 
     expect(response.headers.get('x-percy-core-version')).toMatch(pkg.version);
     await expect(response.json()).resolves.toEqual({ success: true });
     expect(percy.snapshot.calls).toHaveLength(1);
-    expect(percy.snapshot.calls[0]).toEqual({ test: true });
+    expect(percy.snapshot.calls[0]).toEqual({ testMe: true, meToo: true });
   });
 
   it('returns a 500 error when an endpoint throws', async () => {

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -24,8 +24,9 @@ function doctype(dom) {
 export default function serializeDOM(options) {
   let {
     dom = document,
-    enableJavaScript,
-    domTransformation
+    // allow snake_case or camelCase
+    enableJavaScript = options?.enable_javascript,
+    domTransformation = options?.dom_transformation
   } = options || {};
 
   prepareDOM(dom);


### PR DESCRIPTION
## Purpose

Currently, snapshot options via the CLI API are only accepted as camelCase options. In some languages, this goes against the languages own syntax standards such as `snake_case` variables and options. Allowing the snapshot API endpoint to accept any style of options removes the conversion responsibility from the SDK.

## Approach

The `@percy/config` package already has a `normalize` function that removes empty values and converts kebab-case options to camelCase. This has been modified to also convert snake_case options. The `normalize` function is now exported with the package so that the `@percy/core` server can utilize it for converting snapshot API options.