### PR TITLE
✨ Add AMD support to bundles

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,8 +78,10 @@ const plugins = {
           bundle[file].code = [
             // explicitly execute the iife with a window context
             `(function() {\n${indent(bundle[file].code)}}).call(window);\n`,
-            // support commonjs format by exporting the global
-            'if (typeof exports === "object" && typeof module !== "undefined") {',
+            // support amd & commonjs modules by referencing the global
+            'if (typeof define === "function" && define.amd) {',
+            `  define(["${pkg.name}"], () => window.${options.name});`,
+            '} else if (typeof module === "object" && module.exports) {',
             `  module.exports = window.${options.name};`,
             '}\n'
           ].join('\n');


### PR DESCRIPTION
## What is this?

Adds support for AMD format in bundles to allow imports in those environments (such as Ember).