### PR TITLE
🐛 Fix cross-env remote logging handlers

### DIFF
--- a/packages/logger/src/util.js
+++ b/packages/logger/src/util.js
@@ -30,13 +30,3 @@ export const colors = entries(ANSI_COLORS)
       [name]: colorize.bind(null, code)
     });
   }, {});
-
-// adds an event listener and returns a teardown function
-export function listen(subject, event, handler, teardown) {
-  subject.addEventListener(event, handler);
-
-  return () => {
-    subject.removeEventListener(event, handler);
-    return teardown?.();
-  };
-}


### PR DESCRIPTION
## Purpose

In addition to a WebSocket Server, the node `ws` library provides a way for Node environments to use a `WebSocket` client class similar to browser environments. Even though a `ws` WebSocket has identical event names to its browser counterpart, events in Node typically do not emit Event objects like in browsers. This makes it so our agnostic code must handle both types of event listeners.

## Approach

Rather than checking event listener arguments to determine if a value or event object was provided, we can use `on<eventname>` handler counterparts which are called by `ws` in _exactly_ the same way browser WebSocket handlers are called — with an event object. The main difference between listeners and handlers is that multiple event handlers cannot be registered at the same time. However, we are not registering multiple listeners per event anyway.

The test mock and tests were also updated and the `listen` util was removed since it is no longer needed. An additional cleanup handler test was also added to account for coverage changes with the util removal.