### PR TITLE
✨ Allow setting multiple client or environment info at a time

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -27,8 +27,8 @@ export default class PercyClient {
       token,
       apiUrl,
       httpAgent: httpAgentFor(apiUrl),
-      clientInfo: [].concat(clientInfo),
-      environmentInfo: [].concat(environmentInfo),
+      clientInfo: new Set([].concat(clientInfo)),
+      environmentInfo: new Set([].concat(environmentInfo)),
       env: new PercyEnvironment(process.env),
       // build info is stored for reference
       build: { id: null, number: null, url: null }
@@ -37,25 +37,25 @@ export default class PercyClient {
 
   // Adds additional unique client info.
   addClientInfo(info) {
-    if (info && this.clientInfo.indexOf(info) === -1) {
-      this.clientInfo.push(info);
+    for (let i of [].concat(info)) {
+      if (i) this.clientInfo.add(i);
     }
   }
 
   // Adds additional unique environment info.
   addEnvironmentInfo(info) {
-    if (info && this.environmentInfo.indexOf(info) === -1) {
-      this.environmentInfo.push(info);
+    for (let i of [].concat(info)) {
+      if (i) this.environmentInfo.add(i);
     }
   }
 
   // Stringifies client and environment info.
   userAgent() {
     let client = [`Percy/${/\w+$/.exec(this.apiUrl)}`]
-      .concat(`${pkg.name}/${pkg.version}`, this.clientInfo)
+      .concat(`${pkg.name}/${pkg.version}`, ...this.clientInfo)
       .filter(Boolean).join(' ');
-    let environment = this.environmentInfo
-      .concat([`node/${process.version}`, this.env.info])
+    let environment = [...this.environmentInfo]
+      .concat(`node/${process.version}`, this.env.info)
       .filter(Boolean).join('; ');
     return `${client} (${environment})`;
   }

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -59,11 +59,13 @@ describe('PercyClient', () => {
       client.addClientInfo('');
       client.addClientInfo('client-info');
       client.addClientInfo('client-info');
+      client.addClientInfo(['client-info', 'client-info']);
       client.addEnvironmentInfo(null);
       client.addEnvironmentInfo(undefined);
       client.addEnvironmentInfo('');
       client.addEnvironmentInfo('env-info');
       client.addEnvironmentInfo('env-info');
+      client.addEnvironmentInfo(['env-info', 'env-info']);
 
       expect(client.userAgent()).toMatch(
         /^Percy\/v1 @percy\/client\/\S+ client-info \(env-info; node\/v[\d.]+.*\)$/


### PR DESCRIPTION
## What is this?

This allows SDKs and other consumers of `@percy/client` to set multiple client or environment info at a time by providing an array instead of requiring an already formatted string. Rather than use arrays and manually checking for uniqueness, we can use Sets which are inherently unique.