### PR TITLE
✅ Fix test log debugging

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -29,8 +29,12 @@ module.exports = config => config.set({
     'test/**/*.test.js': ['rollupTestFiles']
   },
 
-  // reports look better when not randomized
   client: {
+    env: {
+      // used in the test helper to add failed test debug logs
+      DUMP_FAILED_TEST_LOGS: process.env.DUMP_FAILED_TEST_LOGS
+    },
+    // reports look better when not randomized
     jasmine: {
       random: false
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:watch": "lerna run build --stream -- --watch",
     "bump-version": "lerna version --no-git-tag-version --no-push",
     "chromium-revision": "./scripts/chromium-revision",
-    "clean": "rm -rf packages/**/{dist,.nyc_output,coverage,oclif.manifest.json}",
+    "clean": "rm -rf packages/**/{dist,.nyc_output,coverage,oclif.manifest.json,.local-chromium}",
     "lint": "eslint --ignore-path .gitignore .",
     "readme": "lerna run --parallel readme",
     "postinstall": "lerna run --stream postinstall",

--- a/packages/core/test/helpers/index.js
+++ b/packages/core/test/helpers/index.js
@@ -11,13 +11,7 @@ beforeEach(() => {
   mockAPI.start();
 });
 
-afterEach(function(done) {
-  // dump logs for failed tests when debugging
-  if (process.env.DEBUG_FAILING &&
-      this.currentTest.state === 'failed') {
-    logger.dump();
-  }
-
+afterEach(done => {
   // cleanup tmp files
   rimraf(path.join(os.tmpdir(), 'percy'), () => done());
 });

--- a/scripts/test-helpers.js
+++ b/scripts/test-helpers.js
@@ -42,3 +42,21 @@ beforeAll(() => {
     })
   });
 });
+
+// dump logs for failed tests when debugging
+let DUMP_FAILED_TEST_LOGS = false;
+
+// get the value from the env or from karma
+try { ({ DUMP_FAILED_TEST_LOGS } = process.env); } catch (e) {}
+try { ({ DUMP_FAILED_TEST_LOGS } = window.__karma__.config.env); } catch (e) {}
+
+if (DUMP_FAILED_TEST_LOGS) {
+  // add a spec reporter to dump failed logs
+  jasmine.getEnv().addReporter({
+    specDone: ({ status }) => {
+      if (status === 'failed') {
+        require('@percy/logger/test/helper').dump();
+      }
+    }
+  });
+}


### PR DESCRIPTION
## What is this?

While debugging some failing tests, I noticed that the failed test check used to produce log dumps did not work due to the recent refactor to Jasmine. Jasmine does not have a way to access the current test from within a hook, but it did feel more proper to add it as a shared reporter in the common test helpers file. Since this file is also loaded in browser environments, I had to add catches around reading the environment variable and also set said variable in an alternate way for karma tests since the common test helpers do not get bundled with rollup.