### PR TITLE
🐛 Catch autoload directory errors

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -23,7 +23,7 @@ function findPlugins(dir, pattern, registered) {
     }
 
     return plugins;
-  }, []));
+  }, []), () => []);
 }
 
 // automatically register/unregister plugins by altering the CLI's package.json within node_modules

--- a/packages/cli/test/index.test.js
+++ b/packages/cli/test/index.test.js
@@ -77,4 +77,19 @@ describe('Plugin auto-registration', () => {
       '@percy/cli-other'
     ]);
   });
+
+  it('ignores missing node_modules directory', async () => {
+    // not mocking packages will not create mock directories
+    mock({
+      plugins: {
+        '@percy/cli-exec': true
+      }
+    });
+
+    await run();
+
+    expect(mock.pkg.oclif.plugins).toEqual([
+      '@percy/cli-exec'
+    ]);
+  });
 });


### PR DESCRIPTION
## What is this?

If the directories being searched in do not exist, those errors should be silently ignored since no plugins can exist in a non-existent directory.