### PR TITLE
✅ Fix flakey tests

### DIFF
--- a/packages/core/test/capture.test.js
+++ b/packages/core/test/capture.test.js
@@ -306,8 +306,8 @@ describe('Percy Capture', () => {
     let accessed;
 
     server.reply('/img.png', () => new Promise(resolve => {
+      setTimeout(() => (accessed = true), 100);
       setTimeout(resolve, 500, [500, 'text/plain', 'Server Error']);
-      accessed = true;
     }));
 
     let capture = percy.capture({

--- a/packages/core/test/capture.test.js
+++ b/packages/core/test/capture.test.js
@@ -276,7 +276,33 @@ describe('Percy Capture', () => {
     ]);
   });
 
-  it('handles the page or browser closing early', async () => {
+  it('handles the browser closing early', async () => {
+    let created;
+
+    let page = percy.discoverer.page;
+    percy.discoverer.page = function() {
+      created = true;
+      return page.apply(this, arguments);
+    };
+
+    let capture = percy.capture({
+      name: 'test snapshot',
+      url: 'http://localhost:8000'
+    });
+
+    // wait until a page is requested
+    await waitFor(() => created);
+    percy.discoverer.close();
+    await capture;
+
+    expect(logger.stdout).toEqual([]);
+    expect(logger.stderr).toEqual([
+      expect.stringMatching('Encountered an error'),
+      expect.stringMatching('Protocol error \\(Target\\.createTarget\\): Browser closed')
+    ]);
+  });
+
+  it('handles the page closing early', async () => {
     let accessed = 0;
 
     testDOM += '<link rel="stylesheet" href="/style.css"/>';


### PR DESCRIPTION
## What is this?

Some tests are flakey. This PR aims to unflake them all

- [X] `@percy/dom` frame serialization tests
    
    Sometimes a frame may take longer than expected to load. Even the JS only frame may load after modifying the frame document causing that test to flake. On windows, frames can take even longer to load than 3s, so the wait timeout was upped to 5s and the hook timeout was removed.

- [X] `@percy/core` capture handles closing during network idle

    Expected: `Network error: Page closed`
    Received: `Protocol error (Runtime.callFunctionOn): Page closed`

    Received message suggests that the page is sometimes closing either during the provided script execution or after the second network idle during DOM serialization script execution.

    It's possible for the test to continue after an asset has been accessed but before the request has been intercepted causing it to flake. Delaying when asset access is detected should help the request be intercepted in time for the assertion.


- [X] `@percy/cli-exec` start abort test

    The test sends the process quit signal after running the `exec:start` command, then issues a request to see if the server is down. The server is sometimes still up when that request is sent, but it should be on its way down.

    Sometimes it can take more than half of a second for the server to shutdown when forcefully terminating. Removing the arbitrary wait and making the test more deterministic should show if this was a test timing issue, or if termination itself is flakey.
- [X] `@percy/core` flakey coverage

    Coverage is sometimes missing from [here](https://github.com/percy/cli/blob/master/packages/core/src/discovery/browser.js#L104). Not sure which test normally covers this, but a test was added that should always cover this as long as it passes.
