### PR TITLE
✨ Add browser and remote support for @percy/logger

### DIFF
--- a/packages/cli-build/src/commands/build/wait.js
+++ b/packages/cli-build/src/commands/build/wait.js
@@ -76,23 +76,21 @@ export class Wait extends Command {
       'total-comparisons-finished': finished
     }
   }) {
-    let stdout = logger.instance.stdout;
-
     // update the same line each time
-    readline.cursorTo(stdout, 0);
+    readline.cursorTo(logger.stdout, 0);
 
     // still recieving snapshots
     if (state === 'pending') {
-      stdout.write(logger.format('Recieving snapshots...', 'cli:build:wait'));
+      logger.stdout.write(logger.format('Recieving snapshots...', 'cli:build:wait'));
 
     // need to clear the line before finishing
     } else if (finished === total || state === 'finished') {
-      readline.clearLine(stdout);
+      readline.clearLine(logger.stdout);
     }
 
     // processing snapshots
     if (state === 'processing') {
-      stdout.write(logger.format(
+      logger.stdout.write(logger.format(
         `Processing ${count} snapshots - ` + (
           finished === total ? 'finishing up...'
             : `${finished} of ${total} comparisons finished...`),

--- a/packages/cli-build/test/finalize.test.js
+++ b/packages/cli-build/test/finalize.test.js
@@ -19,7 +19,7 @@ describe('percy build:finalize', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy is disabled\n'
+      '[percy] Percy is disabled'
     ]);
   });
 
@@ -30,8 +30,8 @@ describe('percy build:finalize', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] This command should only be used with PERCY_PARALLEL_TOTAL=-1\n',
-      '[percy] Current value is "5"\n'
+      '[percy] This command should only be used with PERCY_PARALLEL_TOTAL=-1',
+      '[percy] Current value is "5"'
     ]);
   });
 
@@ -49,8 +49,8 @@ describe('percy build:finalize', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Finalizing parallel build...\n',
-      '[percy] Finalized build #1: https://percy.io/test/test/123\n'
+      '[percy] Finalizing parallel build...',
+      '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]);
   });
 });

--- a/packages/cli-build/test/wait.test.js
+++ b/packages/cli-build/test/wait.test.js
@@ -35,7 +35,7 @@ describe('percy build:wait', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy is disabled\n'
+      '[percy] Percy is disabled'
     ]);
   });
 
@@ -43,7 +43,7 @@ describe('percy build:wait', () => {
     await expectAsync(Wait.run([])).toBeRejectedWithError('EEXIT: 1');
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: Missing build ID or commit SHA\n'
+      '[percy] Error: Missing build ID or commit SHA'
     ]);
   });
 
@@ -100,8 +100,8 @@ describe('percy build:wait', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
-      '[percy] Build #10 finished! https://percy.io/test/test/123\n',
-      '[percy] Found 16 changes\n'
+      '[percy] Build #10 finished! https://percy.io/test/test/123',
+      '[percy] Found 16 changes'
     ]));
   });
 
@@ -115,8 +115,8 @@ describe('percy build:wait', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
-      '[percy] Build #10 finished! https://percy.io/test/test/123\n',
-      '[percy] Found 16 changes\n'
+      '[percy] Build #10 finished! https://percy.io/test/test/123',
+      '[percy] Found 16 changes'
     ]));
   });
 
@@ -130,8 +130,8 @@ describe('percy build:wait', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
-      '[percy] Build #10 finished! https://percy.io/test/test/123\n',
-      '[percy] Found 0 changes\n'
+      '[percy] Build #10 finished! https://percy.io/test/test/123',
+      '[percy] Found 0 changes'
     ]));
   });
 
@@ -141,7 +141,7 @@ describe('percy build:wait', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
-      '[percy] Build #10 is expired. https://percy.io/test/test/123\n'
+      '[percy] Build #10 is expired. https://percy.io/test/test/123'
     ]));
   });
 
@@ -156,9 +156,9 @@ describe('percy build:wait', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual(jasmine.arrayContaining([
-        '[percy] Build #10 failed! https://percy.io/test/test/123\n',
+        '[percy] Build #10 failed! https://percy.io/test/test/123',
         '[percy] Some snapshots in this build took too long to render ' +
-          'even after multiple retries.\n'
+          'even after multiple retries.'
       ]));
     });
 
@@ -172,8 +172,8 @@ describe('percy build:wait', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual(jasmine.arrayContaining([
-        '[percy] Build #10 failed! https://percy.io/test/test/123\n',
-        '[percy] No snapshots were uploaded to this build.\n'
+        '[percy] Build #10 failed! https://percy.io/test/test/123',
+        '[percy] No snapshots were uploaded to this build.'
       ]));
     });
 
@@ -187,8 +187,8 @@ describe('percy build:wait', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual(jasmine.arrayContaining([
-        '[percy] Build #10 failed! https://percy.io/test/test/123\n',
-        '[percy] Failed to correctly finalize.\n'
+        '[percy] Build #10 failed! https://percy.io/test/test/123',
+        '[percy] Failed to correctly finalize.'
       ]));
     });
 
@@ -202,8 +202,8 @@ describe('percy build:wait', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual(jasmine.arrayContaining([
-        '[percy] Build #10 failed! https://percy.io/test/test/123\n',
-        '[percy] Some build or snapshot resources failed to correctly upload.\n'
+        '[percy] Build #10 failed! https://percy.io/test/test/123',
+        '[percy] Some build or snapshot resources failed to correctly upload.'
       ]));
     });
 
@@ -222,8 +222,8 @@ describe('percy build:wait', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual(jasmine.arrayContaining([
-        '[percy] Build #10 failed! https://percy.io/test/test/123\n',
-        '[percy] Only 3 of 4 parallelized build processes finished.\n'
+        '[percy] Build #10 failed! https://percy.io/test/test/123',
+        '[percy] Only 3 of 4 parallelized build processes finished.'
       ]));
     });
 
@@ -237,8 +237,8 @@ describe('percy build:wait', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual(jasmine.arrayContaining([
-        '[percy] Build #10 failed! https://percy.io/test/test/123\n',
-        '[percy] Error: unrecognized_reason\n'
+        '[percy] Build #10 failed! https://percy.io/test/test/123',
+        '[percy] Error: unrecognized_reason'
       ]));
     });
   });

--- a/packages/cli-command/test/command.test.js
+++ b/packages/cli-command/test/command.test.js
@@ -76,7 +76,7 @@ describe('PercyCommand', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: test error\n'
+      '[percy] Error: test error'
     ]);
   });
 

--- a/packages/cli-config/src/commands/config/migrate.js
+++ b/packages/cli-config/src/commands/config/migrate.js
@@ -92,6 +92,6 @@ export class Migrate extends Command {
 
     this.log.info('Config file migrated!');
     // when dry-running, print config to stdout when finished
-    if (dry) logger.instance.stdout.write('\n' + body);
+    if (dry) logger.stdout.write('\n' + body);
   }
 }

--- a/packages/cli-config/test/create.test.js
+++ b/packages/cli-config/test/create.test.js
@@ -7,42 +7,42 @@ describe('percy config:create', () => {
   it('creates a .percy.yml config file by default', async () => {
     await Create.run([]);
     expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual(['[percy] Created Percy config: .percy.yml\n']);
+    expect(logger.stdout).toEqual(['[percy] Created Percy config: .percy.yml']);
     expect(getMockConfig('.percy.yml')).toBe(PercyConfig.stringify('yaml'));
   });
 
   it('can create a .percyrc config file', async () => {
     await Create.run(['--rc']);
     expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual(['[percy] Created Percy config: .percyrc\n']);
+    expect(logger.stdout).toEqual(['[percy] Created Percy config: .percyrc']);
     expect(getMockConfig('.percyrc')).toBe(PercyConfig.stringify('yaml'));
   });
 
   it('can create a .percy.yaml config file', async () => {
     await Create.run(['--yaml']);
     expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual(['[percy] Created Percy config: .percy.yaml\n']);
+    expect(logger.stdout).toEqual(['[percy] Created Percy config: .percy.yaml']);
     expect(getMockConfig('.percy.yaml')).toBe(PercyConfig.stringify('yaml'));
   });
 
   it('can create a .percy.yml config file', async () => {
     await Create.run(['--yml']);
     expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual(['[percy] Created Percy config: .percy.yml\n']);
+    expect(logger.stdout).toEqual(['[percy] Created Percy config: .percy.yml']);
     expect(getMockConfig('.percy.yml')).toBe(PercyConfig.stringify('yaml'));
   });
 
   it('can create a .percy.json config file', async () => {
     await Create.run(['--json']);
     expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual(['[percy] Created Percy config: .percy.json\n']);
+    expect(logger.stdout).toEqual(['[percy] Created Percy config: .percy.json']);
     expect(getMockConfig('.percy.json')).toBe(PercyConfig.stringify('json'));
   });
 
   it('can create a .percy.js config file', async () => {
     await Create.run(['--js']);
     expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual(['[percy] Created Percy config: .percy.js\n']);
+    expect(logger.stdout).toEqual(['[percy] Created Percy config: .percy.js']);
     expect(getMockConfig('.percy.js')).toBe(PercyConfig.stringify('js'));
   });
 
@@ -50,23 +50,23 @@ describe('percy config:create', () => {
     let filename = path.join('.config', 'percy.config.js');
     await Create.run([filename]);
     expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual([`[percy] Created Percy config: ${filename}\n`]);
+    expect(logger.stdout).toEqual([`[percy] Created Percy config: ${filename}`]);
     expect(getMockConfig(filename)).toBe(PercyConfig.stringify('js'));
   });
 
   it('logs an error and exits when the filetype is unsupported', async () => {
     await expectAsync(Create.run([path.join('.config', 'percy.config.php')])).toBeRejectedWithError('EEXIT: 1');
     expect(logger.stdout).toEqual([]);
-    expect(logger.stderr).toEqual(['[percy] Unsupported filetype: php\n']);
+    expect(logger.stderr).toEqual(['[percy] Unsupported filetype: php']);
   });
 
   it('logs an error and exits when the config file already exists', async () => {
     await Create.run(['.percy.yml']);
-    logger.clear();
+    logger.reset();
 
     await expectAsync(Create.run(['.percy.yml'])).toBeRejectedWithError('EEXIT: 1');
 
     expect(logger.stdout).toEqual([]);
-    expect(logger.stderr).toEqual(['[percy] Percy config already exists: .percy.yml\n']);
+    expect(logger.stderr).toEqual(['[percy] Percy config already exists: .percy.yml']);
   });
 });

--- a/packages/cli-config/test/migrate.test.js
+++ b/packages/cli-config/test/migrate.test.js
@@ -20,9 +20,9 @@ describe('percy config:migrate', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Found config file: .percy.yml\n',
-      '[percy] Migrating config file...\n',
-      '[percy] Config file migrated!\n'
+      '[percy] Found config file: .percy.yml',
+      '[percy] Migrating config file...',
+      '[percy] Config file migrated!'
     ]);
 
     expect(getMockConfig('.percy.old.yml')).toContain('version: 1');
@@ -34,10 +34,10 @@ describe('percy config:migrate', () => {
     expect(getMockConfig('.percy.yml')).toContain('version: 1');
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Found config file: .percy.yml\n',
-      '[percy] Migrating config file...\n',
-      '[percy] Config file migrated!\n',
-      '\nversion: 2\n'
+      '[percy] Found config file: .percy.yml',
+      '[percy] Migrating config file...',
+      '[percy] Config file migrated!',
+      '\nversion: 2'
     ]);
   });
 
@@ -80,7 +80,7 @@ describe('percy config:migrate', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Config file not found\n'
+      '[percy] Config file not found'
     ]);
   });
 
@@ -95,7 +95,7 @@ describe('percy config:migrate', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: test\n'
+      '[percy] Error: test'
     ]);
   });
 
@@ -104,10 +104,10 @@ describe('percy config:migrate', () => {
     await Migrate.run([]);
 
     expect(logger.stdout).toEqual([
-      '[percy] Found config file: .percy.yml\n'
+      '[percy] Found config file: .percy.yml'
     ]);
     expect(logger.stderr).toEqual([
-      '[percy] Config is already the latest version\n'
+      '[percy] Config is already the latest version'
     ]);
 
     expect(getMockConfig('.percy.old.yml')).toBeUndefined();

--- a/packages/cli-config/test/validate.test.js
+++ b/packages/cli-config/test/validate.test.js
@@ -30,14 +30,14 @@ describe('percy config:validate', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Found config file: .percy.yml\n',
+      '[percy] Found config file: .percy.yml',
       '[percy] Using config:\n' + [
         '{',
         '  version: 2,',
         '  test: {',
         '    value: \'percy\'',
         '  }',
-        '}\n'
+        '}'
       ].join('\n')
     ]);
   });
@@ -49,14 +49,14 @@ describe('percy config:validate', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      `[percy] Found config file: ${filename}\n`,
+      `[percy] Found config file: ${filename}`,
       '[percy] Using config:\n' + [
         '{',
         '  version: 2,',
         '  test: {',
         '    value: \'config\'',
         '  }',
-        '}\n'
+        '}'
       ].join('\n')
     ]);
   });
@@ -66,12 +66,12 @@ describe('percy config:validate', () => {
     await expectAsync(Validate.run(['.invalid.yml'])).toBeRejectedWithError('EEXIT: 1');
 
     expect(logger.stdout).toEqual([
-      '[percy] Found config file: .invalid.yml\n'
+      '[percy] Found config file: .invalid.yml'
     ]);
     expect(logger.stderr).toEqual([
-      '[percy] Invalid config:\n',
-      '[percy] - bar: unknown property\n',
-      '[percy] - test.value: should be a string, received a boolean\n'
+      '[percy] Invalid config:',
+      '[percy] - bar: unknown property',
+      '[percy] - test.value: should be a string, received a boolean'
     ]);
   });
 });

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -11,11 +11,11 @@ describe('percy exec', () => {
     await expectAsync(Exec.run([])).toBeRejectedWithError('EEXIT: 1');
 
     expect(logger.stderr).toEqual([
-      '[percy] You must supply a command to run after --\n'
+      '[percy] You must supply a command to run after --'
     ]);
     expect(logger.stdout).toEqual([
-      '[percy] Example:\n',
-      '[percy] $ percy exec -- echo "run your test suite"\n'
+      '[percy] Example:',
+      '[percy] $ percy exec -- echo "run your test suite"'
     ]);
   });
 
@@ -24,7 +24,7 @@ describe('percy exec', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: command not found "foobar"\n'
+      '[percy] Error: command not found "foobar"'
     ]);
   });
 
@@ -33,12 +33,12 @@ describe('percy exec', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy has started!\n',
-      '[percy] Created build #1: https://percy.io/test/test/123\n',
-      '[percy] Running "node --eval "\n',
-      '[percy] Stopping percy...\n',
-      '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-      '[percy] Done!\n'
+      '[percy] Percy has started!',
+      '[percy] Created build #1: https://percy.io/test/test/123',
+      '[percy] Running "node --eval "',
+      '[percy] Stopping percy...',
+      '[percy] Finalized build #1: https://percy.io/test/test/123',
+      '[percy] Done!'
     ]);
   });
 
@@ -68,8 +68,8 @@ describe('percy exec', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Skipping visual tests - Missing Percy token\n',
-      '[percy] Running "node --eval "\n'
+      '[percy] Skipping visual tests - Missing Percy token',
+      '[percy] Running "node --eval "'
     ]);
   });
 
@@ -78,12 +78,12 @@ describe('percy exec', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy has started!\n',
-      '[percy] Created build #1: https://percy.io/test/test/123\n',
-      '[percy] Running "node --eval process.exit(3)"\n',
-      '[percy] Stopping percy...\n',
-      '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-      '[percy] Done!\n'
+      '[percy] Percy has started!',
+      '[percy] Created build #1: https://percy.io/test/test/123',
+      '[percy] Running "node --eval process.exit(3)"',
+      '[percy] Stopping percy...',
+      '[percy] Finalized build #1: https://percy.io/test/test/123',
+      '[percy] Done!'
     ]);
   });
 
@@ -95,15 +95,15 @@ describe('percy exec', () => {
     await expectAsync(Exec.run(['--', 'foobar'])).toBeRejectedWithError('EEXIT: 1');
 
     expect(logger.stderr).toEqual([
-      '[percy] Error: spawn foobar ENOENT\n'
+      '[percy] Error: spawn foobar ENOENT'
     ]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy has started!\n',
-      '[percy] Created build #1: https://percy.io/test/test/123\n',
-      '[percy] Running "foobar"\n',
-      '[percy] Stopping percy...\n',
-      '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-      '[percy] Done!\n'
+      '[percy] Percy has started!',
+      '[percy] Created build #1: https://percy.io/test/test/123',
+      '[percy] Running "foobar"',
+      '[percy] Stopping percy...',
+      '[percy] Finalized build #1: https://percy.io/test/test/123',
+      '[percy] Done!'
     ]);
   });
 });

--- a/packages/cli-exec/test/ping.test.js
+++ b/packages/cli-exec/test/ping.test.js
@@ -18,13 +18,13 @@ describe('percy exec:ping', () => {
     expect(percyServer.requests).toEqual([['/percy/healthcheck']]);
 
     expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual(['[percy] Percy is running\n']);
+    expect(logger.stdout).toEqual(['[percy] Percy is running']);
   });
 
   it('logs an error when the endpoint errors', async () => {
     await expectAsync(Ping.run([])).toBeRejectedWithError('EEXIT: 1');
 
     expect(logger.stdout).toEqual([]);
-    expect(logger.stderr).toEqual(['[percy] Percy is not running\n']);
+    expect(logger.stderr).toEqual(['[percy] Percy is not running']);
   });
 });

--- a/packages/cli-exec/test/start.test.js
+++ b/packages/cli-exec/test/start.test.js
@@ -39,7 +39,7 @@ describe('percy exec:start', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: Percy is already running or the port is in use\n'
+      '[percy] Error: Percy is already running or the port is in use'
     ]);
   });
 
@@ -51,7 +51,7 @@ describe('percy exec:start', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy has been disabled. Not starting\n'
+      '[percy] Percy has been disabled. Not starting'
     ]);
   });
 });

--- a/packages/cli-exec/test/stop.test.js
+++ b/packages/cli-exec/test/stop.test.js
@@ -21,7 +21,7 @@ describe('percy exec:stop', () => {
     ]);
 
     expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual(['[percy] Percy has stopped\n']);
+    expect(logger.stdout).toEqual(['[percy] Percy has stopped']);
   });
 
   it('logs when percy is disabled', async () => {
@@ -29,13 +29,13 @@ describe('percy exec:stop', () => {
     await Stop.run([]);
 
     expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual(['[percy] Percy is disabled\n']);
+    expect(logger.stdout).toEqual(['[percy] Percy is disabled']);
   });
 
   it('logs an error when the endpoint errors', async () => {
     await expectAsync(Stop.run([])).toBeRejectedWithError('EEXIT: 1');
 
     expect(logger.stdout).toEqual([]);
-    expect(logger.stderr).toEqual(['[percy] Percy is not running\n']);
+    expect(logger.stderr).toEqual(['[percy] Percy is not running']);
   });
 });

--- a/packages/cli-snapshot/test/snapshot.test.js
+++ b/packages/cli-snapshot/test/snapshot.test.js
@@ -73,7 +73,7 @@ describe('percy snapshot', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy is disabled. Skipping snapshots\n'
+      '[percy] Percy is disabled. Skipping snapshots'
     ]);
   });
 
@@ -82,7 +82,7 @@ describe('percy snapshot', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: Not found: ./404\n'
+      '[percy] Error: Not found: ./404'
     ]);
   });
 
@@ -91,7 +91,7 @@ describe('percy snapshot', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: The base-url flag must begin with a forward slash (/)\n'
+      '[percy] Error: The base-url flag must begin with a forward slash (/)'
     ]);
   });
 
@@ -100,7 +100,7 @@ describe('percy snapshot', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: No snapshots found\n'
+      '[percy] Error: No snapshots found'
     ]);
   });
 
@@ -110,14 +110,14 @@ describe('percy snapshot', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual(jasmine.arrayContaining([
-        '[percy] Percy has started!\n',
-        '[percy] Created build #1: https://percy.io/test/test/123\n',
-        '[percy] Snapshot taken: /test-3.htm\n',
-        '[percy] Snapshot taken: /test-2.html\n',
-        '[percy] Snapshot taken: /test-1.html\n',
-        '[percy] Stopping percy...\n',
-        '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-        '[percy] Done!\n'
+        '[percy] Percy has started!',
+        '[percy] Created build #1: https://percy.io/test/test/123',
+        '[percy] Snapshot taken: /test-3.htm',
+        '[percy] Snapshot taken: /test-2.html',
+        '[percy] Snapshot taken: /test-1.html',
+        '[percy] Stopping percy...',
+        '[percy] Finalized build #1: https://percy.io/test/test/123',
+        '[percy] Done!'
       ]));
     });
 
@@ -126,14 +126,14 @@ describe('percy snapshot', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual(jasmine.arrayContaining([
-        '[percy] Percy has started!\n',
-        '[percy] Created build #1: https://percy.io/test/test/123\n',
-        '[percy] Snapshot taken: /base/test-3.htm\n',
-        '[percy] Snapshot taken: /base/test-2.html\n',
-        '[percy] Snapshot taken: /base/test-1.html\n',
-        '[percy] Stopping percy...\n',
-        '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-        '[percy] Done!\n'
+        '[percy] Percy has started!',
+        '[percy] Created build #1: https://percy.io/test/test/123',
+        '[percy] Snapshot taken: /base/test-3.htm',
+        '[percy] Snapshot taken: /base/test-2.html',
+        '[percy] Snapshot taken: /base/test-1.html',
+        '[percy] Stopping percy...',
+        '[percy] Finalized build #1: https://percy.io/test/test/123',
+        '[percy] Done!'
       ]));
     });
 
@@ -144,7 +144,7 @@ describe('percy snapshot', () => {
         '[percy] Found 3 snapshots:\n' +
           '/test-1.html\n' +
           '/test-2.html\n' +
-          '/test-3.htm\n'
+          '/test-3.htm'
       ]);
     });
   });
@@ -167,13 +167,13 @@ describe('percy snapshot', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
-        '[percy] Percy has started!\n',
-        '[percy] Created build #1: https://percy.io/test/test/123\n',
-        '[percy] Snapshot taken: YAML Snapshot\n',
-        '[percy] Stopping percy...\n',
-        '[percy] Waiting for 1 snapshot(s) to finish uploading\n',
-        '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-        '[percy] Done!\n'
+        '[percy] Percy has started!',
+        '[percy] Created build #1: https://percy.io/test/test/123',
+        '[percy] Snapshot taken: YAML Snapshot',
+        '[percy] Stopping percy...',
+        '[percy] Waiting for 1 snapshot(s) to finish uploading',
+        '[percy] Finalized build #1: https://percy.io/test/test/123',
+        '[percy] Done!'
       ]);
     });
 
@@ -182,13 +182,13 @@ describe('percy snapshot', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
-        '[percy] Percy has started!\n',
-        '[percy] Created build #1: https://percy.io/test/test/123\n',
-        '[percy] Snapshot taken: JSON Snapshot\n',
-        '[percy] Stopping percy...\n',
-        '[percy] Waiting for 1 snapshot(s) to finish uploading\n',
-        '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-        '[percy] Done!\n'
+        '[percy] Percy has started!',
+        '[percy] Created build #1: https://percy.io/test/test/123',
+        '[percy] Snapshot taken: JSON Snapshot',
+        '[percy] Stopping percy...',
+        '[percy] Waiting for 1 snapshot(s) to finish uploading',
+        '[percy] Finalized build #1: https://percy.io/test/test/123',
+        '[percy] Done!'
       ]);
     });
 
@@ -197,13 +197,13 @@ describe('percy snapshot', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
-        '[percy] Percy has started!\n',
-        '[percy] Created build #1: https://percy.io/test/test/123\n',
-        '[percy] Snapshot taken: JS Snapshot\n',
-        '[percy] Stopping percy...\n',
-        '[percy] Waiting for 1 snapshot(s) to finish uploading\n',
-        '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-        '[percy] Done!\n'
+        '[percy] Percy has started!',
+        '[percy] Created build #1: https://percy.io/test/test/123',
+        '[percy] Snapshot taken: JS Snapshot',
+        '[percy] Stopping percy...',
+        '[percy] Waiting for 1 snapshot(s) to finish uploading',
+        '[percy] Finalized build #1: https://percy.io/test/test/123',
+        '[percy] Done!'
       ]);
     });
 
@@ -212,13 +212,13 @@ describe('percy snapshot', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
-        '[percy] Percy has started!\n',
-        '[percy] Created build #1: https://percy.io/test/test/123\n',
-        '[percy] Snapshot taken: JS Function Snapshot\n',
-        '[percy] Stopping percy...\n',
-        '[percy] Waiting for 1 snapshot(s) to finish uploading\n',
-        '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-        '[percy] Done!\n'
+        '[percy] Percy has started!',
+        '[percy] Created build #1: https://percy.io/test/test/123',
+        '[percy] Snapshot taken: JS Function Snapshot',
+        '[percy] Stopping percy...',
+        '[percy] Waiting for 1 snapshot(s) to finish uploading',
+        '[percy] Finalized build #1: https://percy.io/test/test/123',
+        '[percy] Done!'
       ]);
     });
 
@@ -227,7 +227,7 @@ describe('percy snapshot', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([
-        '[percy] Error: Unsupported filetype: ./nope\n'
+        '[percy] Error: Unsupported filetype: ./nope'
       ]);
     });
 
@@ -236,7 +236,7 @@ describe('percy snapshot', () => {
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
         '[percy] Found 1 snapshot:\n' +
-          'JS Snapshot\n'
+          'JS Snapshot'
       ]);
     });
   });

--- a/packages/cli-upload/test/upload.test.js
+++ b/packages/cli-upload/test/upload.test.js
@@ -51,7 +51,7 @@ describe('percy upload', () => {
     await Upload.run(['./images']);
 
     expect(logger.stderr).toEqual([]);
-    expect(logger.stdout).toEqual(['[percy] Percy is disabled. Skipping upload\n']);
+    expect(logger.stdout).toEqual(['[percy] Percy is disabled. Skipping upload']);
   });
 
   it('errors when the directory is not found', async () => {
@@ -59,7 +59,7 @@ describe('percy upload', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: Not found: ./404\n'
+      '[percy] Error: Not found: ./404'
     ]);
   });
 
@@ -68,7 +68,7 @@ describe('percy upload', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: Not a directory: ./nope\n'
+      '[percy] Error: Not a directory: ./nope'
     ]);
   });
 
@@ -77,7 +77,7 @@ describe('percy upload', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: No matching files found in \'./images\'\n'
+      '[percy] Error: No matching files found in \'./images\''
     ]);
   });
 
@@ -86,12 +86,12 @@ describe('percy upload', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy has started!\n',
-      '[percy] Created build #1: https://percy.io/test/test/123\n',
-      '[percy] Snapshot uploaded: test-1.png\n',
-      '[percy] Snapshot uploaded: test-2.jpg\n',
-      '[percy] Snapshot uploaded: test-3.jpeg\n',
-      '[percy] Finalized build #1: https://percy.io/test/test/123\n'
+      '[percy] Percy has started!',
+      '[percy] Created build #1: https://percy.io/test/test/123',
+      '[percy] Snapshot uploaded: test-1.png',
+      '[percy] Snapshot uploaded: test-2.jpg',
+      '[percy] Snapshot uploaded: test-3.jpeg',
+      '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]);
 
     expect(mockAPI.requests['/builds/123/snapshots'][0].body).toEqual({
@@ -133,13 +133,13 @@ describe('percy upload', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy has started!\n',
-      '[percy] Created build #1: https://percy.io/test/test/123\n',
-      '[percy] Snapshot uploaded: test-1.png\n',
-      '[percy] Snapshot uploaded: test-2.jpg\n',
-      '[percy] Snapshot uploaded: test-3.jpeg\n',
-      '[percy] Skipping unsupported image type: test-4.gif\n',
-      '[percy] Finalized build #1: https://percy.io/test/test/123\n'
+      '[percy] Percy has started!',
+      '[percy] Created build #1: https://percy.io/test/test/123',
+      '[percy] Snapshot uploaded: test-1.png',
+      '[percy] Snapshot uploaded: test-2.jpg',
+      '[percy] Snapshot uploaded: test-3.jpeg',
+      '[percy] Skipping unsupported image type: test-4.gif',
+      '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]);
   });
 
@@ -151,7 +151,7 @@ describe('percy upload', () => {
       '[percy] Matching files:\n' +
         'test-1.png\n' +
         'test-2.jpg\n' +
-        'test-3.jpeg\n'
+        'test-3.jpeg'
     ]);
   });
 });

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -220,7 +220,7 @@ describe('PercyConfig', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toContain(
-        '[percy] Found config file: .percy.yml\n'
+        '[percy] Found config file: .percy.yml'
       );
     });
 
@@ -242,7 +242,7 @@ describe('PercyConfig', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toContain(
-        `[percy:config] Found config file: ${filename}\n`
+        `[percy:config] Found config file: ${filename}`
       );
     });
 
@@ -284,7 +284,7 @@ describe('PercyConfig', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([
-        '[percy:config] Config file not found\n'
+        '[percy:config] Config file not found'
       ]);
     });
 
@@ -340,7 +340,7 @@ describe('PercyConfig', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([
-        '[percy:config] Found config file: .foo.yml\n',
+        '[percy:config] Found config file: .foo.yml',
         '[percy:config] Using config:\n' + [
           '{',
           '  version: 2,',
@@ -356,7 +356,7 @@ describe('PercyConfig', () => {
           '  test: {',
           '    value: \'hi\'',
           '  }',
-          '}\n'
+          '}'
         ].join('\n')
       ]);
     });
@@ -373,8 +373,8 @@ describe('PercyConfig', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([
-        '[percy:config] Found config file: .no-version.yml\n',
-        '[percy:config] Ignoring config file - missing or invalid version\n'
+        '[percy:config] Found config file: .no-version.yml',
+        '[percy:config] Ignoring config file - missing or invalid version'
       ]);
     });
 
@@ -390,8 +390,8 @@ describe('PercyConfig', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([
-        '[percy:config] Found config file: .bad-version.yml\n',
-        '[percy:config] Ignoring config file - unsupported version "3"\n'
+        '[percy:config] Found config file: .bad-version.yml',
+        '[percy:config] Ignoring config file - unsupported version "3"'
       ]);
     });
 
@@ -411,16 +411,16 @@ describe('PercyConfig', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([
-        '[percy:config] Found config file: .old-version.yml\n',
+        '[percy:config] Found config file: .old-version.yml',
         '[percy:config] Found older config file version, please run ' +
-          '`percy config:migrate` to update to the latest version\n',
+          '`percy config:migrate` to update to the latest version',
         '[percy:config] Using config:\n' + [
           '{',
           '  version: 2,',
           '  test: {',
           '    value: \'new-value\'',
           '  }',
-          '}\n'
+          '}'
         ].join('\n')
       ]);
     });
@@ -454,19 +454,19 @@ describe('PercyConfig', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([
-        '[percy:config] Found config file: .invalid.yml\n',
-        '[percy:config] Invalid config:\n',
-        '[percy:config] - foo: unknown property\n',
-        '[percy:config] - test.value: should be a string, received a number\n',
-        '[percy:config] - arr: should be an array, received an object\n',
-        '[percy:config] - req.bar: missing required property\n',
+        '[percy:config] Found config file: .invalid.yml',
+        '[percy:config] Invalid config:',
+        '[percy:config] - foo: unknown property',
+        '[percy:config] - test.value: should be a string, received a number',
+        '[percy:config] - arr: should be an array, received an object',
+        '[percy:config] - req.bar: missing required property',
         '[percy:config] Using config:\n' + [
           '{',
           '  version: 2,',
           '  req: {',
           '    foo: \'bar\'',
           '  }',
-          '}\n'
+          '}'
         ].join('\n')
       ]);
     });
@@ -486,11 +486,11 @@ describe('PercyConfig', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([
-        '[percy:config] Found config file: .invalid.yml\n',
-        '[percy:config] Invalid config:\n',
-        '[percy:config] - foo: unknown property\n',
-        '[percy:config] - test.value: should be a string, received a number\n',
-        '[percy:config] - arr: should be an array, received an object\n'
+        '[percy:config] Found config file: .invalid.yml',
+        '[percy:config] Invalid config:',
+        '[percy:config] - foo: unknown property',
+        '[percy:config] - test.value: should be a string, received a number',
+        '[percy:config] - arr: should be an array, received an object'
       ]);
     });
   });

--- a/packages/core/src/install.js
+++ b/packages/core/src/install.js
@@ -85,7 +85,7 @@ async function install({
           let size = parseInt(response.headers['content-length'], 10);
           let msg = `${readableBytes(size)} (${revision}) [:bar] :percent :etas`;
           let progress = new (require('progress'))(logger.format(msg), {
-            stream: logger.instance.stdout,
+            stream: logger.stdout,
             incomplete: ' ',
             total: size,
             width: 20

--- a/packages/core/test/asset-discovery.test.js
+++ b/packages/core/test/asset-discovery.test.js
@@ -208,7 +208,7 @@ describe('Asset Discovery', () => {
     ]);
 
     expect(logger.stderr).toContain(
-      '[percy:core:discovery] Skipping - Max file size exceeded [15.3MB]\n'
+      '[percy:core:discovery] Skipping - Max file size exceeded [15.3MB]'
     );
   });
 
@@ -224,42 +224,42 @@ describe('Asset Discovery', () => {
     });
 
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
-      '[percy:core] Snapshot taken: test snapshot\n'
+      '[percy:core] Snapshot taken: test snapshot'
     ]));
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
-      '[percy:core] ---------\n',
-      '[percy:core] Handling snapshot:\n',
-      '[percy:core] -> name: test snapshot\n',
-      '[percy:core] -> url: http://localhost:8000/\n',
-      '[percy:core] -> widths: 400px, 1200px\n',
-      '[percy:core] -> clientInfo: test client info\n',
-      '[percy:core] -> environmentInfo: test env info\n',
-      '[percy:core] -> requestHeaders: {}\n',
-      `[percy:core] -> domSnapshot:\n${testDOM.substr(0, 1024)}... [truncated]\n`,
-      '[percy:core:discovery] Discovering resources @400px for http://localhost:8000/\n',
-      '[percy:core:discovery] Handling request for http://localhost:8000/\n',
-      '[percy:core:discovery] Serving root resource for http://localhost:8000/\n',
-      '[percy:core:discovery] Handling request for http://localhost:8000/style.css\n',
-      '[percy:core:discovery] Handling request for http://localhost:8000/img.gif\n',
-      '[percy:core:discovery] Processing resource - http://localhost:8000/style.css\n',
-      '[percy:core:discovery] Making local copy of response - http://localhost:8000/style.css\n',
-      '[percy:core:discovery] -> url: http://localhost:8000/style.css\n',
-      `[percy:core:discovery] -> sha: ${sha256hash(testCSS)}\n`,
-      `[percy:core:discovery] -> filepath: ${path.join(os.tmpdir(), 'percy', sha256hash(testCSS))}\n`,
-      '[percy:core:discovery] -> mimetype: text/css\n',
-      '[percy:core:discovery] Processing resource - http://localhost:8000/img.gif\n',
-      '[percy:core:discovery] Making local copy of response - http://localhost:8000/img.gif\n',
-      '[percy:core:discovery] -> url: http://localhost:8000/img.gif\n',
-      `[percy:core:discovery] -> sha: ${sha256hash(pixel)}\n`,
-      `[percy:core:discovery] -> filepath: ${path.join(os.tmpdir(), 'percy', sha256hash(pixel))}\n`,
-      '[percy:core:discovery] -> mimetype: image/gif\n',
-      '[percy:core:discovery] Discovering resources @1200px for http://localhost:8000/\n',
-      '[percy:core:discovery] Handling request for http://localhost:8000/\n',
-      '[percy:core:discovery] Serving root resource for http://localhost:8000/\n',
-      '[percy:core:discovery] Handling request for http://localhost:8000/style.css\n',
-      '[percy:core:discovery] Response cache hit for http://localhost:8000/style.css\n',
-      '[percy:core:discovery] Handling request for http://localhost:8000/img.gif\n',
-      '[percy:core:discovery] Response cache hit for http://localhost:8000/img.gif\n'
+      '[percy:core] ---------',
+      '[percy:core] Handling snapshot:',
+      '[percy:core] -> name: test snapshot',
+      '[percy:core] -> url: http://localhost:8000/',
+      '[percy:core] -> widths: 400px, 1200px',
+      '[percy:core] -> clientInfo: test client info',
+      '[percy:core] -> environmentInfo: test env info',
+      '[percy:core] -> requestHeaders: {}',
+      `[percy:core] -> domSnapshot:\n${testDOM.substr(0, 1024)}... [truncated]`,
+      '[percy:core:discovery] Discovering resources @400px for http://localhost:8000/',
+      '[percy:core:discovery] Handling request for http://localhost:8000/',
+      '[percy:core:discovery] Serving root resource for http://localhost:8000/',
+      '[percy:core:discovery] Handling request for http://localhost:8000/style.css',
+      '[percy:core:discovery] Handling request for http://localhost:8000/img.gif',
+      '[percy:core:discovery] Processing resource - http://localhost:8000/style.css',
+      '[percy:core:discovery] Making local copy of response - http://localhost:8000/style.css',
+      '[percy:core:discovery] -> url: http://localhost:8000/style.css',
+      `[percy:core:discovery] -> sha: ${sha256hash(testCSS)}`,
+      `[percy:core:discovery] -> filepath: ${path.join(os.tmpdir(), 'percy', sha256hash(testCSS))}`,
+      '[percy:core:discovery] -> mimetype: text/css',
+      '[percy:core:discovery] Processing resource - http://localhost:8000/img.gif',
+      '[percy:core:discovery] Making local copy of response - http://localhost:8000/img.gif',
+      '[percy:core:discovery] -> url: http://localhost:8000/img.gif',
+      `[percy:core:discovery] -> sha: ${sha256hash(pixel)}`,
+      `[percy:core:discovery] -> filepath: ${path.join(os.tmpdir(), 'percy', sha256hash(pixel))}`,
+      '[percy:core:discovery] -> mimetype: image/gif',
+      '[percy:core:discovery] Discovering resources @1200px for http://localhost:8000/',
+      '[percy:core:discovery] Handling request for http://localhost:8000/',
+      '[percy:core:discovery] Serving root resource for http://localhost:8000/',
+      '[percy:core:discovery] Handling request for http://localhost:8000/style.css',
+      '[percy:core:discovery] Response cache hit for http://localhost:8000/style.css',
+      '[percy:core:discovery] Handling request for http://localhost:8000/img.gif',
+      '[percy:core:discovery] Response cache hit for http://localhost:8000/img.gif'
     ]));
   });
 
@@ -272,7 +272,7 @@ describe('Asset Discovery', () => {
     });
 
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
-      '[percy:core] Snapshot taken: test snapshot\n'
+      '[percy:core] Snapshot taken: test snapshot'
     ]));
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
       jasmine.stringMatching(new RegExp( // eslint-disable-line prefer-regex-literals
@@ -342,12 +342,12 @@ describe('Asset Discovery', () => {
       });
 
       expect(logger.stdout).toEqual(jasmine.arrayContaining([
-        '[percy:core] Snapshot taken: test snapshot\n'
+        '[percy:core] Snapshot taken: test snapshot'
       ]));
       expect(logger.stderr).toEqual(jasmine.arrayContaining([
-        '[percy:core:discovery] Encountered an error handling request: http://localhost:8000/style.css\n',
+        '[percy:core:discovery] Encountered an error handling request: http://localhost:8000/style.css',
         jasmine.stringMatching('\\[percy:core:discovery] Error: some unhandled request error\n'),
-        '[percy:core:discovery] Encountered an error handling request: http://localhost:8000/img.gif\n',
+        '[percy:core:discovery] Encountered an error handling request: http://localhost:8000/img.gif',
         jasmine.stringMatching('\\[percy:core:discovery] Error: some unhandled request error\n')
       ]));
     });
@@ -370,12 +370,12 @@ describe('Asset Discovery', () => {
       });
 
       expect(logger.stdout).toEqual(jasmine.arrayContaining([
-        '[percy:core] Snapshot taken: test snapshot\n'
+        '[percy:core] Snapshot taken: test snapshot'
       ]));
       expect(logger.stderr).toEqual(jasmine.arrayContaining([
-        '[percy:core:discovery] Encountered an error processing resource: http://localhost:8000/style.css\n',
+        '[percy:core:discovery] Encountered an error processing resource: http://localhost:8000/style.css',
         jasmine.stringMatching('\\[percy:core:discovery] Error: some unhandled response error\n'),
-        '[percy:core:discovery] Encountered an error processing resource: http://localhost:8000/img.gif\n',
+        '[percy:core:discovery] Encountered an error processing resource: http://localhost:8000/img.gif',
         jasmine.stringMatching('\\[percy:core:discovery] Error: some unhandled response error\n')
       ]));
     });
@@ -541,7 +541,7 @@ describe('Asset Discovery', () => {
       });
 
       expect(logger.stderr).toEqual([
-        '[percy] Browser executable not found: ./404\n'
+        '[percy] Browser executable not found: ./404'
       ]);
     });
 

--- a/packages/core/test/capture.test.js
+++ b/packages/core/test/capture.test.js
@@ -21,7 +21,7 @@ describe('Percy Capture', () => {
       concurrency: 1
     });
 
-    logger.clear();
+    logger.reset();
   });
 
   afterEach(async () => {
@@ -117,8 +117,8 @@ describe('Percy Capture', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Snapshot taken: snapshot one\n',
-      '[percy] Snapshot taken: snapshot two\n'
+      '[percy] Snapshot taken: snapshot one',
+      '[percy] Snapshot taken: snapshot two'
     ]);
   });
 
@@ -134,9 +134,9 @@ describe('Percy Capture', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Snapshot taken: test snapshot\n',
-      '[percy] Snapshot taken: test snapshot two\n',
-      '[percy] Snapshot taken: test snapshot three\n'
+      '[percy] Snapshot taken: test snapshot',
+      '[percy] Snapshot taken: test snapshot two',
+      '[percy] Snapshot taken: test snapshot three'
     ]);
   });
 
@@ -151,7 +151,7 @@ describe('Percy Capture', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Snapshot taken: foo snapshot\n'
+      '[percy] Snapshot taken: foo snapshot'
     ]);
 
     await percy.idle();
@@ -175,7 +175,7 @@ describe('Percy Capture', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Snapshot taken: test snapshot\n'
+      '[percy] Snapshot taken: test snapshot'
     ]);
 
     await percy.idle();
@@ -201,7 +201,7 @@ describe('Percy Capture', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Snapshot taken: framed snapshot\n'
+      '[percy] Snapshot taken: framed snapshot'
     ]);
 
     await percy.idle();
@@ -223,10 +223,10 @@ describe('Percy Capture', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Encountered an error for page: http://localhost:8000\n',
+      '[percy] Encountered an error for page: http://localhost:8000',
       '[percy] Error: test error\n' +
         '    at execute (<anonymous>:2:15)\n' +
-        '    at withPercyHelpers (<anonymous>:3:9)\n'
+        '    at withPercyHelpers (<anonymous>:3:9)'
     ]);
   });
 
@@ -239,8 +239,8 @@ describe('Percy Capture', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Encountered an error for page: http://localhost:8000\n',
-      '[percy] Error: The provided function is not serializable\n'
+      '[percy] Encountered an error for page: http://localhost:8000',
+      '[percy] Error: The provided function is not serializable'
     ]);
   });
 
@@ -252,8 +252,8 @@ describe('Percy Capture', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Encountered an error for page: wat:/localhost:8000\n',
-      '[percy] Error: Navigation failed: net::ERR_ABORTED\n'
+      '[percy] Encountered an error for page: wat:/localhost:8000',
+      '[percy] Error: Navigation failed: net::ERR_ABORTED'
     ]);
   });
 
@@ -268,10 +268,10 @@ describe('Percy Capture', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Encountered an error taking snapshot: invalid snapshot\n',
+      '[percy] Encountered an error taking snapshot: invalid snapshot',
       '[percy] Error: Protocol error (Emulation.setDeviceMetricsOverride): ' +
         'Invalid parameters: Failed to deserialize params.width ' +
-        '- BINDINGS: int32 value expected at position 50\n'
+        '- BINDINGS: int32 value expected at position 50'
     ]);
   });
 

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -144,8 +144,8 @@ describe('Percy', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
-        '[percy] Percy has started!\n',
-        '[percy] Created build #1: https://percy.io/test/test/123\n'
+        '[percy] Percy has started!',
+        '[percy] Created build #1: https://percy.io/test/test/123'
       ]);
     });
 
@@ -172,7 +172,7 @@ describe('Percy', () => {
   describe('#stop()', () => {
     beforeEach(async () => {
       await percy.start();
-      logger.clear();
+      logger.reset();
     });
 
     it('finalizes the build', async () => {
@@ -197,9 +197,9 @@ describe('Percy', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
-        '[percy] Stopping percy...\n',
-        '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-        '[percy] Done!\n'
+        '[percy] Stopping percy...',
+        '[percy] Finalized build #1: https://percy.io/test/test/123',
+        '[percy] Done!'
       ]);
     });
 
@@ -215,11 +215,11 @@ describe('Percy', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
-        '[percy] Snapshot taken: test snapshot\n',
-        '[percy] Stopping percy...\n',
-        '[percy] Waiting for 1 snapshot(s) to finish uploading\n',
-        '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-        '[percy] Done!\n'
+        '[percy] Snapshot taken: test snapshot',
+        '[percy] Stopping percy...',
+        '[percy] Waiting for 1 snapshot(s) to finish uploading',
+        '[percy] Finalized build #1: https://percy.io/test/test/123',
+        '[percy] Done!'
       ]);
     });
 
@@ -234,11 +234,11 @@ describe('Percy', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
-        '[percy] Stopping percy...\n',
-        '[percy] Waiting for 1 page(s) to finish snapshotting\n',
-        '[percy] Snapshot taken: test snapshot\n',
-        '[percy] Finalized build #1: https://percy.io/test/test/123\n',
-        '[percy] Done!\n'
+        '[percy] Stopping percy...',
+        '[percy] Waiting for 1 page(s) to finish snapshotting',
+        '[percy] Snapshot taken: test snapshot',
+        '[percy] Finalized build #1: https://percy.io/test/test/123',
+        '[percy] Done!'
       ]);
     });
 
@@ -257,7 +257,7 @@ describe('Percy', () => {
   describe('#idle()', () => {
     beforeEach(async () => {
       await percy.start();
-      logger.clear();
+      logger.reset();
     });
 
     it('resolves after captures idle', async () => {
@@ -271,7 +271,7 @@ describe('Percy', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
-        '[percy] Snapshot taken: test snapshot\n'
+        '[percy] Snapshot taken: test snapshot'
       ]);
     });
 
@@ -324,7 +324,7 @@ describe('Percy', () => {
       });
 
       await percy.start();
-      logger.clear();
+      logger.reset();
     });
 
     it('creates a new snapshot for the build', async () => {
@@ -537,7 +537,7 @@ describe('Percy', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
-        '[percy] Snapshot taken: test snapshot\n'
+        '[percy] Snapshot taken: test snapshot'
       ]);
     });
 
@@ -554,8 +554,8 @@ describe('Percy', () => {
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([
-        '[percy] Encountered an error taking snapshot: test snapshot\n',
-        '[percy] Error: snapshot error\n'
+        '[percy] Encountered an error taking snapshot: test snapshot',
+        '[percy] Error: snapshot error'
       ]);
     });
 
@@ -570,13 +570,13 @@ describe('Percy', () => {
         domSnapshot: testDOM
       });
 
-      logger.clear();
+      logger.reset();
       await percy.idle();
 
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([
-        '[percy] Encountered an error uploading snapshot: test snapshot\n',
-        '[percy] Error: snapshot upload error\n'
+        '[percy] Encountered an error uploading snapshot: test snapshot',
+        '[percy] Error: snapshot upload error'
       ]);
     });
   });

--- a/packages/core/test/server.test.js
+++ b/packages/core/test/server.test.js
@@ -79,7 +79,7 @@ describe('Snapshot Server', () => {
     await expectAsync(response.text()).toBeResolvedTo(bundle);
     expect(logger.stderr).toEqual([
       '[percy] Warning: It looks like you’re using @percy/cli with an older SDK. Please upgrade to the latest version' +
-        ' to fix this warning. See these docs for more info: https://docs.percy.io/docs/migrating-to-percy-cli\n'
+        ' to fix this warning. See these docs for more info: https://docs.percy.io/docs/migrating-to-percy-cli'
     ]);
   });
 

--- a/packages/core/test/server.test.js
+++ b/packages/core/test/server.test.js
@@ -170,17 +170,17 @@ describe('Snapshot Server', () => {
 
     // log from a separate async process
     let [stdout, stderr] = await new Promise((resolve, reject) => {
-      require('child_process').exec('node -e \'' + [
-        'const logger = require("@percy/logger");',
+      require('child_process').exec('node -e "' + [
+        "const logger = require('@percy/logger');",
         // connect to the local websocket server for logging and unref the socket
-        'const ws = new (require("ws"))("http://localhost:1337");',
-        'ws.on("open", () => ws._socket.unref());',
+        "const ws = new (require('ws'))('http://localhost:1337');",
+        "ws.on('open', () => ws._socket.unref());",
         // set loglevel to debug failures
-        'logger.loglevel("debug");',
+        "logger.loglevel('debug');",
         // connect and send a remote log
         'logger.remote(ws).then(() => ',
-        'logger("remote-sdk").info("whoa"));'
-      ].join('') + '\'', (err, stdout, stderr) => {
+        "logger('remote-sdk').info('whoa'));"
+      ].join('') + '"', (err, stdout, stderr) => {
         if (!err) resolve([stdout, stderr]);
         else reject(err);
       });

--- a/packages/core/test/unit/install.test.js
+++ b/packages/core/test/unit/install.test.js
@@ -82,9 +82,9 @@ describe('Unit / Install', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Test Download not found, downloading...\n',
-      '[percy] 16B (v0) [====================] 100% 0.0s', '\n',
-      '[percy] Successfully downloaded Test Download\n'
+      '[percy] Test Download not found, downloading...',
+      '[percy] 16B (v0) [====================] 100% 0.0s', '',
+      '[percy] Successfully downloaded Test Download'
     ]);
   });
 
@@ -188,9 +188,9 @@ describe('Unit / Install', () => {
 
         expect(logger.stderr).toEqual([]);
         expect(logger.stdout).toEqual([
-          '[percy] Chromium not found, downloading...\n',
-          jasmine.stringMatching(`(${expected.revision})`), '\n',
-          '[percy] Successfully downloaded Chromium\n'
+          '[percy] Chromium not found, downloading...',
+          jasmine.stringMatching(`(${expected.revision})`), '',
+          '[percy] Successfully downloaded Chromium'
         ]);
       });
     }

--- a/packages/core/test/unit/install.test.js
+++ b/packages/core/test/unit/install.test.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { Writable } from 'stream';
 import nock from 'nock';
 import mockRequire from 'mock-require';
-import logger from '@percy/logger';
+import logger from '@percy/logger/test/helper';
 import install from '../../src/install';
 
 // mock writable stream
@@ -18,7 +18,7 @@ describe('Unit / Install', () => {
 
   beforeEach(() => {
     // emulate tty properties for testing
-    Object.assign(logger.instance.stdout, {
+    Object.assign(logger.constructor.stdout, {
       isTTY: true,
       columns: 80,
       cursorTo() {},

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-beta.41",
   "license": "MIT",
   "main": "dist/index.js",
+  "browser": "dist/bundle.js",
   "files": [
     "dist",
     "test/helper.js"
@@ -18,5 +19,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "rollup": {
+    "output": {
+      "name": "PercyLogger"
+    }
   }
 }

--- a/packages/logger/src/browser.js
+++ b/packages/logger/src/browser.js
@@ -1,4 +1,4 @@
-import { ANSI_COLORS, ANSI_REG } from './colors';
+import { ANSI_COLORS, ANSI_REG } from './util';
 import PercyLogger from './logger';
 
 export default class BrowserLogger extends PercyLogger {

--- a/packages/logger/src/browser.js
+++ b/packages/logger/src/browser.js
@@ -1,0 +1,16 @@
+import { ANSI_COLORS, ANSI_REG } from './colors';
+import PercyLogger from './logger';
+
+export default class BrowserLogger extends PercyLogger {
+  write(level, message) {
+    let out = ['warn', 'error'].includes(level) ? level : 'log';
+    let colors = [];
+
+    message = message.replace(ANSI_REG, (_, ansi) => {
+      colors.push(`color:${ANSI_COLORS[ansi] || 'inherit'}`);
+      return '%c';
+    });
+
+    console[out](message, ...colors);
+  }
+}

--- a/packages/logger/src/colors.js
+++ b/packages/logger/src/colors.js
@@ -1,15 +1,29 @@
-const LINE_REGEXP = /^.*$/gm;
+const { assign, entries } = Object;
+
+export const ANSI_REG = new RegExp((
+  '[\\u001B\\u009B][[\\]()#;?]*((?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)' +
+  '|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))'
+), 'g');
+
+export const ANSI_COLORS = {
+  '31m': 'red',
+  '33m': 'yellow',
+  '34m': 'blue',
+  '35m': 'magenta',
+  '90m': 'grey'
+};
+
+const LINE_REG = /^.*$/gm;
 
 function colorize(code, str) {
-  return str.replace(LINE_REGEXP, line => (
-    `\u001b[${code}m${line}\u001b[39m`
+  return str.replace(LINE_REG, line => (
+    `\u001b[${code}${line}\u001b[39m`
   ));
 }
 
-export default {
-  red: str => colorize(31, str),
-  yellow: str => colorize(33, str),
-  blue: str => colorize(34, str),
-  magenta: str => colorize(35, str),
-  grey: str => colorize(90, str)
-};
+export default entries(ANSI_COLORS)
+  .reduce((colors, [code, name]) => {
+    return assign(colors, {
+      [name]: colorize.bind(null, code)
+    });
+  }, {});

--- a/packages/logger/src/index.js
+++ b/packages/logger/src/index.js
@@ -9,19 +9,15 @@ function logger(name) {
 }
 
 Object.assign(logger, {
+  format: (...args) => new Logger().format(...args),
+  query: (...args) => new Logger().query(...args),
+  connect: (...args) => new Logger().connect(...args),
+  remote: (...args) => new Logger().remote(...args),
   loglevel(level, flags = {}) {
     if (flags.verbose) level = 'debug';
     else if (flags.quiet) level = 'warn';
     else if (flags.silent) level = 'silent';
     return new Logger().loglevel(level);
-  },
-
-  format(...args) {
-    return new Logger().format(...args);
-  },
-
-  query(filter) {
-    return new Logger().query(filter);
   }
 });
 

--- a/packages/logger/src/index.js
+++ b/packages/logger/src/index.js
@@ -1,27 +1,34 @@
-const Logger = require('./logger').default;
+const { default: Logger } = (
+  process.env.__PERCY_BROWSERIFIED__
+    ? require('./browser')
+    : require('./logger')
+);
 
 function logger(name) {
-  logger.instance ||= new Logger();
-  return logger.instance.group(name);
+  return new Logger().group(name);
 }
 
-logger.loglevel = function loglevel(level, flags = {}) {
-  logger.instance ||= new Logger();
-  if (!level) return logger.instance.loglevel();
-  if (flags.verbose) level = 'debug';
-  else if (flags.quiet) level = 'warn';
-  else if (flags.silent) level = 'silent';
-  return logger.instance.loglevel(level);
-};
+Object.assign(logger, {
+  loglevel(level, flags = {}) {
+    if (flags.verbose) level = 'debug';
+    else if (flags.quiet) level = 'warn';
+    else if (flags.silent) level = 'silent';
+    return new Logger().loglevel(level);
+  },
 
-logger.format = function format(...args) {
-  logger.instance ||= new Logger();
-  return logger.instance.format(...args);
-};
+  format(...args) {
+    return new Logger().format(...args);
+  },
 
-logger.query = function query(filter) {
-  logger.instance ||= new Logger();
-  return logger.instance.query(filter);
-};
+  query(filter) {
+    return new Logger().query(filter);
+  }
+});
+
+Object.defineProperties(logger, {
+  stdout: { get: () => Logger.stdout },
+  stderr: { get: () => Logger.stderr }
+});
 
 module.exports = logger;
+module.exports.Logger = Logger;

--- a/packages/logger/src/logger.js
+++ b/packages/logger/src/logger.js
@@ -1,4 +1,4 @@
-import colors from './colors';
+import { colors } from './util';
 
 const URL_REGEXP = /\bhttps?:\/\/[^\s/$.?#].[^\s]*\b/i;
 const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };

--- a/packages/logger/src/util.js
+++ b/packages/logger/src/util.js
@@ -1,10 +1,12 @@
 const { assign, entries } = Object;
 
+// matches ansi escape sequences
 export const ANSI_REG = new RegExp((
   '[\\u001B\\u009B][[\\]()#;?]*((?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)' +
   '|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))'
 ), 'g');
 
+// color names by ansi escape code
 export const ANSI_COLORS = {
   '31m': 'red',
   '33m': 'yellow',
@@ -13,17 +15,28 @@ export const ANSI_COLORS = {
   '90m': 'grey'
 };
 
+// colorize each line of a string using an ansi escape sequence
 const LINE_REG = /^.*$/gm;
-
 function colorize(code, str) {
   return str.replace(LINE_REG, line => (
     `\u001b[${code}${line}\u001b[39m`
   ));
 }
 
-export default entries(ANSI_COLORS)
+// map ansi colors to bound colorize functions
+export const colors = entries(ANSI_COLORS)
   .reduce((colors, [code, name]) => {
     return assign(colors, {
       [name]: colorize.bind(null, code)
     });
   }, {});
+
+// adds an event listener and returns a teardown function
+export function listen(subject, event, handler, teardown) {
+  subject.addEventListener(event, handler);
+
+  return () => {
+    subject.removeEventListener(event, handler);
+    return teardown?.();
+  };
+}

--- a/packages/logger/test/helper.js
+++ b/packages/logger/test/helper.js
@@ -1,5 +1,5 @@
 const logger = require('@percy/logger');
-const { ANSI_REG } = require('@percy/logger/dist/colors');
+const { ANSI_REG } = require('@percy/logger/dist/util');
 const { Logger } = logger;
 
 const ELAPSED_REG = /\s\S*?\(\d+ms\)\S*/;

--- a/packages/logger/test/index.test.js
+++ b/packages/logger/test/index.test.js
@@ -1,5 +1,5 @@
 import helper from './helper';
-import colors from '../src/colors';
+import { colors } from '../src/util';
 import logger from '../src';
 
 describe('logger', () => {

--- a/packages/logger/test/index.test.js
+++ b/packages/logger/test/index.test.js
@@ -1,5 +1,5 @@
-import colors from '../src/colors';
 import helper from './helper';
+import colors from '../src/colors';
 import logger from '../src';
 
 describe('logger', () => {
@@ -42,7 +42,7 @@ describe('logger', () => {
       meta
     });
 
-    expect(logger.instance.messages).toEqual(new Set([
+    expect(helper.messages).toEqual(new Set([
       entry('info', 'Info log', { foo: 'bar' }),
       entry('warn', 'Warn log', { bar: 'baz' }),
       entry('error', 'Error log', { to: 'be' }),
@@ -56,7 +56,7 @@ describe('logger', () => {
 
     expect(helper.stderr).toEqual([]);
     expect(helper.stdout).toEqual([
-      `[${colors.magenta('percy')}] Info log\n`
+      `[${colors.magenta('percy')}] Info log`
     ]);
   });
 
@@ -66,8 +66,8 @@ describe('logger', () => {
 
     expect(helper.stdout).toEqual([]);
     expect(helper.stderr).toEqual([
-      `[${colors.magenta('percy')}] ${colors.yellow('Warn log')}\n`,
-      `[${colors.magenta('percy')}] ${colors.red('Error log')}\n`
+      `[${colors.magenta('percy')}] ${colors.yellow('Warn log')}`,
+      `[${colors.magenta('percy')}] ${colors.red('Error log')}`
     ]);
   });
 
@@ -75,7 +75,7 @@ describe('logger', () => {
     log.info('URL: https://percy.io');
 
     expect(helper.stdout).toEqual([
-      `[${colors.magenta('percy')}] URL: ${colors.blue('https://percy.io')}\n`
+      `[${colors.magenta('percy')}] URL: ${colors.blue('https://percy.io')}`
     ]);
   });
 
@@ -83,7 +83,7 @@ describe('logger', () => {
     let error = new Error('test');
     log.error(error);
 
-    expect(logger.instance.messages).toContain({
+    expect(helper.messages).toContain({
       debug: 'test',
       level: 'error',
       message: error.stack,
@@ -92,7 +92,7 @@ describe('logger', () => {
     });
 
     expect(helper.stderr).toEqual([
-      `[${colors.magenta('percy')}] ${colors.red('Error: test')}\n`
+      `[${colors.magenta('percy')}] ${colors.red('Error: test')}`
     ]);
   });
 
@@ -109,8 +109,8 @@ describe('logger', () => {
     log.deprecated('Update me too');
 
     expect(helper.stderr).toEqual([
-      `[${colors.magenta('percy')}] ${colors.yellow('Warning: Update me')}\n`,
-      `[${colors.magenta('percy')}] ${colors.yellow('Warning: Update me too')}\n`
+      `[${colors.magenta('percy')}] ${colors.yellow('Warning: Update me')}`,
+      `[${colors.magenta('percy')}] ${colors.yellow('Warning: Update me too')}`
     ]);
   });
 
@@ -156,10 +156,16 @@ describe('logger', () => {
     );
   });
 
+  it('exposes own stdout and stderr streams', () => {
+    expect(logger.stdout).toBe(logger.Logger.stdout);
+    expect(logger.stderr).toBe(logger.Logger.stderr);
+  });
+
   describe('levels', () => {
     it('can be initially set by defining PERCY_LOGLEVEL', () => {
-      delete logger.instance;
       process.env.PERCY_LOGLEVEL = 'error';
+      helper.reset();
+
       expect(logger.loglevel()).toEqual('error');
     });
 
@@ -184,8 +190,8 @@ describe('logger', () => {
 
       expect(helper.stdout).toEqual([]);
       expect(helper.stderr).toEqual([
-        `[${colors.magenta('percy')}] ${colors.yellow('Warn log')}\n`,
-        `[${colors.magenta('percy')}] ${colors.red('Error log')}\n`
+        `[${colors.magenta('percy')}] ${colors.yellow('Warn log')}`,
+        `[${colors.magenta('percy')}] ${colors.red('Error log')}`
       ]);
     });
 
@@ -199,7 +205,7 @@ describe('logger', () => {
 
       expect(helper.stdout).toEqual([]);
       expect(helper.stderr).toEqual([
-        `[${colors.magenta('percy')}] ${colors.red('Error log')}\n`
+        `[${colors.magenta('percy')}] ${colors.red('Error log')}`
       ]);
     });
 
@@ -212,13 +218,12 @@ describe('logger', () => {
       log.debug('Debug log');
 
       expect(helper.stdout).toEqual([
-        `[${colors.magenta('percy:test')}] Info log\n`
+        `[${colors.magenta('percy:test')}] Info log`
       ]);
-
       expect(helper.stderr).toEqual([
-        `[${colors.magenta('percy:test')}] ${colors.yellow('Warn log')}\n`,
-        `[${colors.magenta('percy:test')}] ${colors.red('Error log')}\n`,
-        `[${colors.magenta('percy:test')}] Debug log\n`
+        `[${colors.magenta('percy:test')}] ${colors.yellow('Warn log')}`,
+        `[${colors.magenta('percy:test')}] ${colors.red('Error log')}`,
+        `[${colors.magenta('percy:test')}] Debug log`
       ]);
     });
 
@@ -228,7 +233,7 @@ describe('logger', () => {
       log.error(error);
 
       expect(helper.stderr).toEqual([
-        `[${colors.magenta('percy:test')}] ${colors.red(error.stack)}\n`
+        `[${colors.magenta('percy:test')}] ${colors.red(error.stack)}`
       ]);
     });
 
@@ -238,13 +243,11 @@ describe('logger', () => {
       log.debug(errorlike);
 
       expect(helper.stderr).toEqual([
-        `[${colors.magenta('percy:test')}] ${colors.red('ERROR')}\n`
+        `[${colors.magenta('percy:test')}] ${colors.red('ERROR')}`
       ]);
     });
 
     it('logs elapsed time when loglevel is "debug"', async () => {
-      // it is hard to escape ansi colors with `stringMatching`, which is needed because the time
-      // between logs can vary by a few milliseconds
       helper.mock({ elapsed: true });
       logger.loglevel('debug');
       log = logger('test');
@@ -256,20 +259,20 @@ describe('logger', () => {
       log.debug('Debug log');
 
       expect(helper.stdout).toEqual([
-        jasmine.stringMatching('Info log \\(\\dms\\)\\n')
+        jasmine.stringMatching('Info log \\(\\dms\\)')
       ]);
 
       expect(helper.stderr).toEqual([
-        jasmine.stringMatching('Warn log \\(\\dms\\)\\n'),
-        jasmine.stringMatching('Error log \\(\\dms\\)\\n'),
-        jasmine.stringMatching('Debug log \\(10\\dms\\)\\n')
+        jasmine.stringMatching('Warn log \\(\\dms\\)'),
+        jasmine.stringMatching('Error log \\(\\dms\\)'),
+        jasmine.stringMatching('Debug log \\(10\\dms\\)')
       ]);
     });
   });
 
   describe('debugging', () => {
     beforeEach(() => {
-      delete logger.instance;
+      helper.reset();
     });
 
     it('enables debug logging when PERCY_DEBUG is defined', () => {
@@ -280,7 +283,7 @@ describe('logger', () => {
 
       expect(logger.loglevel()).toEqual('debug');
       expect(helper.stderr).toEqual([
-        `[${colors.magenta('percy:test')}] Debug log\n`
+        `[${colors.magenta('percy:test')}] Debug log`
       ]);
     });
 
@@ -294,9 +297,9 @@ describe('logger', () => {
       logger('test:3').debug('Debug test 3');
 
       expect(helper.stderr).toEqual([
-        `[${colors.magenta('percy:test')}] Debug test\n`,
-        `[${colors.magenta('percy:test:1')}] Debug test 1\n`,
-        `[${colors.magenta('percy:test:3')}] Debug test 3\n`
+        `[${colors.magenta('percy:test')}] Debug test`,
+        `[${colors.magenta('percy:test:1')}] Debug test 1`,
+        `[${colors.magenta('percy:test:3')}] Debug test 3`
       ]);
     });
 
@@ -310,4 +313,29 @@ describe('logger', () => {
       expect(helper.stderr).toEqual([]);
     });
   });
+
+  if (process.env.__PERCY_BROWSERIFIED__) {
+    describe('browser support', () => {
+      it('logs messages with CSS colors', () => {
+        log.info('Colorful!');
+
+        expect(console.log).toHaveBeenCalledOnceWith(
+          '[%cpercy%c] Colorful!', 'color:magenta', 'color:inherit');
+      });
+
+      it('logs errors with console.error', () => {
+        log.error('ERR!');
+
+        expect(console.error).toHaveBeenCalledOnceWith(
+          '[%cpercy%c] %cERR!%c', 'color:magenta', 'color:inherit', 'color:red', 'color:inherit');
+      });
+
+      it('logs warnings with console.warn', () => {
+        log.warn('Warning!');
+
+        expect(console.warn).toHaveBeenCalledOnceWith(
+          '[%cpercy%c] %cWarning!%c', 'color:magenta', 'color:inherit', 'color:yellow', 'color:inherit');
+      });
+    });
+  }
 });

--- a/packages/logger/test/remote.test.js
+++ b/packages/logger/test/remote.test.js
@@ -1,0 +1,225 @@
+import helper from './helper';
+import logger from '../src';
+
+// very shallow mock websocket
+class MockSocket {
+  constructor(client) {
+    this.client = client || new MockSocket(this);
+    this.readyState = 0;
+    this.listeners = {};
+  }
+
+  addEventListener(event, callback) {
+    (this.listeners[event] ||= []).push(callback);
+  }
+
+  removeEventListener(event, callback) {
+    let listeners = this.listeners[event];
+    listeners.splice(listeners.indexOf(callback), 1);
+  }
+
+  emit(event, ...args) {
+    this.listeners[event] ||= [];
+    for (let callback of this.listeners[event]) {
+      callback.apply(this, args);
+    }
+  }
+
+  send(message) {
+    this.client.emit('message', { data: message });
+  }
+}
+
+describe('remote logging', () => {
+  let log, socket;
+
+  beforeEach(async () => {
+    helper.mock();
+    log = logger('remote');
+    socket = new MockSocket();
+  });
+
+  afterEach(() => {
+    delete process.env.PERCY_LOGLEVEL;
+    delete process.env.PERCY_DEBUG;
+  });
+
+  it('can connect to a remote logger', async () => {
+    let connected = logger.remote(socket);
+    await expectAsync(connected).toBePending();
+
+    socket.readyState = 1;
+    socket.emit('open');
+
+    await expectAsync(connected).toBeResolved();
+  });
+
+  it('logs a local debug error when unable to connect remotely', async () => {
+    setTimeout(() => socket.emit('error', { error: 'Socket Error' }), 100);
+
+    logger.loglevel('debug');
+    await logger.remote(socket);
+
+    expect(helper.stderr).toEqual([
+      '[percy:logger] Unable to connect to remote logger',
+      '[percy:logger] Socket Error'
+    ]);
+  });
+
+  it('logs a local debug error when the connection times out', async () => {
+    logger.loglevel('debug');
+    await logger.remote(socket, 10);
+
+    expect(helper.stderr).toEqual([
+      '[percy:logger] Unable to connect to remote logger',
+      '[percy:logger] Error: Socket connection timed out'
+    ]);
+  });
+
+  it('sends all previous logs when connected remotely', async () => {
+    log.info('Remote connection test 1');
+    log.info('Remote connection test 2', { foo: 'bar' });
+
+    spyOn(socket, 'send');
+    socket.readyState = 1;
+    await logger.remote(socket);
+
+    expect(socket.send).toHaveBeenCalled();
+    expect(JSON.parse(socket.send.calls.first().args[0])).toEqual({
+      logAll: [{
+        level: 'info',
+        debug: 'remote',
+        message: 'Remote connection test 1',
+        meta: { remote: true },
+        timestamp: jasmine.any(Number)
+      }, {
+        level: 'info',
+        debug: 'remote',
+        message: 'Remote connection test 2',
+        meta: { remote: true, foo: 'bar' },
+        timestamp: jasmine.any(Number)
+      }]
+    });
+  });
+
+  it('sends logs remotely when connected', async () => {
+    spyOn(socket, 'send');
+    socket.readyState = 1;
+    await logger.remote(socket);
+
+    expect(socket.send).not.toHaveBeenCalled();
+
+    log.info('Remote connection test');
+
+    expect(socket.send).toHaveBeenCalled();
+    expect(JSON.parse(socket.send.calls.first().args[0])).toEqual({
+      log: ['remote', 'info', 'Remote connection test', { remote: true }]
+    });
+  });
+
+  it('sends serialized error logs remotely when conected', async () => {
+    spyOn(socket, 'send');
+    socket.readyState = 1;
+    await logger.remote(socket);
+
+    expect(socket.send).not.toHaveBeenCalled();
+
+    let error = new Error('Test');
+    log.error(error);
+
+    expect(socket.send).toHaveBeenCalled();
+    expect(JSON.parse(socket.send.calls.first().args[0])).toEqual({
+      log: ['remote', 'error', {
+        message: 'Test',
+        stack: error.stack
+      }, { remote: true }]
+    });
+  });
+
+  it('updates local env info when connected remotely', async () => {
+    socket.readyState = 1;
+    await logger.remote(socket);
+
+    expect(process.env.PERCY_LOGLEVEL).toBeUndefined();
+    expect(process.env.PERCY_DEBUG).toBeUndefined();
+
+    socket.client.send('{}');
+
+    expect(process.env.PERCY_LOGLEVEL).toBeUndefined();
+    expect(process.env.PERCY_DEBUG).toBeUndefined();
+
+    socket.client.send(JSON.stringify({
+      env: {
+        PERCY_LOGLEVEL: 'debug',
+        PERCY_DEBUG: '*'
+      }
+    }));
+
+    expect(process.env.PERCY_LOGLEVEL).toEqual('debug');
+    expect(process.env.PERCY_DEBUG).toEqual('*');
+  });
+
+  it('can disconnect by running the returned function', async () => {
+    spyOn(socket, 'send');
+    socket.readyState = 1;
+    let disconnect = await logger.remote(socket);
+
+    log.info('Remote connection test 1');
+    log.info('Remote connection test 2');
+
+    expect(socket.send).toHaveBeenCalledTimes(2);
+
+    disconnect();
+    log.info('Remote connection test 3');
+
+    expect(socket.send).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not connect to more than one socket', async () => {
+    let { instance } = helper.constructor;
+    let socket2 = new MockSocket();
+
+    socket.readyState = 1;
+    socket2.readyState = 1;
+
+    expect(instance.socket).toBeUndefined();
+
+    await logger.remote(socket);
+    expect(instance.socket).toBe(socket);
+
+    await logger.remote(socket2);
+    expect(instance.socket).not.toBe(socket2);
+    expect(instance.socket).toBe(socket);
+  });
+
+  it('can accept incoming connections and sends env info', () => {
+    spyOn(socket, 'send');
+    logger.connect(socket);
+
+    expect(socket.send).toHaveBeenCalledOnceWith(
+      '{"env":{"PERCY_LOGLEVEL":"info"}}'
+    );
+  });
+
+  it('handles incoming messages from the remote logger', () => {
+    let send = data => socket.client.send(JSON.stringify(data));
+    logger.connect(socket);
+
+    send({ logAll: [{ debug: 'test1', level: 'warn', message: 'Test 1' }] });
+    send({ log: ['test2', 'info', 'Test 2'] });
+    send({ foo: 'bar' });
+
+    expect(helper.stdout).toEqual(['[percy] Test 2']);
+    expect(helper.messages).toEqual(new Set([{
+      debug: 'test1',
+      level: 'warn',
+      message: 'Test 1'
+    }, {
+      debug: 'test2',
+      level: 'info',
+      message: 'Test 2',
+      timestamp: jasmine.any(Number),
+      meta: {}
+    }]));
+  });
+});

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -22,12 +22,12 @@ describe('SDK Utils', () => {
     });
 
     it('returns the loglevel as defined by PERCY_LOGLEVEL', () => {
-      delete sdk.logger.reset();
+      sdk.logger.reset();
       expect(process.env.PERCY_LOGLEVEL).toBeUndefined();
       expect(sdk.rerequire('..').getInfo()).toHaveProperty('loglevel', 'info');
       delete require.cache[require.resolve('..')];
 
-      delete sdk.logger.reset();
+      sdk.logger.reset();
       process.env.PERCY_LOGLEVEL = 'debug';
       expect(sdk.rerequire('..').getInfo()).toHaveProperty('loglevel', 'debug');
     });
@@ -74,7 +74,7 @@ describe('SDK Utils', () => {
       await expectAsync(isPercyEnabled()).toBeResolvedTo(false);
 
       expect(sdk.logger.stdout).toEqual([
-        '[percy] Percy is not running, disabling snapshots\n'
+        '[percy] Percy is not running, disabling snapshots'
       ]);
     });
 
@@ -84,7 +84,7 @@ describe('SDK Utils', () => {
       await expectAsync(isPercyEnabled()).toBeResolvedTo(false);
 
       expect(sdk.logger.stdout).toEqual([
-        '[percy] Percy is not running, disabling snapshots\n'
+        '[percy] Percy is not running, disabling snapshots'
       ]);
     });
 
@@ -94,7 +94,7 @@ describe('SDK Utils', () => {
       await expectAsync(isPercyEnabled()).toBeResolvedTo(false);
 
       expect(sdk.logger.stdout).toEqual([
-        '[percy] Unsupported Percy CLI version, disabling snapshots\n'
+        '[percy] Unsupported Percy CLI version, disabling snapshots'
       ]);
     });
   });

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -22,12 +22,12 @@ describe('SDK Utils', () => {
     });
 
     it('returns the loglevel as defined by PERCY_LOGLEVEL', () => {
-      delete sdk.logger.instance;
+      delete sdk.logger.reset();
       expect(process.env.PERCY_LOGLEVEL).toBeUndefined();
       expect(sdk.rerequire('..').getInfo()).toHaveProperty('loglevel', 'info');
       delete require.cache[require.resolve('..')];
 
-      delete sdk.logger.instance;
+      delete sdk.logger.reset();
       process.env.PERCY_LOGLEVEL = 'debug';
       expect(sdk.rerequire('..').getInfo()).toHaveProperty('loglevel', 'debug');
     });

--- a/scripts/chromium-revision
+++ b/scripts/chromium-revision
@@ -47,10 +47,10 @@ async function task({ message, state: init, function: fn }) {
       let i = state.i = (state.i || 0) + 1;
 
       // clear the current line
-      readline.clearLine(logger.instance.stdout);
-      readline.cursorTo(logger.instance.stdout, 0);
+      readline.clearLine(logger.stdout);
+      readline.cursorTo(logger.stdout, 0);
       // log the message with an additional period for each iteration
-      logger.instance.stdout.write(
+      logger.stdout.write(
         logger.format(message(state, '.'.repeat(i)), 'script')
       );
 
@@ -59,7 +59,7 @@ async function task({ message, state: init, function: fn }) {
     })((init?.() || {}));
   } finally {
     // this ensures errors will log on their own line
-    logger.instance.stdout.write('\n');
+    logger.stdout.write('\n');
   }
 }
 
@@ -156,7 +156,7 @@ async function printVersionRevisions(version) {
   });
 
   // log all matching revisions
-  logger.instance.stdout.write('\n' + (
+  logger.stdout.write('\n' + (
     Object.entries(revisions).map(([platform, i]) => (
       `${platform}: ${i.revision} (${i.sha}; ${i.version})`
     )).join('\n') + '\n\n'));


### PR DESCRIPTION
## What is this?

This PR contains two important change to `@percy/logger`.

### Browserification

This takes advantage of all the new test and build scripts to create a browser bundle by simply adding two new fields to the package.json. One to signify a browser bundle, and another to provide package specific rollup options. Of course, the package didn't magically work in a browser. Although it was close! The logger's `log` method would write directly to the process stdio, which doesn't exist in a browser. The test helper was also relying on a native stream object to mock stdio properties for testing.

The write logic was moved into it's own method, as well as some other methods being moved around. A new `BrowserLogger` class was created to extend the normal logger while replacing the new write method with a browser compatible one. Since logs are still colorized via ansi escape codes, and some browsers such as Firefox do not support logging ansi escape sequences, they are instead replaced with the string `%c` and the appropriate CSS is added to another array which is appended to the console log call. This CSS log formatting is supported in all major desktop browsers with the exceptions of IE and versions of Edge prior to 79 (released Jan 2020).

With the help of the bundled `__PERCY_BROWSERIFIED__` environment variable, the logger index file will conditionally use the correct Logger class when creating logger instances. The test helper also uses this variable to spy on the logger's write method and console log usage rather than creating a mock stdio stream.

The singleton logic was also moved to be within the class itself rather than as part of the index helper. As such, the index file was refactored a little. The colors util was also adjusted to allow the browser class to more easily replace ansi codes with CSS colors. The test helper was also change to remove trailing newlines from recorded log messages since the browser logger and new write method both do not receive the newline character and it is only written purposefully in node environments.

### Remote Logging

Part two of this PR doesn't necessarily relate to browser support, but does allow browser loggers to log out to the CLI process when a local Percy server is running. Enabling this in an agnostic way regardless of WebSocket implementation allows this feature to also work across other Node processes. In turn, allowing our main logger to capture and record logs from within the SDKs themselves.

This is made available via two new logger methods. The `#connect` method, to be used by the main logger, will send logging environment info, attach a `message` listener, and allow the connected WebSocket to issue remote logs. The `#remote` method, to be used by SDK loggers, will wait for an open WebSocket connection, silently send previously logged entries, and attach a listener to update local logger environment info. When logging and connected to a remote instance, logs will flow through the websocket and be handled by the remote logger. If a connection cannot be established, a debug error is logged and local logs will continue to be handled locally.

Since the new methods were made to be agnostic of the WebSocket implementation, it will have to be handled in two other places. First, in this PR, the core server was given a WebSocket server via `ws` (already a dependency for CDP connections). This simple server will connect any socket to the logger. In the future, it could be made more robust and allow snapshots and other info to be sent over the established connection. Part two of the WebSocket connect must be made by the SDK. This can be handled for all official JS SDKs via the `@percy/sdk-utils` package (once it is browserified). There is also the potential for other languages to be able to connect to and use the remote logger via their own WebSocket implementations.

### Related changes

Since logger test helpers were updated, that means tests throughout the repo that used the helper needed to be updated. This also means that JS SDKs that use the logger test helper will also need to be updated.