### PR TITLE
♻️ Update `agent.js` deprecation message to be user friendly

### DIFF
--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -113,7 +113,7 @@ export default function createPercyServer(percy) {
       .readFile(require.resolve('@percy/dom'), 'utf-8')
       .then(content => {
         let wrapper = '(window.PercyAgent = class PercyAgent { snapshot(n, o) { return PercyDOM.serialize(o); } });';
-        log.deprecated('`percy-agent.js` is deprecated, please update to the latest SDK version');
+        log.deprecated('It looks like you’re using @percy/cli with an older SDK. Please upgrade to the latest version to fix this warning. See these docs for more info: https://docs.percy.io/docs/migrating-to-percy-cli');
         return [200, 'applicaton/javascript', content.concat(wrapper)];
       }),
 

--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -113,7 +113,8 @@ export default function createPercyServer(percy) {
       .readFile(require.resolve('@percy/dom'), 'utf-8')
       .then(content => {
         let wrapper = '(window.PercyAgent = class PercyAgent { snapshot(n, o) { return PercyDOM.serialize(o); } });';
-        log.deprecated('It looks like you’re using @percy/cli with an older SDK. Please upgrade to the latest version to fix this warning. See these docs for more info: https://docs.percy.io/docs/migrating-to-percy-cli');
+        log.deprecated('It looks like you’re using @percy/cli with an older SDK. Please upgrade to the latest version' +
+          ' to fix this warning. See these docs for more info: https://docs.percy.io/docs/migrating-to-percy-cli');
         return [200, 'applicaton/javascript', content.concat(wrapper)];
       }),
 

--- a/packages/core/test/server.test.js
+++ b/packages/core/test/server.test.js
@@ -81,7 +81,8 @@ describe('Snapshot Server', () => {
 
     await expect(response.text()).resolves.toBe(bundle);
     expect(logger.stderr).toEqual([
-      '[percy] Warning: It looks like you’re using @percy/cli with an older SDK. Please upgrade to the latest version to fix this warning. See these docs for more info: https://docs.percy.io/docs/migrating-to-percy-cli\n'
+      '[percy] Warning: It looks like you’re using @percy/cli with an older SDK. Please upgrade to the latest version' +
+        ' to fix this warning. See these docs for more info: https://docs.percy.io/docs/migrating-to-percy-cli\n'
     ]);
   });
 

--- a/packages/core/test/server.test.js
+++ b/packages/core/test/server.test.js
@@ -81,7 +81,7 @@ describe('Snapshot Server', () => {
 
     await expect(response.text()).resolves.toBe(bundle);
     expect(logger.stderr).toEqual([
-      '[percy] Warning: `percy-agent.js` is deprecated, please update to the latest SDK version\n'
+      '[percy] Warning: It looks like you’re using @percy/cli with an older SDK. Please upgrade to the latest version to fix this warning. See these docs for more info: https://docs.percy.io/docs/migrating-to-percy-cli\n'
     ]);
   });
 


### PR DESCRIPTION
## What is this?

When accessing the old DOM library server endpoint (that `@percy/agent` uses) we log a deprecation message. The previous deprecation message is too technical and won't make sense unless you know how the SDKs piece together. The new one aims to be more actionable. 