### PR TITLE
🐛 Force @percy/dom globalization

### DIFF
--- a/packages/dom/src/index.js
+++ b/packages/dom/src/index.js
@@ -1,14 +1,9 @@
 import serialize from './serialize-dom';
 
 /* istanbul ignore next */
-// works around instances where the context has an incorrect global scope
-// https://github.com/mozilla/geckodriver/issues/1798
-try {
-  if (globalThis !== window) {
-    window.PercyDOM = { serialize };
-  }
-} catch (error) {
-  // `globalThis` is probably not defined
+// works around instances where the context has an incorrect scope
+if (typeof window !== 'undefined') {
+  window.PercyDOM = { serialize };
 }
 
 export { serialize };

--- a/packages/dom/src/index.js
+++ b/packages/dom/src/index.js
@@ -3,7 +3,7 @@ import serialize from './serialize-dom';
 /* istanbul ignore next */
 // works around instances where the context has an incorrect scope
 if (typeof window !== 'undefined') {
-  window.PercyDOM = { serialize };
+  window.PercyDOM = exports;
 }
 
 export { serialize };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,8 +45,7 @@ const base = {
     ...pkg.rollup.output,
     intro: [
       // provide the bundle with a fake process.env if needed
-      'let process = {};',
-      'try { process = globalThis.process || {}; } catch (e) {}',
+      'const process = (typeof globalThis !== "undefined" && globalThis.process) || {};',
       'process.env = process.env || {};',
       // signals that the package is running in a browserified bundle
       'process.env.__PERCY_BROWSERIFIED__ = true;'


### PR DESCRIPTION
## What is this?

Sometimes modules or exports are polyfilled causing the UMD bundle to not attach the DOM script to the global scope. Since this scope issue seems to keep coming up, let's always set the serialize function globally when the window object is defined.

I also updated the bundle intro to use `typeof` rather than `try-catch`.