### PR TITLE
💚 Add @percy/logger to CI test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
           - '@percy/env'
           - '@percy/client'
           - '@percy/dom'
+          - '@percy/logger'
           - '@percy/config'
           - '@percy/core'
           - '@percy/cli-command'


### PR DESCRIPTION
## What is this?

It appears that `@percy/logger` tests slipped by without being added to the CI tests workflow. This PR adds the package to the workflow so that its tests are run for each commit.