### PR TITLE
✨ Add exec partial build flag

### DIFF
--- a/packages/cli-exec/README.md
+++ b/packages/cli-exec/README.md
@@ -21,11 +21,11 @@ OPTIONS
   -P, --port=port                                  [default: 5338] server port
   -c, --config=config                              configuration file path
   -h, --allowed-hostname=allowed-hostname          allowed hostnames
-  -p, --parallel                                   marks the build as one of many parallel builds
   -q, --quiet                                      log errors only
   -t, --network-idle-timeout=network-idle-timeout  asset discovery idle timeout
   -v, --verbose                                    log everything
   --disable-cache                                  disable asset discovery caches
+  --parallel                                       marks the build as one of many parallel builds
   --partial                                        marks the build as a partial build
   --silent                                         log nothing
 

--- a/packages/cli-exec/README.md
+++ b/packages/cli-exec/README.md
@@ -26,6 +26,7 @@ OPTIONS
   -t, --network-idle-timeout=network-idle-timeout  asset discovery idle timeout
   -v, --verbose                                    log everything
   --disable-cache                                  disable asset discovery caches
+  --partial                                        marks the build as a partial build
   --silent                                         log nothing
 
 EXAMPLES

--- a/packages/cli-exec/src/commands/exec/index.js
+++ b/packages/cli-exec/src/commands/exec/index.js
@@ -16,7 +16,6 @@ export class Exec extends Command {
     ...execFlags,
 
     parallel: flags.boolean({
-      char: 'p',
       description: 'marks the build as one of many parallel builds'
     }),
 

--- a/packages/cli-exec/src/commands/exec/index.js
+++ b/packages/cli-exec/src/commands/exec/index.js
@@ -18,6 +18,10 @@ export class Exec extends Command {
     parallel: flags.boolean({
       char: 'p',
       description: 'marks the build as one of many parallel builds'
+    }),
+
+    partial: flags.boolean({
+      description: 'marks the build as a partial build'
     })
   };
 
@@ -46,6 +50,11 @@ export class Exec extends Command {
     // set environment parallel total for `n` parallel builds (use with build:finalize)
     if (this.flags.parallel && !process.env.PERCY_PARALLEL_TOTAL) {
       process.env.PERCY_PARALLEL_TOTAL = '-1';
+    }
+
+    // set environment partial build flag
+    if (this.flags.partial) {
+      process.env.PERCY_PARTIAL_BUILD = '1';
     }
 
     // attempt to start percy if enabled

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -48,18 +48,13 @@ describe('percy exec', () => {
   it('sets the parallel total when the --parallel flag is provided', async () => {
     expect(process.env.PERCY_PARALLEL_TOTAL).toBeUndefined();
     await Exec.run(['--parallel', '--', 'node', '--eval', '']);
-
-    expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual([
-      '[percy] Percy has started!\n',
-      '[percy] Created build #1: https://percy.io/test/test/123\n',
-      '[percy] Running "node --eval "\n',
-      '[percy] Stopping percy...\n',
-      '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-      '[percy] Done!\n'
-    ]);
-
     expect(process.env.PERCY_PARALLEL_TOTAL).toBe('-1');
+  });
+
+  it('sets the partial env var when the --partial flag is provided', async () => {
+    expect(process.env.PERCY_PARTIAL_BUILD).toBeUndefined();
+    await Exec.run(['--partial', '--', 'node', '--eval', '']);
+    expect(process.env.PERCY_PARTIAL_BUILD).toBe('1');
   });
 
   it('runs the command even when percy is disabled', async () => {


### PR DESCRIPTION
## What is this?

Rather than requiring the user set an environment variable to determine if a build is a partial build, we can set the environment variable automatically when provided a `--partial` flag.

This brought up a question in my mind about the `--parallel` flag's short version, `-p`. Could be confusing now with a second "p" argument; should we remove the parallel shorthand to avoid confusion before leaving beta?