### PR TITLE
🐛 Work around incorrect global context in @percy/dom

### DIFF
--- a/packages/dom/karma.conf.js
+++ b/packages/dom/karma.conf.js
@@ -45,7 +45,7 @@ module.exports = config => {
         require('@rollup/plugin-node-resolve').default(),
         require('@rollup/plugin-commonjs')(),
         require('@rollup/plugin-babel').default({
-          babelHelpers: 'inline'
+          babelHelpers: 'bundled'
         })
       ],
       output: {

--- a/packages/dom/rollup.config.js
+++ b/packages/dom/rollup.config.js
@@ -12,7 +12,7 @@ export default {
   },
   plugins: [
     resolve(),
-    babel({ babelHelpers: 'inline' })
+    babel({ babelHelpers: 'bundled' })
   ],
   onwarn: message => {
     if (/circular dependency/i.test(message)) return;

--- a/packages/dom/src/index.js
+++ b/packages/dom/src/index.js
@@ -1,1 +1,11 @@
-export { default, default as serialize } from './serialize-dom';
+import serialize from './serialize-dom';
+
+/* istanbul ignore next */
+// works around instances where the context has an incorrect global scope
+// https://github.com/mozilla/geckodriver/issues/1798
+if (globalThis !== window) {
+  window.PercyDOM = { serialize };
+}
+
+export { serialize };
+export default serialize;


### PR DESCRIPTION
## What is this?

The `@percy/dom` package uses a UMD format which assigns exports to a `globalThis` variable when in a browser environment. However, if the implementation of `globalThis` is incorrect (mozilla/geckodriver#1798), the `PercyDOM` object is not correctly carried forward into other script executions where the DOM is meant to be serialized.

This PR aims to work around this issue by checking if `window` and `globalThis` are not equal to each other (which technically should be impossible under normal circumstances). If they are not equal, the library adds itself to `window` ahead of the eventual UMD dance.

While testing this, I also noticed that babel helpers were inlined multiple times. Updating this setting to `bundled` will ensure they are only bundled once in the final output.