### PR TITLE
🐛 Expose version header for CORS

### DIFF
--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -31,7 +31,10 @@ async function getReply({ version, routes }, request) {
   if (headers['Content-Type']?.includes('json')) body = JSON.stringify(body);
   // add additional headers
   headers['Content-Length'] = body?.length ?? 0;
+  // cors headers
+  headers['Access-Control-Expose-Headers'] = 'X-Percy-Core-Version';
   headers['Access-Control-Allow-Origin'] = '*';
+  // version header
   headers['X-Percy-Core-Version'] = version;
 
   return [status, headers, body];

--- a/packages/core/test/server.test.js
+++ b/packages/core/test/server.test.js
@@ -150,6 +150,7 @@ describe('Snapshot Server', () => {
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
     expect(response.headers.get('Access-Control-Allow-Methods')).toBe('GET,POST,OPTIONS');
     expect(response.headers.get('Access-Control-Request-Headers')).toBe('Vary');
+    expect(response.headers.get('Access-Control-Expose-Headers')).toBe('X-Percy-Core-Version');
     expect(percy.snapshot).not.toHaveBeenCalled();
 
     response = await fetch('http://localhost:1337/percy/snapshot', {


### PR DESCRIPTION
## What is this?

With most responses, all headers in the request response are included in the response object. In browsers however, the `Access-Control-Expose-Headers` header is strictly respected and if that header does not exist, or the desired header is not defined within it, the response object will not contain all response headers.

Adding this header will allow SDKs within browsers to access the version header exposed by the local Percy server API.

Depends on #252, #253, & #254