### PR TITLE
✅ Make @percy/logger test helper framework agnostic

### DIFF
--- a/packages/logger/test/index.test.js
+++ b/packages/logger/test/index.test.js
@@ -319,22 +319,25 @@ describe('logger', () => {
       it('logs messages with CSS colors', () => {
         log.info('Colorful!');
 
-        expect(console.log).toHaveBeenCalledOnceWith(
-          '[%cpercy%c] Colorful!', 'color:magenta', 'color:inherit');
+        expect(console.log.calls).toEqual([
+          ['[%cpercy%c] Colorful!', 'color:magenta', 'color:inherit']
+        ]);
       });
 
       it('logs errors with console.error', () => {
         log.error('ERR!');
 
-        expect(console.error).toHaveBeenCalledOnceWith(
-          '[%cpercy%c] %cERR!%c', 'color:magenta', 'color:inherit', 'color:red', 'color:inherit');
+        expect(console.error.calls).toEqual([
+          ['[%cpercy%c] %cERR!%c', 'color:magenta', 'color:inherit', 'color:red', 'color:inherit']
+        ]);
       });
 
       it('logs warnings with console.warn', () => {
         log.warn('Warning!');
 
-        expect(console.warn).toHaveBeenCalledOnceWith(
-          '[%cpercy%c] %cWarning!%c', 'color:magenta', 'color:inherit', 'color:yellow', 'color:inherit');
+        expect(console.warn.calls).toEqual([
+          ['[%cpercy%c] %cWarning!%c', 'color:magenta', 'color:inherit', 'color:yellow', 'color:inherit']
+        ]);
       });
     });
   }


### PR DESCRIPTION
## Purpose

We currently use the `spyOn` helper from jasmine to spy on browser logs. This works great for tests within this repo which also uses Jasmine, however it does not work so well outside of Jasmine where `spyOn` isn't typically globally available.

## Approach

Add our own small `spy` helper within this util that takes care of the spying regardless of the testing framework. The expectation API changed and tests updated since we are no longer using a built-in spy, however those changes were small.