### PR TITLE
✨ Better browser bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 oclif.manifest.json
 .DS_Store
 .local-chromium
+packages/logger/test/client.js

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:watch": "lerna run build --stream -- --watch",
     "bump-version": "lerna version --no-git-tag-version --no-push",
     "chromium-revision": "./scripts/chromium-revision",
-    "clean": "git clean -Xdf --exclude '!node_modules'",
+    "clean": "git clean -Xdf --exclude !node_modules",
     "lint": "eslint --ignore-path .gitignore .",
     "readme": "lerna run --parallel readme",
     "postinstall": "lerna run --stream postinstall",

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -19,6 +19,11 @@
   "rollup": {
     "output": {
       "name": "PercyDOM"
+    },
+    "test": {
+      "output": {
+        "exports": "named"
+      }
     }
   },
   "devDependencies": {

--- a/packages/dom/src/index.js
+++ b/packages/dom/src/index.js
@@ -1,10 +1,1 @@
-import serialize from './serialize-dom';
-
-/* istanbul ignore next */
-// works around instances where the context has an incorrect scope
-if (typeof window !== 'undefined') {
-  window.PercyDOM = exports;
-}
-
-export { serialize };
-export default serialize;
+export { default, default as serialize } from './serialize-dom';

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -6,7 +6,8 @@
   "browser": "dist/bundle.js",
   "files": [
     "dist",
-    "test/helpers.js"
+    "test/helpers.js",
+    "test/client.js"
   ],
   "engines": {
     "node": ">=12"

--- a/packages/logger/src/index.js
+++ b/packages/logger/src/index.js
@@ -22,9 +22,9 @@ Object.assign(logger, {
 });
 
 Object.defineProperties(logger, {
+  Logger: { get: () => Logger },
   stdout: { get: () => Logger.stdout },
   stderr: { get: () => Logger.stderr }
 });
 
 module.exports = logger;
-module.exports.Logger = Logger;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -129,7 +129,10 @@ const testFiles = {
   ]
 };
 
-module.exports.default = base;
+// export default bundle config
+const bundles = [base];
+
+module.exports.default = bundles;
 module.exports.test = test;
 module.exports.testHelpers = testHelpers;
 module.exports.testFiles = testFiles;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -33,15 +33,16 @@ async function main({ node, bundle } = argv) {
     let start = Date.now();
 
     // $ rollup --config <root>/rollup.config.js
-    let config = require('../rollup.config').default;
-    let bundle = await require('rollup').rollup(config);
-    await bundle.write(config.output);
-    await bundle.close();
+    for (let config of require('../rollup.config').default) {
+      let bundle = await require('rollup').rollup(config);
+      await bundle.write(config.output);
+      await bundle.close();
 
-    // programatic rollup api doesn't log
-    console.log(`${
-      colors.green(`${config.input} → ${config.output.file}`)
-    } (${Date.now() - start}ms)`);
+      // programatic rollup api doesn't log
+      console.log(`${
+        colors.green(`${config.input} → ${config.output.file}`)
+      } (${Date.now() - start}ms)`);
+    }
   }
 }
 


### PR DESCRIPTION
## Purpose

Currently, `@percy/dom` and `@percy/logger` have UMD browser bundles. When injecting `@percy/dom` in different environments, we've found that it sometimes didn't properly attach itself to the context due to factors such as inconsistent `globalThis` implementations or re-compiling causing the UMD code to assume a commonjs environment. 

We've worked around these issues in `@percy/dom` by forcefully setting a global variable when a `window` context is available. However, these bundles should only ever be consumed in a browser environment, resulting in that window global should _always_ be set. Rather than support every module format, we can use an IIFE since we know the code will only ever be executed in a browser. To support other bundlers consuming our bundle, we can conditionally check for a commonjs environment.

The logger also distributes its test helpers, but without specific bundler settings, they are difficult to consume directly in a browser. To make this easier, we can support multiple bundles per package, and enable bundling `test/helpers.js` as `test/client.js`. Consuming browser test bundles can use `test/client.js` directly or alias `test/helpers.js` for polymorphic code.

## Approach

First, we can handle multiple bundles by exporting an array from our rollup config. Arrays of configs are supported by rollup's CLI, but in our own custom build script, we must loop over the exported configs.

The rollup config was refactored after extensive testing with `@percy/dom`, `@percy/logger`, and the future browserified `@percy/sdk-utils`. It now has better helpers for dealing with various config settings for both main package bundles and test bundles.

IIFE bundle formats are now used by default. And wrapped with custom code to support commonjs. The default IIFE output uses `this` as the global window without a way to configure it, so the entire IIFE is also wrapped in another IIFE bound to the window context. This new bundle will always attach itself to the window, and export that global in commonjs environments.

Due to the new rollup settings, `@percy/dom` and `@percy/logger` needed some small adjustments. I also fixed the `clean` script in windows by removing the quotes from the excluded parameter.