### PR TITLE
✨ Accept browser executable env var

### DIFF
--- a/packages/core/src/discovery/browser.js
+++ b/packages/core/src/discovery/browser.js
@@ -47,7 +47,7 @@ export default class Browser extends EventEmitter {
   ];
 
   async launch({
-    executable,
+    executable = process.env.PERCY_BROWSER_EXECUTABLE,
     headless = true,
     args: uargs = [],
     timeout


### PR DESCRIPTION
## What is this?

The browser executable option is typically more useful as a CI environment variable rather than a config option that is carried forward to various environments. 