### PR TITLE
🐛 Account for logger websocket synchrony

### DIFF
--- a/packages/core/test/server.test.js
+++ b/packages/core/test/server.test.js
@@ -172,16 +172,13 @@ describe('Snapshot Server', () => {
     // log from a separate async process
     let [stdout, stderr] = await new Promise((resolve, reject) => {
       require('child_process').exec('node -e "' + [
-        "const logger = require('@percy/logger');",
-        // connect to the local websocket server for logging and unref the socket
-        "const ws = new (require('ws'))('http://localhost:1337');",
-        "ws.on('open', () => ws._socket.unref());",
-        // set loglevel to debug failures
+        "let logger = require('@percy/logger');",
+        "let ws = new (require('ws'))('ws://localhost:1337');",
         "logger.loglevel('debug');",
-        // connect and send a remote log
-        'logger.remote(ws).then(() => ',
-        "logger('remote-sdk').info('whoa'));"
-      ].join('') + '"', (err, stdout, stderr) => {
+        'logger.remote(() => ws)',
+        "  .then(() => logger('remote-sdk').info('whoa'))",
+        '  .then(() => setTimeout(() => ws.close(), 100));'
+      ].join('\n') + '"', (err, stdout, stderr) => {
         if (!err) resolve([stdout, stderr]);
         else reject(err);
       });

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -116,26 +116,6 @@ describe('SDK Utils', () => {
         log: ['testing:utils', 'info', 'Test remote logging', { remote: true }]
       })]);
     });
-
-    it('logs debug info when the remote logger fails to connect', async () => {
-      // trigger an unexpected error via percy.address
-      let t = { i: 0, addr: utils.percy.address };
-      spyOnProperty(utils.percy, 'address').and.callFake(() => t.i++ || t.addr);
-
-      utils.logger.loglevel('debug');
-      await expectAsync(isPercyEnabled()).toBeResolvedTo(true);
-      utils.logger('testing:utils').info('Test remote logging');
-
-      // wait briefly for remote to receive the message
-      await new Promise(r => setTimeout(r, 100));
-
-      expect(helpers.logger.stderr[0]).toEqual(
-        '[percy:utils] Unable to connect to remote logger');
-      expect(helpers.logger.stdout).toEqual([
-        '[percy:testing:utils] Test remote logging']);
-      expectAsync(helpers.call('server.messages'))
-        .toBeResolvedTo([]);
-    });
   });
 
   describe('fetchPercyDOM()', () => {


### PR DESCRIPTION
## What is this?

Sometimes, WebSocket errors can come from the constructor itself which is defined outside the scope of the logger. Rather than having extra error handling, we can have the logger accept a socket creator function and wrap it with the existing error handling.

Usage of the `remote` method was updated in `@percy/sdk-utils` as well as other tests.