### PR TITLE
🔨 Only bundle for browsers that support async/await

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -54,7 +54,11 @@ const plugins = {
     babelHelpers: 'bundled',
     presets: [
       ['@babel/env', {
-        targets: 'last 2 version'
+        targets: {
+          browsers: [
+            'last 2 versions and supports async-functions'
+          ]
+        }
       }]
     ]
   }),


### PR DESCRIPTION
## Purpose

Currently, our bundles require `regeneratorRuntime` to be present in the environment in order for async functions to work (`@percy/logger` now, `@percy/sdk-utils` soon). This is because they are bundled for the "last 2 versions" of browsers including browsers with very little usage or browsers that might not be maintained.

The "defaults" browser target option also targets the last 2 versions, but further filters the list based on usage and also includes Firefox ESR and a particular browser that is soon to be no longer maintained. This option would still require the regenerator runtime for bundles with async functions.

## Approach

Rather than bundle based on browsers, we can bundle based on feature support. In addition to the last 2 versions, the target list can be further filtered by support for async functions to avoid the regenerator runtime requirement. This list is a bit more restrictive than the "defaults" option, but still includes all major browsers with the exception of IE11 which will stop being maintained later this year (August 2021).