### PR TITLE
✅ Fix flakey logger test

### DIFF
--- a/packages/logger/test/index.test.js
+++ b/packages/logger/test/index.test.js
@@ -265,7 +265,7 @@ describe('logger', () => {
       expect(helpers.stderr).toEqual([
         jasmine.stringMatching('Warn log \\(\\dms\\)'),
         jasmine.stringMatching('Error log \\(\\dms\\)'),
-        jasmine.stringMatching('Debug log \\(10\\dms\\)')
+        jasmine.stringMatching('Debug log \\((9[0-9]|1[01][0-9])ms\\)')
       ]);
     });
   });


### PR DESCRIPTION
## What is this?

A test logs, waits 100ms to log again, then asserts that the correct elapsed time was printed. Sometimes this logger test shows the elapsed time a little out of range of 100-109ms, so the check is loosened to 90-119ms. We're not really testing speed here, just that the elapsed time prints.