### PR TITLE
♻ Improve browser process handling

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "@percy/config": "^1.0.0-beta.36",
     "@percy/dom": "^1.0.0-beta.36",
     "@percy/logger": "^1.0.0-beta.36",
+    "cross-spawn": "^7.0.3",
     "extract-zip": "^2.0.1",
     "progress": "^2.0.3",
     "rimraf": "^3.0.2",

--- a/packages/core/src/discovery/browser.js
+++ b/packages/core/src/discovery/browser.js
@@ -1,7 +1,7 @@
 import os from 'os';
 import path from 'path';
 import { promises as fs, existsSync } from 'fs';
-import { spawn } from 'child_process';
+import spawn from 'cross-spawn';
 import EventEmitter from 'events';
 import WebSocket from 'ws';
 import rimraf from 'rimraf';

--- a/packages/core/src/discovery/browser.js
+++ b/packages/core/src/discovery/browser.js
@@ -116,8 +116,9 @@ export default class Browser extends EventEmitter {
     this.pages.clear();
 
     // no executable means the browser never launched
+    // an exit code means the browser has already closed
     /* istanbul ignore next: sanity */
-    if (!this.executable) return;
+    if (!this.executable || this.process.exitCode) return;
 
     // attempt to close the browser gracefully
     let closed = new Promise(resolve => {
@@ -194,8 +195,7 @@ export default class Browser extends EventEmitter {
       let handleClose = () => handleError();
       let handleError = error => {
         cleanup(() => reject(new Error(
-          `Failed to launch browser. ${error?.message ?? ''}` +
-            '\n', stderr, '\n\n'
+          `Failed to launch browser. ${error?.message ?? ''}\n${stderr}'\n\n`
         )));
       };
 

--- a/packages/core/src/discovery/browser.js
+++ b/packages/core/src/discovery/browser.js
@@ -72,9 +72,14 @@ export default class Browser extends EventEmitter {
     for (let a of uargs) if (!args.includes(a)) args.push(a);
 
     // spawn the browser process detached in its own group and session
-    this.process = spawn(this.executable, args, { detached: true });
+    this.process = spawn(this.executable, args, {
+      detached: process.platform !== 'win32'
+    });
+
     // connect a websocket to the devtools address
-    this.ws = new WebSocket(await this.address(timeout), { perMessageDeflate: false });
+    this.ws = new WebSocket(await this.address(timeout), {
+      perMessageDeflate: false
+    });
 
     // wait until the websocket has connected before continuing
     await new Promise(resolve => this.ws.once('open', resolve));


### PR DESCRIPTION
## What is this?

While chasing an issue on Windows where the `@percy/cli-exec` test suite hangs, some changes were made in an attempt to ensure the browser process was being handled correctly. While this ultimately didn't fix the issue on Windows, I do think these are good changes that should be adopted regardless.

- Add check if browser is already closed
- Use cross-spawn to spawn browsers
- Do not spawn detached browser in Windows
- Always kill browser process when able to