### PR TITLE
✨ Expose used chrome versions

### DIFF
--- a/packages/core/src/install.js
+++ b/packages/core/src/install.js
@@ -4,7 +4,7 @@ import https from 'https';
 import logger from '@percy/logger';
 import readableBytes from './utils/bytes';
 
-const chromiumRevisions = {
+const revisions = {
   linux: '812847',
   win64: '812845',
   win32: '812822',
@@ -22,7 +22,7 @@ function installChromium({
   // default directory is within @percy/core package root
   directory = path.resolve(__dirname, '../.local-chromium'),
   // default revision corresponds to v87.0.4280.x
-  revision = selectByPlatform(chromiumRevisions),
+  revision = selectByPlatform(revisions),
 } = {}) {
   let extract = (i, o) => require('extract-zip')(i, { dir: o });
 
@@ -50,6 +50,8 @@ function installChromium({
     executable
   });
 }
+
+installChromium.revisions = revisions;
 
 // Installs an executable from a url to a local directory, returning the full path to the extracted
 // binary. Skips installation if the executable already exists at the binary path.
@@ -126,5 +128,4 @@ async function install({
 // commonjs friendly
 module.exports = install;
 module.exports.chromium = installChromium;
-module.exports.chromiumRevisions = chromiumRevisions;
 module.exports.selectByPlatform = selectByPlatform;

--- a/packages/core/src/install.js
+++ b/packages/core/src/install.js
@@ -4,6 +4,13 @@ import https from 'https';
 import logger from '@percy/logger';
 import readableBytes from './utils/bytes';
 
+const chromeRevisions = {
+  linux: '812847',
+  win64: '812845',
+  win32: '812822',
+  darwin: '812851'
+};
+
 // Returns an item from the map keyed by the current platform
 function selectByPlatform(map) {
   let { platform, arch } = process;
@@ -15,12 +22,7 @@ function installChromium({
   // default directory is within @percy/core package root
   directory = path.resolve(__dirname, '../.local-chromium'),
   // default revision corresponds to v87.0.4280.x
-  revision = selectByPlatform({
-    linux: '812847',
-    win64: '812845',
-    win32: '812822',
-    darwin: '812851'
-  })
+  revision = selectByPlatform(chromeRevisions),
 } = {}) {
   let extract = (i, o) => require('extract-zip')(i, { dir: o });
 
@@ -124,4 +126,5 @@ async function install({
 // commonjs friendly
 module.exports = install;
 module.exports.chromium = installChromium;
+module.exports.chromeRevisions = chromeRevisions;
 module.exports.selectByPlatform = selectByPlatform;

--- a/packages/core/src/install.js
+++ b/packages/core/src/install.js
@@ -4,7 +4,7 @@ import https from 'https';
 import logger from '@percy/logger';
 import readableBytes from './utils/bytes';
 
-const chromeRevisions = {
+const chromiumRevisions = {
   linux: '812847',
   win64: '812845',
   win32: '812822',
@@ -22,7 +22,7 @@ function installChromium({
   // default directory is within @percy/core package root
   directory = path.resolve(__dirname, '../.local-chromium'),
   // default revision corresponds to v87.0.4280.x
-  revision = selectByPlatform(chromeRevisions),
+  revision = selectByPlatform(chromiumRevisions),
 } = {}) {
   let extract = (i, o) => require('extract-zip')(i, { dir: o });
 
@@ -126,5 +126,5 @@ async function install({
 // commonjs friendly
 module.exports = install;
 module.exports.chromium = installChromium;
-module.exports.chromeRevisions = chromeRevisions;
+module.exports.chromiumRevisions = chromiumRevisions;
 module.exports.selectByPlatform = selectByPlatform;

--- a/packages/core/test/unit/install.test.js
+++ b/packages/core/test/unit/install.test.js
@@ -155,23 +155,23 @@ describe('Unit / Install', () => {
 
     for (let [platform, expected] of Object.entries({
       linux: {
-        revision: install.chromeRevisions.linux,
-        url: jasmine.stringMatching(`Linux_x64/${install.chromeRevisions.linux}/chrome-linux.zip`),
+        revision: install.chromiumRevisions.linux,
+        url: jasmine.stringMatching(`Linux_x64/${install.chromiumRevisions.linux}/chrome-linux.zip`),
         return: path.join('chrome-linux', 'chrome')
       },
       darwin: {
-        revision: install.chromeRevisions.darwin,
-        url: jasmine.stringMatching(`Mac/${install.chromeRevisions.darwin}/chrome-mac.zip`),
+        revision: install.chromiumRevisions.darwin,
+        url: jasmine.stringMatching(`Mac/${install.chromiumRevisions.darwin}/chrome-mac.zip`),
         return: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium')
       },
       win64: {
-        revision: install.chromeRevisions.win64,
-        url: jasmine.stringMatching(`Win_x64/${install.chromeRevisions.win64}/chrome-win.zip`),
+        revision: install.chromiumRevisions.win64,
+        url: jasmine.stringMatching(`Win_x64/${install.chromiumRevisions.win64}/chrome-win.zip`),
         return: path.join('chrome-win', 'chrome.exe')
       },
       win32: {
-        revision: install.chromeRevisions.win32,
-        url: jasmine.stringMatching(`Win/${install.chromeRevisions.win32}/chrome-win32.zip`),
+        revision: install.chromiumRevisions.win32,
+        url: jasmine.stringMatching(`Win/${install.chromiumRevisions.win32}/chrome-win32.zip`),
         return: path.join('chrome-win32', 'chrome.exe')
       }
     })) {

--- a/packages/core/test/unit/install.test.js
+++ b/packages/core/test/unit/install.test.js
@@ -155,23 +155,23 @@ describe('Unit / Install', () => {
 
     for (let [platform, expected] of Object.entries({
       linux: {
-        revision: '812847',
-        url: jasmine.stringMatching('Linux_x64/812847/chrome-linux.zip'),
+        revision: install.chromeRevisions.linux,
+        url: jasmine.stringMatching(`Linux_x64/${install.chromeRevisions.linux}/chrome-linux.zip`),
         return: path.join('chrome-linux', 'chrome')
       },
       darwin: {
-        revision: '812851',
-        url: jasmine.stringMatching('Mac/812851/chrome-mac.zip'),
+        revision: install.chromeRevisions.darwin,
+        url: jasmine.stringMatching(`Mac/${install.chromeRevisions.darwin}/chrome-mac.zip`),
         return: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium')
       },
       win64: {
-        revision: '812845',
-        url: jasmine.stringMatching('Win_x64/812845/chrome-win.zip'),
+        revision: install.chromeRevisions.win64,
+        url: jasmine.stringMatching(`Win_x64/${install.chromeRevisions.win64}/chrome-win.zip`),
         return: path.join('chrome-win', 'chrome.exe')
       },
       win32: {
-        revision: '812822',
-        url: jasmine.stringMatching('Win/812822/chrome-win32.zip'),
+        revision: install.chromeRevisions.win32,
+        url: jasmine.stringMatching(`Win/${install.chromeRevisions.win32}/chrome-win32.zip`),
         return: path.join('chrome-win32', 'chrome.exe')
       }
     })) {

--- a/packages/core/test/unit/install.test.js
+++ b/packages/core/test/unit/install.test.js
@@ -155,23 +155,23 @@ describe('Unit / Install', () => {
 
     for (let [platform, expected] of Object.entries({
       linux: {
-        revision: install.chromiumRevisions.linux,
-        url: jasmine.stringMatching(`Linux_x64/${install.chromiumRevisions.linux}/chrome-linux.zip`),
+        revision: install.chromium.revisions.linux,
+        url: jasmine.stringMatching(`Linux_x64/${install.chromium.revisions.linux}/chrome-linux.zip`),
         return: path.join('chrome-linux', 'chrome')
       },
       darwin: {
-        revision: install.chromiumRevisions.darwin,
-        url: jasmine.stringMatching(`Mac/${install.chromiumRevisions.darwin}/chrome-mac.zip`),
+        revision: install.chromium.revisions.darwin,
+        url: jasmine.stringMatching(`Mac/${install.chromium.revisions.darwin}/chrome-mac.zip`),
         return: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium')
       },
       win64: {
-        revision: install.chromiumRevisions.win64,
-        url: jasmine.stringMatching(`Win_x64/${install.chromiumRevisions.win64}/chrome-win.zip`),
+        revision: install.chromium.revisions.win64,
+        url: jasmine.stringMatching(`Win_x64/${install.chromium.revisions.win64}/chrome-win.zip`),
         return: path.join('chrome-win', 'chrome.exe')
       },
       win32: {
-        revision: install.chromiumRevisions.win32,
-        url: jasmine.stringMatching(`Win/${install.chromiumRevisions.win32}/chrome-win32.zip`),
+        revision: install.chromium.revisions.win32,
+        url: jasmine.stringMatching(`Win/${install.chromium.revisions.win32}/chrome-win32.zip`),
         return: path.join('chrome-win32', 'chrome.exe')
       }
     })) {


### PR DESCRIPTION
### Background

The `@percy/core` package [manages chromium version](https://github.com/percy/cli/blob/master/packages/core/src/install.js#L18-L23) on its own when no executables provided, so there is no versions mismatch possible in this scenario. However, when the `PERCY_BROWSER_EXECUTABLE` env var is set to point to a chromium executable it becomes difficult to manage the chromium version and keep it aligned with the ones that the library is supposed to work with. Especially, when the dependency definition in `package.json` file is set like:

```
{
  ...
  "peerDependencies": {
    "@percy/core": "*",
  },
  ...
}
```

### In this PR

Expose chromium versions to be able to assert that the local one fits the requirement. For example:

```js
const { chromium } = require('@percy/core/dist/install');
assert.equal(
  '812847',
  chromium.revisions.linux,
  'The local chromium version for @percy/core don\'t match the expected one!',
);
```

By exposing the chromium version, we can provide a guarantee that the versions are matching along with the ability to upgrade the library independently while the local and required versions are the same.

cc @joscha