### PR TITLE
🐛 Fix normalized config request-headers

### DIFF
--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -36,13 +36,17 @@ export function merge(target, source, options) {
   if (options?.replaceArrays && isSourceArray) return source;
   if (typeof source !== 'object') return source != null ? source : target;
   let convertcase = options?.kebab ? kebabcase : camelcase;
+  let skipMerge = [convertcase('request-headers')];
 
   return entries(source).reduce((result, [key, value]) => {
-    value = merge(result?.[key], value, options);
+    let k = convertcase(key);
+
+    value = skipMerge.includes(k) ? value
+      : merge(result?.[key], value, options);
 
     return value == null ? result
       : isSourceArray ? (result || []).concat(value)
-        : assign(result || {}, { [convertcase(key)]: value });
+        : assign(result || {}, { [k]: value });
   }, target);
 }
 

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -538,6 +538,18 @@ describe('PercyConfig', () => {
         'enable-javascript': false
       });
     });
+
+    it('ignores normalizing specific nested objects', () => {
+      expect(PercyConfig.normalize({
+        'request-headers': {
+          'X-Custom-Header': 'custom header'
+        }
+      })).toEqual({
+        requestHeaders: {
+          'X-Custom-Header': 'custom header'
+        }
+      });
+    });
   });
 
   describe('.stringify()', () => {


### PR DESCRIPTION
## Purpose

Currently the normalize method traverses nested objects, including `request-headers`, and converts the casing of the keys to be predictable. Request header keys however, should not be converted and key casing should be left as-is.

## Approach

Add a `skipMerge` array to the merge helper that will not traverse the object any further if the key is present in the array. Currently, the only key to skip is `request-headers`.