### PR TITLE
🐛 Fix @percy/logger test helper unsupported syntax

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,17 +1,24 @@
-const pkg = require(`${process.cwd()}/package.json`);
+const cwd = process.cwd();
+const path = require('path');
+const pkg = require(`${cwd}/package.json`);
 
 const base = {
-  ignore: pkg.files,
-  presets: [
-    ['@babel/env', {
-      targets: {
-        node: '12'
-      }
-    }]
-  ],
-  plugins: [
-    '@babel/proposal-class-properties'
-  ]
+  overrides: [{
+    exclude: pkg.files && (
+      pkg.files.map(f => (
+        path.join(cwd, f)
+      ))),
+    presets: [
+      ['@babel/env', {
+        targets: {
+          node: '12'
+        }
+      }]
+    ],
+    plugins: [
+      '@babel/proposal-class-properties'
+    ]
+  }]
 };
 
 const development = {

--- a/packages/logger/test/helpers.js
+++ b/packages/logger/test/helpers.js
@@ -95,7 +95,7 @@ const helpers = {
   },
 
   dump() {
-    if (!helpers.messages?.size) return;
+    if (!helpers.messages || !helpers.messages.size) return;
     if (console.log.and) console.log.and.callThrough();
 
     let write = m => process.env.__PERCY_BROWSERIFIED__


### PR DESCRIPTION
## What is this?

The optional chaining syntax (`?.`) is supported in Node 14, but not Node 12. So it was missed when developing `@percy/logger` test helpers. Babel config exists that is meant to ignore distributed files to raise such issues during CI, however it was not configured correctly.

This updates the babel config to use the current working directory in combination with a package's distributed files list. Unfortunately, this meant that development aliases no longer existed for some of these files. To accommodate development aliases, only the base config is not applied to distributed files. This makes it so no ES features are accidentally transpiled in these files and tests will now warn when such a file has been encountered.

Now that this is fixed, the offending `?.` was also fixed in `@percy/logger`'s test helper.