### PR TITLE
✨ Add Azure Pipelines env var for pull request number

### DIFF
--- a/packages/env/src/environment.js
+++ b/packages/env/src/environment.js
@@ -183,7 +183,11 @@ export default class PercyEnvironment {
         case 'gitlab':
           return this.vars.CI_MERGE_REQUEST_IID;
         case 'azure':
-          return this.vars.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER;
+          return (
+            this.vars.SYSTEM_PULLREQUEST_PULLREQUESTID ||
+            this.vars.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER ||
+            null
+          );
         case 'appveyor':
           return this.vars.APPVEYOR_PULL_REQUEST_NUMBER;
         case 'probo':

--- a/packages/env/src/environment.js
+++ b/packages/env/src/environment.js
@@ -183,11 +183,7 @@ export default class PercyEnvironment {
         case 'gitlab':
           return this.vars.CI_MERGE_REQUEST_IID;
         case 'azure':
-          return (
-            this.vars.SYSTEM_PULLREQUEST_PULLREQUESTID ||
-            this.vars.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER ||
-            null
-          );
+          return this.vars.SYSTEM_PULLREQUEST_PULLREQUESTID || this.vars.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER;
         case 'appveyor':
           return this.vars.APPVEYOR_PULL_REQUEST_NUMBER;
         case 'probo':

--- a/packages/env/test/azure.test.js
+++ b/packages/env/test/azure.test.js
@@ -27,12 +27,13 @@ describe('Azure', () => {
   it('has the correct properties for PR builds', () => {
     env = new PercyEnvironment({
       ...env.vars,
+      SYSTEM_PULLREQUEST_PULLREQUESTID: '502',
       SYSTEM_PULLREQUEST_PULLREQUESTNUMBER: '512',
       SYSTEM_PULLREQUEST_SOURCECOMMITID: 'azure-pr-commit-sha',
       SYSTEM_PULLREQUEST_SOURCEBRANCH: 'azure-pr-branch'
     });
 
-    expect(env).toHaveProperty('pullRequest', '512');
+    expect(env).toHaveProperty('pullRequest', '502');
     expect(env).toHaveProperty('branch', 'azure-pr-branch');
     expect(env).toHaveProperty('commit', 'azure-pr-commit-sha');
   });


### PR DESCRIPTION
Copying over the same change from https://github.com/percy/percy-js/pull/257

Add support for Azure Pipelines change in pull request number environment variable
https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables-devops-services

> **System.PullRequest.PullRequestId**
> 
> The ID of the pull request that caused this build. For example: 17. (This variable is initialized only if the build ran because of a Git PR affected by a branch policy).


> **System.PullRequest.PullRequestNumber**
> 
> The number of the pull request that caused this build. This variable  is populated for pull requests from GitHub which have a different pull  request ID and pull request number. This variable is only available in a  YAML pipeline if the PR is a affected by a branch policy.