### PR TITLE
🐛 Improve plugin autoloading

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -1,37 +1,57 @@
 const { promises: fs } = require('fs');
 const path = require('path');
 
-// find plugins in a directory, matching a regexp, ignoring registered plugins
-function findPlugins(dir, regexp, registered) {
+// find plugins in a directory, matching a pattern, ignoring registered plugins
+function findPlugins(dir, pattern, registered) {
+  let segments = pattern.split('/');
+  let regexp = new RegExp(`^${segments.pop().replace('*', '.*')}`);
+  dir = path.join(dir, ...segments);
+
   return fs.readdir(dir).then(f => f.reduce((plugins, dirname) => {
+    // exclude CLI's own directory and any directory not matching the pattern
     if (dirname === 'cli' || !regexp.test(dirname)) return plugins;
 
-    let { name, oclif } = require(`${dir}/${dirname}/package.json`);
+    try {
+      let { name, oclif } = require(`${dir}/${dirname}/package.json`);
 
-    if (!registered.includes(name) && oclif && oclif.bin === 'percy') {
-      return plugins.concat(name);
-    } else {
-      return plugins;
+      // plugin's package.json have a percy oclif binary defined
+      if (!registered.includes(name) && oclif && oclif.bin === 'percy') {
+        return plugins.concat(name);
+      }
+    } catch {
+      // ignore directories without a package.json
     }
+
+    return plugins;
   }, []));
 }
 
 // automatically register/unregister plugins by altering the CLI's package.json within node_modules
 async function autoRegisterPlugins() {
+  let nodeModules = path.resolve(__dirname, '../..');
   let pkgPath = path.resolve(__dirname, 'package.json');
   let pkg = require(pkgPath);
 
+  // if not installed within node_modules, look within own node_modules
+  /* istanbul ignore else: always true during tests */
+  if (path.basename(nodeModules) !== 'node_modules') {
+    nodeModules = path.resolve(__dirname, 'node_modules');
+  }
+
+  // ensure registered plugins can be resolved
   let registered = pkg.oclif.plugins.filter(plugin => {
     if (pkg.dependencies[plugin]) return true;
     try { return !!require.resolve(plugin); } catch {}
     return false;
   });
 
+  // find unregistered plugins
   let unregistered = await Promise.all([
-    findPlugins(path.resolve(__dirname, '..'), /^.*/, registered), // @percy/*
-    findPlugins(path.resolve(__dirname, '../..'), /^percy-cli-.*/, registered) // percy-cli-*
+    findPlugins(nodeModules, '@percy/*', registered),
+    findPlugins(nodeModules, 'percy-cli-*', registered)
   ]).then(p => Array.from(new Set(p.flat())));
 
+  // if any unregistered or unresolved registered, modify plugin registry
   if (unregistered.length || registered.length !== pkg.oclif.plugins.length) {
     pkg.oclif.plugins = registered.concat(unregistered);
     await fs.writeFile(pkgPath, JSON.stringify(pkg, null, 2) + '\n');

--- a/packages/cli/test/helpers.js
+++ b/packages/cli/test/helpers.js
@@ -11,7 +11,8 @@ export function pluginMocker() {
     }
 
     for (let [name, plugin] of Object.entries(packages)) {
-      let dir = path.resolve(__dirname, name.startsWith('@percy') ? '../..' : '../../..');
+      let dir = path.resolve(__dirname, '../node_modules');
+      if (name.startsWith('@percy')) dir = path.resolve(dir, '@percy');
       let dirname = name.replace('@percy', '');
 
       mock.dir[dir].push(dirname);
@@ -27,8 +28,8 @@ export function pluginMocker() {
   };
 
   mock.dir = {
-    [path.resolve(__dirname, '../..')]: [],
-    [path.resolve(__dirname, '../../..')]: []
+    [path.resolve(__dirname, '../node_modules/@percy')]: [],
+    [path.resolve(__dirname, '../node_modules')]: []
   };
 
   mockRequire(pkgPath, mock.pkg);


### PR DESCRIPTION
## What is this?

When the CLI is linked or eventually distributed outside of NPM, it might not always reside within a project or global `node_modules`. In these cases, it should autoload plugins from within its own `node_modules`. This will enable linking plugins to the linked CLI and also allow future iterations to install plugins into the CLIs own `node_modules`.

This is labeled as a bug although it doesn't necessarily fix anything because it would be one if we distributed the CLI outside of NPM.