### PR TITLE
✨ Add config search method

### DIFF
--- a/packages/cli-config/src/commands/config/migrate.js
+++ b/packages/cli-config/src/commands/config/migrate.js
@@ -39,27 +39,20 @@ export class Migrate extends Command {
       flags: { 'dry-run': dry }
     } = this.parse();
 
-    // load config using the explorer directly rather than the load method to
-    // better control logs and prevent validation
     try {
-      let result = !input || fs.statSync(input).isDirectory()
-        ? PercyConfig.explorer.search(input)
-        : PercyConfig.explorer.load(input);
-
-      if (result && result.config) {
-        ({ config, filepath: input } = result);
-        this.log.info(`Found config file: ${path.relative('', input)}`);
-        output = output ? path.resolve(output) : input;
-      } else {
-        this.log.error('Config file not found');
-      }
+      ({ config, filepath: input } = PercyConfig.search(input));
     } catch (error) {
-      this.log.error('Failed to load or parse config file');
       this.log.error(error);
+      this.exit(1);
     }
 
-    // no config, bail
-    if (!config) return this.exit(1);
+    if (config) {
+      this.log.info(`Found config file: ${path.relative('', input)}`);
+      output = output ? path.resolve(output) : input;
+    } else {
+      this.log.error('Config file not found');
+      this.exit(1);
+    }
 
     // if migrating versions, warn when latest
     if (input === output && config.version === 2) {

--- a/packages/cli-config/test/migrate.test.js
+++ b/packages/cli-config/test/migrate.test.js
@@ -95,7 +95,6 @@ describe('percy config:migrate', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Failed to load or parse config file\n',
       '[percy] Error: test\n'
     ]);
   });

--- a/packages/config/src/index.js
+++ b/packages/config/src/index.js
@@ -1,4 +1,4 @@
-import load, { cache, explorer } from './load';
+import load, { cache, explorer, search } from './load';
 import validate, { addSchema, resetSchema } from './validate';
 import migrate, { addMigration, clearMigrations } from './migrate';
 import getDefaults from './defaults';
@@ -8,6 +8,7 @@ import stringify from './stringify';
 // Export a single object that can be imported as PercyConfig
 export default {
   load,
+  search,
   cache,
   explorer,
   validate,

--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -25,6 +25,13 @@ export const explorer = cosmiconfigSync('percy', {
   ]
 });
 
+// Searches within a provided directory, or loads the provided config path
+export function search(path) {
+  let result = !path || statSync(path).isDirectory()
+    ? explorer.search(path) : explorer.load(path);
+  return result?.config ? result : {};
+}
+
 // Finds and loads a config file using cosmiconfig, merges it with optional
 // inputs, validates the combined config according to the schema, and returns
 // the combined config. Loaded config files are cached and reused on next load,
@@ -49,10 +56,9 @@ export default function load({
   // load config or reload cached config
   if (path !== false && (!config || reload)) {
     try {
-      let result = !path || statSync(path).isDirectory()
-        ? explorer.search(path) : explorer.load(path);
+      let result = search(path);
 
-      if (result && result.config) {
+      if (result.config) {
         log[infoDebug](`Found config file: ${relative('', result.filepath)}`);
         let version = parseInt(result.config.version, 10);
 
@@ -75,7 +81,6 @@ export default function load({
         log[infoDebug]('Config file not found');
       }
     } catch (error) {
-      log[errorDebug]('Failed to load or parse config file');
       log[errorDebug](error);
     }
   }

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -298,7 +298,6 @@ describe('PercyConfig', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([
-        '[percy] Failed to load or parse config file\n',
         expect.stringContaining('[percy] Error: test')
       ]);
     });


### PR DESCRIPTION
## What is this?

This pattern is used in `@percy/config`, `@percy/cli-config`, and `@percy/migrate`; so making it a helper will DRY up those places.

I also removed a redundant error message as the real error gets printed anyway.