### PR TITLE
🔨 Fix script watching

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -48,10 +48,10 @@ async function main({ node, bundle } = argv) {
 // handle errors
 function handleError(err) {
   if (!err.exitCode) console.error(err);
-  process.exit(err.exitCode || 1);
+  if (!argv.watch) process.exit(err.exitCode || 1);
 }
 
 // run everything and maybe watch for changes
-main().then(() => argv.watch && (
+main().catch(handleError).then(() => argv.watch && (
   require('./watch')(() => main().catch(handleError))
-)).catch(handleError);
+));


### PR DESCRIPTION
## What is this?

If the first run of a script fails, it never gets to the watch logic. The error handler also called `process.exit`, which it should not do when watching.

Since test runners like to assume they have control over the process, when run together they were forked. They are now always forked since the watch process needs to control its own process.