### PR TITLE
♻️ Migrate to package.json config without string replacement

### DIFF
--- a/packages/cli-config/test/migrate.test.js
+++ b/packages/cli-config/test/migrate.test.js
@@ -48,7 +48,7 @@ describe('percy config:migrate', () => {
   });
 
   it('works with package.json configs', async () => {
-    let json = o => JSON.stringify(o, null, 2);
+    let json = o => JSON.stringify(o, null, 2) + '\n';
 
     let pkg = {
       name: 'some-package',
@@ -72,7 +72,7 @@ describe('percy config:migrate', () => {
   it('can convert between config types', async () => {
     await Migrate.run(['.percy.yml', '.percy.js']);
     expect(getMockConfig('.percy.js'))
-      .toEqual('module.exports = {\n  version: 2\n}');
+      .toEqual('module.exports = {\n  version: 2\n}\n');
   });
 
   it('errors and exits when a config cannot be found', async () => {

--- a/packages/config/src/stringify.js
+++ b/packages/config/src/stringify.js
@@ -15,9 +15,9 @@ export default function stringify(format, config = getDefaults()) {
     case 'yaml':
       return YAML.stringify(config);
     case 'json':
-      return JSON.stringify(config, null, 2);
+      return JSON.stringify(config, null, 2) + '\n';
     case 'js':
-      return `module.exports = ${inspect(config)}`;
+      return `module.exports = ${inspect(config)}\n`;
     default:
       throw new Error(`Unsupported format: ${format}`);
   }

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -548,7 +548,7 @@ describe('PercyConfig', () => {
         '  "test": {',
         '    "value": "foo"',
         '  }',
-        '}'
+        '}\n'
       ].join('\n'));
     });
 
@@ -576,7 +576,7 @@ describe('PercyConfig', () => {
         '  "foo": {',
         '    "bar": "baz"',
         '  }',
-        '}'
+        '}\n'
       ].join('\n'));
     });
 
@@ -588,7 +588,7 @@ describe('PercyConfig', () => {
         '  foo: {',
         '    bar: \'baz\'',
         '  }',
-        '}'
+        '}\n'
       ].join('\n'));
     });
 


### PR DESCRIPTION
## What is this?

Although I haven't noticed any issues with the string replacement method, it feels like it has the potential to be buggy. I think the initial intention was to avoid having to parse the entire json file, but in reality parsing a single package.json file is very quick.

While making this change, I noticed that the parsing and re-stringifying causes the file to lose it's line ending. I decided to add this line ending to the config stringify output so it will be consistent for all formats.