### PR TITLE
🐛  Catch any errors that arise from `globalThis` in the DOM libary

### DIFF
--- a/packages/dom/src/index.js
+++ b/packages/dom/src/index.js
@@ -3,8 +3,12 @@ import serialize from './serialize-dom';
 /* istanbul ignore next */
 // works around instances where the context has an incorrect global scope
 // https://github.com/mozilla/geckodriver/issues/1798
-if (globalThis !== window) {
-  window.PercyDOM = { serialize };
+try {
+  if (globalThis !== window) {
+    window.PercyDOM = { serialize };
+  }
+} catch (error) {
+  // `globalThis` is probably not defined
 }
 
 export { serialize };


### PR DESCRIPTION
## What is this?

Nightmare/electron envs don't have `globalThis` defined, which errors and breaks snapshots. This wraps a try/catch around it to stop that from happening