### PR TITLE
🐛 Check src directory for post-install

### DIFF
--- a/packages/core/post-install.js
+++ b/packages/core/post-install.js
@@ -5,8 +5,8 @@ if (process.env.PERCY_POSTINSTALL_BROWSER || require.main !== module) {
   const fs = require('fs');
   const path = require('path');
 
-  // the test directory indicates postinstall during development
-  const isDev = fs.existsSync(path.join(__dirname, 'test'));
+  // the src directory indicates postinstall during development
+  const isDev = fs.existsSync(path.join(__dirname, 'src'));
 
   // register babel transforms for development install
   if (isDev) require('../../scripts/babel-register');


### PR DESCRIPTION
## What is this?

The post-install script checks for a test directory to determine if it is being run in development. This package exports a test helper which means the test directory is also present in production. The src files should never be included, so should be a much safer check.