### PR TITLE
🐛 Include post-install script in packaged files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
   "types": "types/index.d.ts",
   "files": [
     "dist",
+    "post-install.js",
     "types/index.d.ts",
     "test/helpers/server.js"
   ],


### PR DESCRIPTION
## What is this?

The addition to include the post-install script in the packaged files was missed in #206 