### PR TITLE
✅ Fix test log dumping

### DIFF
--- a/packages/logger/test/helpers.js
+++ b/packages/logger/test/helpers.js
@@ -81,7 +81,7 @@ const helpers = {
   },
 
   dump() {
-    if (!helpers.message) return;
+    if (!helpers.messages?.size) return;
     if (console.log.and) console.log.and.callThrough();
 
     let write = m => process.env.__PERCY_BROWSERIFIED__

--- a/scripts/test-helpers.js
+++ b/scripts/test-helpers.js
@@ -44,18 +44,23 @@ beforeAll(() => {
 });
 
 // dump logs for failed tests when debugging
-let DUMP_FAILED_TEST_LOGS = false;
-
-// get the value from the env or from karma
-try { ({ DUMP_FAILED_TEST_LOGS } = process.env); } catch (e) {}
-try { ({ DUMP_FAILED_TEST_LOGS } = window.__karma__.config.env); } catch (e) {}
+const { DUMP_FAILED_TEST_LOGS } = (
+  typeof window !== 'undefined'
+    ? window.__karma__.config.env
+    : process.env
+);
 
 if (DUMP_FAILED_TEST_LOGS) {
   // add a spec reporter to dump failed logs
   jasmine.getEnv().addReporter({
     specDone: ({ status }) => {
-      if (status === 'failed') {
-        require('@percy/logger/test/helpers').dump();
+      let logger = typeof window !== 'undefined'
+        ? (window.PercyLogger && window.PercyLogger.TestHelpers) ||
+          (window.PercySDKUtils && window.PercySDKUtils.TestHelpers.logger)
+        : require('@percy/logger/test/helpers');
+
+      if (logger && status === 'failed') {
+        logger.dump();
       }
     }
   });


### PR DESCRIPTION
## What is this?

Log dumping was broken in a couple of ways. The actual `dump` method had a member typo which always returned undefined causing the function to abort. Even if it were defined it would log the warning even with zero logs. Finally, the failed test reporter did not work in browser environments since this file does not get bundled. The reporter now references the possible window globals when in a browser context.

Depends on #252