### PR TITLE
♻️ Rename server address method / environment variable

### DIFF
--- a/packages/cli-exec/src/commands/exec/index.js
+++ b/packages/cli-exec/src/commands/exec/index.js
@@ -73,7 +73,7 @@ export class Exec extends Command {
 
     // provide SDKs with useful env vars
     let env = {
-      PERCY_CLI_API: this.percy?.apiAddress(),
+      PERCY_SERVER_ADDRESS: this.percy?.address(),
       PERCY_LOGLEVEL: logger.loglevel(),
       ...process.env
     };

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -74,7 +74,7 @@ export default class Percy {
   }
 
   // Snapshot server API address
-  apiAddress() {
+  address() {
     return `http://localhost:${this.port}`;
   }
 

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -94,9 +94,9 @@ describe('Percy', () => {
     });
   });
 
-  describe('#apiAddress()', () => {
+  describe('#address()', () => {
     it('returns the server API address', async () => {
-      expect(percy.apiAddress()).toEqual('http://localhost:5338');
+      expect(percy.address()).toEqual('http://localhost:5338');
     });
   });
 

--- a/packages/sdk-utils/README.md
+++ b/packages/sdk-utils/README.md
@@ -27,7 +27,7 @@ const { cliApi, loglevel, version, config } = getInfo();
 
 #### Returned properties
 
-- `cliApi` — CLI API address (`process.env.PERCY_CLI_API || 'http://localhost:5338'`)
+- `cliApi` — CLI API address (`process.env.PERCY_SERVER_ADDRESS || 'http://localhost:5338'`)
 - `loglevel` — CLI log level  (`process.env.PERCY_LOGLEVEL || 'info'`)
 
 The following properties are only populated after [`isPercyEnabled`](#ispercyenabled) has been

--- a/packages/sdk-utils/index.js
+++ b/packages/sdk-utils/index.js
@@ -1,11 +1,11 @@
 const logger = require('@percy/logger');
 
 // Maybe get the CLI API address from the environment
-const { PERCY_CLI_API = 'http://localhost:5338' } = process.env;
+const { PERCY_SERVER_ADDRESS = 'http://localhost:5338' } = process.env;
 
 // Helper to send a request to the local CLI API
 function request(path, { body, ...options } = {}) {
-  let { protocol, hostname, port, pathname, search } = new URL(PERCY_CLI_API + path);
+  let { protocol, hostname, port, pathname, search } = new URL(PERCY_SERVER_ADDRESS + path);
   options = { ...options, protocol, hostname, port, path: pathname + search };
 
   return new Promise((resolve, reject) => {
@@ -41,7 +41,7 @@ function request(path, { body, ...options } = {}) {
 // Returns CLI information
 function getInfo() {
   return {
-    cliApi: PERCY_CLI_API,
+    cliApi: PERCY_SERVER_ADDRESS,
     loglevel: logger.loglevel(),
     version: getInfo.version,
     config: getInfo.config

--- a/packages/sdk-utils/test/helpers.js
+++ b/packages/sdk-utils/test/helpers.js
@@ -21,7 +21,7 @@ sdk.setup = async function setup() {
   }, 5338);
 
   // reset things
-  delete process.env.PERCY_CLI_API;
+  delete process.env.PERCY_SERVER_ADDRESS;
   delete process.env.PERCY_LOGLEVEL;
   sdk.serializeDOM = serializeDOM;
   logger.mock();

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -10,13 +10,13 @@ describe('SDK Utils', () => {
   });
 
   describe('getInfo()', () => {
-    it('returns the CLI API address as defined by PERCY_CLI_API', () => {
-      expect(process.env.PERCY_CLI_API).toBeUndefined();
+    it('returns the CLI API address as defined by PERCY_SERVER_ADDRESS', () => {
+      expect(process.env.PERCY_SERVER_ADDRESS).toBeUndefined();
       expect(sdk.rerequire('..').getInfo())
         .toHaveProperty('cliApi', 'http://localhost:5338');
       delete require.cache[require.resolve('..')];
 
-      process.env.PERCY_CLI_API = 'http://localhost:1234';
+      process.env.PERCY_SERVER_ADDRESS = 'http://localhost:1234';
       expect(sdk.rerequire('..').getInfo())
         .toHaveProperty('cliApi', 'http://localhost:1234');
     });


### PR DESCRIPTION
## Purpose

Initially, the `PERCY_CLI_API` environment variable was named so because it was the CLI that set that variable for SDKs to consume. However, that API address can still be consumed by SDKs without the CLI. In reality, this value comes from the core server, so it's name should reflect that.

`PERCY_SERVER_ADDRESS` was chosen as it is pretty descriptive in that the variable contains the address of the local Percy server. However, I'm open to other suggestions.  <img alt="bikeshed" title="bikeshed" height="20px" src="https://emojis.slackmojis.com/emojis/images/1515784750/3372/bikeshed.png"/>

Since this variable is only set by the CLI, and official SDKs consume this internally, I wouldn't count this as breaking for our own SDKs. If the user was using the `--port` option (not likely), it will still continue to work once the SDK is updated to account for the new variable name. However this would be considered a breaking change for custom SDKs that do not use sdk-utils, although this package is technically still beta so changes should be expected.

Depends on #252, #253, #254, & #255