### PR TITLE
✨ Autoload plugins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
           - '@percy/dom'
           - '@percy/config'
           - '@percy/core'
+          - '@percy/cli'
           - '@percy/cli-command'
           - '@percy/cli-exec'
           - '@percy/cli-snapshot'

--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-require('@oclif/command').run()
+require('@percy/cli').run()
   .then(require('@oclif/command/flush'))
   .catch(require('@oclif/errors/handle'))

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -1,2 +1,43 @@
-// This package is a multi-command oclif CLI composed of plugins that provide
-// various functionalities for taking Percy snapshots.
+const { promises: fs } = require('fs');
+const path = require('path');
+
+// find plugins in a directory, matching a regexp, ignoring registered plugins
+function findPlugins(dir, regexp, registered) {
+  return fs.readdir(dir).then(f => f.reduce((plugins, dirname) => {
+    if (dirname === 'cli' || !regexp.test(dirname)) return plugins;
+
+    let { name, oclif } = require(`${dir}/${dirname}/package.json`);
+
+    if (!registered.includes(name) && oclif && oclif.bin === 'percy') {
+      return plugins.concat(name);
+    } else {
+      return plugins;
+    }
+  }, []));
+}
+
+// automatically register/unregister plugins by altering the CLI's package.json within node_modules
+async function autoRegisterPlugins() {
+  let pkgPath = path.resolve(__dirname, 'package.json');
+  let pkg = require(pkgPath);
+
+  let registered = pkg.oclif.plugins.filter(plugin => {
+    if (pkg.dependencies[plugin]) return true;
+    try { return !!require.resolve(plugin); } catch {}
+    return false;
+  });
+
+  let unregistered = await Promise.all([
+    findPlugins(path.resolve(__dirname, '..'), /^.*/, registered), // @percy/*
+    findPlugins(path.resolve(__dirname, '../..'), /^percy-cli-.*/, registered) // percy-cli-*
+  ]).then(p => Array.from(new Set(p.flat())));
+
+  if (unregistered.length || registered.length !== pkg.oclif.plugins.length) {
+    pkg.oclif.plugins = registered.concat(unregistered);
+    await fs.writeFile(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  }
+}
+
+// auto register plugins before running oclif
+module.exports.run = () => autoRegisterPlugins()
+  .then(() => require('@oclif/command').run());

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,13 +29,11 @@
       "@percy/cli-build",
       "@percy/cli-snapshot",
       "@percy/cli-upload",
-      "@oclif/plugin-help",
-      "@oclif/plugin-plugins"
+      "@oclif/plugin-help"
     ]
   },
   "dependencies": {
     "@oclif/plugin-help": "^3.2.0",
-    "@oclif/plugin-plugins": "^1.9.0",
     "@percy/cli-build": "^1.0.0-beta.34",
     "@percy/cli-config": "^1.0.0-beta.34",
     "@percy/cli-exec": "^1.0.0-beta.34",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,10 +16,14 @@
   },
   "scripts": {
     "lint": "eslint --ignore-path ../../.gitignore .",
-    "postbuild": "oclif-dev manifest"
+    "test": "cross-env NODE_ENV=test mocha",
+    "test:coverage": "nyc yarn test"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "mocha": {
+    "require": "../../scripts/babel-register"
   },
   "oclif": {
     "bin": "percy",

--- a/packages/cli/test/.eslintrc
+++ b/packages/cli/test/.eslintrc
@@ -1,0 +1,2 @@
+env:
+  mocha: true

--- a/packages/cli/test/helpers.js
+++ b/packages/cli/test/helpers.js
@@ -1,0 +1,51 @@
+import path from 'path';
+import mockRequire from 'mock-require';
+
+export function pluginMocker() {
+  let pkgPath = path.resolve(__dirname, '../package.json');
+
+  let mock = ({ plugins, packages }) => {
+    for (let [name, dep] of Object.entries(plugins)) {
+      if (dep) mock.pkg.dependencies[name] = true;
+      mock.pkg.oclif.plugins.push(name);
+    }
+
+    for (let [name, plugin] of Object.entries(packages)) {
+      let dir = path.resolve(__dirname, name.startsWith('@percy') ? '../..' : '../../..');
+      let dirname = name.replace('@percy', '');
+
+      mock.dir[dir].push(dirname);
+      mockRequire(`${dir}/${dirname}/package.json`, plugin ? (
+        { name, oclif: { bin: 'percy' } }
+      ) : { name });
+    }
+  };
+
+  mock.pkg = {
+    oclif: { plugins: [] },
+    dependencies: {}
+  };
+
+  mock.dir = {
+    [path.resolve(__dirname, '../..')]: [],
+    [path.resolve(__dirname, '../../..')]: []
+  };
+
+  mockRequire(pkgPath, mock.pkg);
+  mockRequire('fs', {
+    ...require('fs'),
+
+    promises: {
+      readdir: async dir => mock.dir[dir],
+      writeFile: async (path, contents) => {
+        if (path === pkgPath) {
+          mock.pkg = JSON.parse(contents);
+        }
+      }
+    }
+  });
+
+  return mock;
+}
+
+export { mockRequire };

--- a/packages/cli/test/index.test.js
+++ b/packages/cli/test/index.test.js
@@ -1,0 +1,80 @@
+import expect from 'expect';
+import { pluginMocker, mockRequire } from './helpers';
+
+describe('Plugin auto-registration', () => {
+  let mock, run;
+
+  beforeEach(() => {
+    mock = pluginMocker();
+    mockRequire('@oclif/command', { run() {} });
+    run = mockRequire.reRequire('..').run;
+  });
+
+  afterEach(() => {
+    mockRequire.stopAll();
+  });
+
+  it('adds unregistered plugins to the package.json', async () => {
+    mock({
+      plugins: {
+        '@percy/cli-exec': true
+      },
+      packages: {
+        '@percy/cli-config': true,
+        '@percy/cli-exec': true,
+        '@percy/core': false,
+        '@percy/storybook': true,
+        'percy-cli-custom': true,
+        'percy-cli-no': false,
+        'percy-custom': true
+      }
+    });
+
+    await run();
+
+    expect(mock.pkg.oclif.plugins).toEqual([
+      '@percy/cli-exec',
+      '@percy/cli-config',
+      '@percy/storybook',
+      'percy-cli-custom'
+    ]);
+  });
+
+  it('removes missing plugins from the package.json', async () => {
+    mock({
+      plugins: {
+        '@percy/cli-exec': true,
+        '@percy/cli-other': false
+      },
+      packages: {
+        '@percy/cli-exec': true
+      }
+    });
+
+    await run();
+
+    expect(mock.pkg.oclif.plugins).toEqual([
+      '@percy/cli-exec'
+    ]);
+  });
+
+  it('does nothing when plugins are registered', async () => {
+    mock({
+      plugins: {
+        '@percy/cli-exec': true,
+        '@percy/cli-other': true
+      },
+      packages: {
+        '@percy/cli-exec': true,
+        '@percy/cli-other': true
+      }
+    });
+
+    await run();
+
+    expect(mock.pkg.oclif.plugins).toEqual([
+      '@percy/cli-exec',
+      '@percy/cli-other'
+    ]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1704,18 +1704,7 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@oclif/color@^0.x":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@oclif/color/-/color-0.1.2.tgz#28b07e2850d9ce814d0b587ce3403b7ad8f7d987"
-  integrity sha512-M9o+DOrb8l603qvgz1FogJBUGLqcMFL1aFg2ZEL0FbXJofiNTLOWIeB4faeZTLwE6dt0xH9GpCVpzksMMzGbmA==
-  dependencies:
-    ansi-styles "^3.2.1"
-    chalk "^3.0.0"
-    strip-ansi "^5.2.0"
-    supports-color "^5.4.0"
-    tslib "^1"
-
-"@oclif/command@^1.5.12", "@oclif/command@^1.5.20", "@oclif/command@^1.6.0", "@oclif/command@^1.8.0":
+"@oclif/command@^1.5.20", "@oclif/command@^1.6.0", "@oclif/command@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.8.0.tgz#c1a499b10d26e9d1a611190a81005589accbb339"
   integrity sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==
@@ -1799,25 +1788,6 @@
     strip-ansi "^6.0.0"
     widest-line "^3.1.0"
     wrap-ansi "^4.0.0"
-
-"@oclif/plugin-plugins@^1.9.0":
-  version "1.9.5"
-  resolved "https://registry.yarnpkg.com/@oclif/plugin-plugins/-/plugin-plugins-1.9.5.tgz#b66176e4e8eda731913df6b8f310293a19b95138"
-  integrity sha512-8U1MKPTaitCBj4HPZpwFo7F5Krw9zEaNqKiX+QkvPz2wfftLqnSqariYvP38S/uo8CDwiR3zHPEYFSxu9CDQQA==
-  dependencies:
-    "@oclif/color" "^0.x"
-    "@oclif/command" "^1.5.12"
-    "@oclif/errors" "^1.2.2"
-    chalk "^4.1.0"
-    cli-ux "^5.2.1"
-    debug "^4.1.0"
-    fs-extra "^9.0"
-    http-call "^5.2.2"
-    load-json-file "^5.2.0"
-    npm-run-path "^4.0.1"
-    semver "^7.3.2"
-    tslib "^2.0.0"
-    yarn "^1.21.1"
 
 "@oclif/screen@^1.0.3":
   version "1.0.4"
@@ -2434,11 +2404,6 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
-
-at-least-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
-  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 atob-lite@^2.0.0:
   version "2.0.0"
@@ -4533,16 +4498,6 @@ fs-extra@^8.1, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
-  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs-minipass@^1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
@@ -4997,7 +4952,7 @@ http-cache-semantics@^4.0.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
-http-call@^5.1.2, http-call@^5.2.2:
+http-call@^5.1.2:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/http-call/-/http-call-5.3.0.tgz#4ded815b13f423de176eb0942d69c43b25b148db"
   integrity sha512-ahwimsC23ICE4kPl9xTBjKB4inbRaeLyZeRunC/1Jy/Z6X8tv22MEAjK+KBOMSVLaqXPTTmd8638waVIKLGx2w==
@@ -5803,15 +5758,6 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonfile@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
-  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
-  dependencies:
-    universalify "^2.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -6013,7 +5959,7 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
-load-json-file@^5.2.0, load-json-file@^5.3.0:
+load-json-file@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-5.3.0.tgz#4d3c1e01fa1c03ea78a60ac7af932c9ce53403f3"
   integrity sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==
@@ -6813,13 +6759,6 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npm-run-path@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
-  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
-  dependencies:
-    path-key "^3.0.0"
-
 npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
@@ -7262,7 +7201,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-key@^3.0.0, path-key@^3.1.0:
+path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
@@ -8667,7 +8606,7 @@ supports-color@7.2.0, supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -8934,7 +8873,7 @@ tsd@^0.14.0:
     read-pkg-up "^7.0.0"
     update-notifier "^4.1.0"
 
-tslib@^1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -9103,11 +9042,6 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
-
-universalify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
-  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -9552,11 +9486,6 @@ yargs@^16.1.1:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
-
-yarn@^1.21.1:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
-  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
## Purpose

With `@oclif/plugin-plugins`, the user is _required_ to use the various `plugin:*` commands in order to use plugins with the CLI. This means that if the CLI and a CLI plugin are both dependencies, the plugin will **not** automatically be associated with the CLI until the user runs the appropriate `plugin:*` command.

## Approach

Before calling the first OCLIF entry point within `@percy/cli`, we can search through `node_modules` for `@percy/*` and `percy-cli-*` packages to append to `@percy/cli`'s list of plugins. 

This is similar but distinctly different from how the `@oclif/plugins-plugin` handles plugins. With the official plugin, it has its own dependency on `yarn` which manages plugin package, and registers plugins via editing a global data directory's `package.json` file associated with the CLI package. This makes it so all versions of the CLI that may be installed on a single machine in various projects have the same shared registered plugins.

The autoload approach used here will instead edit the local `node_modules/@percy/cli/package.json` file so that only plugins at the same scope as the CLI are registered. Global CLI plugins will be registered with the global CLI package, and individual project plugins will be registered with the project's own CLI dependency.

All `@percy/*` packages are checked for plugin compatibility so official SDKs that extend the CLI do not need to name themselves as CLI plugins. However, rather than checking all `percy-*` dependencies for CLI plugins, only `percy-cli-*` dependencies are checked, requiring custom third party SDKs/plugins to be more explicit.

Finally, the `@oclif/plugins-plugin` package was removed in favor of this autoload approach and letting the users manage Percy CLI plugins using their normal, familiar, package manager. In the future, whenever we require plugins to be installed outside of Node ecosystems, we can leverage [the tarball's included Node binary](https://oclif.io/docs/releasing#standalone-tarballs) to manage plugins.