### PR TITLE
✨ Prefer kebab-case for yaml config files

### DIFF
--- a/packages/cli-config/src/commands/config/migrate.js
+++ b/packages/cli-config/src/commands/config/migrate.js
@@ -71,6 +71,13 @@ export class Migrate extends Command {
     this.log.info('Migrating config file...');
     let format = path.extname(output).replace(/^./, '') || 'yaml';
     let migrated = PercyConfig.migrate(config);
+
+    // prefer kebab-case for yaml
+    if (/^ya?ml$/.test(format)) {
+      migrated = PercyConfig.normalize(migrated, { kebab: true });
+    }
+
+    // stringify to the desired format
     let body = PercyConfig.stringify(format, migrated);
 
     // update the package.json entry via string replacement

--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -81,7 +81,7 @@ export default function load({
   }
 
   // merge found config with overrides and validate
-  config = normalize(config, overrides);
+  config = normalize(config, { overrides });
   let validation = config && validate(config);
 
   if (validation && !validation.result) {

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -2,18 +2,31 @@ const { isArray } = Array;
 const { entries, assign } = Object;
 
 // Edge case camelizations
-const CAMELIZE_MAP = {
-  css: 'CSS',
-  javascript: 'JavaScript'
-};
+const CAMELCASE_MAP = new Map([
+  ['css', 'CSS'],
+  ['javascript', 'JavaScript']
+]);
 
 // Converts kebab-cased and snake_cased strings to camelCase.
 const KEBAB_SNAKE_REG = /[-_]([^-_]+)/g;
 
-function camelize(str) {
+function camelcase(str) {
   return str.replace(KEBAB_SNAKE_REG, (match, word) => (
-    CAMELIZE_MAP[word] || (word[0].toUpperCase() + word.slice(1))
+    CAMELCASE_MAP.get(word) || (word[0].toUpperCase() + word.slice(1))
   ));
+}
+
+// Coverts camelCased and snake_cased strings to kebab-case.
+const CAMEL_SNAKE_REG = /([a-z])([A-Z]+)|_([^_]+)/g;
+
+function kebabcase(str) {
+  return Array.from(CAMELCASE_MAP)
+    .reduce((str, [word, camel]) => (
+      str.replace(camel, `-${word}`)
+    ), str)
+    .replace(CAMEL_SNAKE_REG, (match, p, n, w) => (
+      `${p || ''}-${(n || w).toLowerCase()}`
+    ));
 }
 
 // Merges source values into the target object unless empty. When `options.replaceArrays` is truthy,
@@ -22,18 +35,20 @@ export function merge(target, source, options) {
   let isSourceArray = isArray(source);
   if (options?.replaceArrays && isSourceArray) return source;
   if (typeof source !== 'object') return source != null ? source : target;
+  let convertcase = options?.kebab ? kebabcase : camelcase;
 
   return entries(source).reduce((result, [key, value]) => {
     value = merge(result?.[key], value, options);
 
     return value == null ? result
       : isSourceArray ? (result || []).concat(value)
-        : assign(result || {}, { [camelize(key)]: value });
+        : assign(result || {}, { [convertcase(key)]: value });
   }, target);
 }
 
 // Recursively reduces config objects and arrays to remove undefined and empty values and rename
-// kebab-case properties to camelCase. Optionally allows deep merging of override values
+// kebab-case properties to camelCase. Optionally allows deep merging of a second overrides
+// argument, and converting keys to kebab-case with a third options.kebab argument.
 export default function normalize(object, options) {
   object = merge(undefined, object, options);
   return options?.overrides

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -34,6 +34,9 @@ export function merge(target, source, options) {
 
 // Recursively reduces config objects and arrays to remove undefined and empty values and rename
 // kebab-case properties to camelCase. Optionally allows deep merging of override values
-export default function normalize(object, overrides) {
-  return merge(merge(undefined, object), overrides);
+export default function normalize(object, options) {
+  object = merge(undefined, object, options);
+  return options?.overrides
+    ? merge(object, options.overrides, options)
+    : object;
 }

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -511,11 +511,31 @@ describe('PercyConfig', () => {
       expect(PercyConfig.normalize({
         'foo-bar': 'baz',
         foo: { bar_baz: 'qux' },
-        'foo_bar-baz': 'qux'
+        'foo_bar-baz': 'qux',
+        'percy-css': '',
+        'enable-javascript': false
       })).toEqual({
         fooBar: 'baz',
         foo: { barBaz: 'qux' },
-        fooBarBaz: 'qux'
+        fooBarBaz: 'qux',
+        percyCSS: '',
+        enableJavaScript: false
+      });
+    });
+
+    it('can converts keys to kebab-case', () => {
+      expect(PercyConfig.normalize({
+        'foo-bar': 'baz',
+        foo: { bar_baz: 'qux' },
+        fooBar_baz: 'qux',
+        percyCSS: '',
+        enableJavaScript: false
+      }, { kebab: true })).toEqual({
+        'foo-bar': 'baz',
+        foo: { 'bar-baz': 'qux' },
+        'foo-bar-baz': 'qux',
+        'percy-css': '',
+        'enable-javascript': false
       });
     });
   });


### PR DESCRIPTION
## Purpose

The yaml config format typically prefers keys to be kebab-cased. Our docs even show the yaml config files with kebab-cased keys. With config migration moved into `@percy/config`, it always normalizes keys as camelCased. We should always prefer kebab-cased when migrating to a yaml format.

## Approach

Allow normalize to accept options other than `overrides`, including an option to convert keys to kebab-cased rather than camelCase. The new kebab-case function will convert both camelCase and snake_case, similarly to how the camelCase function converts both kebab-case and snake_case. In order to account for edge case camelizations such as `CSS` and `JavaScript`, the edge cases map was utilized to covert keys the other direction as well to avoid accidentally adding dashes where there shouldn't be.