### PR TITLE
🐛 Fix remote logger cleanup

### DIFF
--- a/packages/logger/src/logger.js
+++ b/packages/logger/src/logger.js
@@ -208,18 +208,21 @@ export default class PercyLogger {
     // if not already connected, wait until the timeout
     if (!this.isRemote) {
       err = await new Promise(resolve => {
-        let done = error => {
+        let done = event => {
           socket.removeEventListener('error', done);
           socket.removeEventListener('open', done);
           clearTimeout(timeoutid);
-          resolve(error);
+
+          resolve(event?.error || (event?.type === 'error' && (
+            'Error: Socket connection failed')));
         };
 
-        let timeoutid = setTimeout(done, timeout, (
-          'Error: Socket connection timed out'));
+        let timeoutid = setTimeout(done, timeout, {
+          error: 'Error: Socket connection timed out'
+        });
 
-        socket.addEventListener('open', () => done());
-        socket.addEventListener('error', ({ error }) => done(error));
+        socket.addEventListener('open', done);
+        socket.addEventListener('error', done);
       });
     }
 

--- a/packages/logger/test/remote.test.js
+++ b/packages/logger/test/remote.test.js
@@ -66,6 +66,18 @@ describe('remote logging', () => {
     ]);
   });
 
+  it('logs a fallback debug message when an error is emitted without one', async () => {
+    setTimeout(() => socket.emit('error', { type: 'error' }), 100);
+
+    logger.loglevel('debug');
+    await logger.remote(socket);
+
+    expect(helpers.stderr).toEqual([
+      '[percy:logger] Unable to connect to remote logger',
+      '[percy:logger] Error: Socket connection failed'
+    ]);
+  });
+
   it('logs a local debug error when the connection times out', async () => {
     logger.loglevel('debug');
     await logger.remote(socket, 10);


### PR DESCRIPTION
## What is this?

The cleanup function for remote logging attempted to remove event listeners, however the events were registered with anonymous functions. By providing the intended function, the argument must be changed along with its usage as the timeout callback.

This bug doesn't necessarily effect anything as the socket lives as long as the process anyway unless it fails to connect. However this code should at least be corrected.

I also experienced an instance where a WebSocket error within the browser may not contain an `error` property. So a fallback message is used for error events without said property (and an accompanying test was added).

Depends on #252 & #253