### PR TITLE
✨ Better GitHub Action env support

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -1,5 +1,5 @@
 import PercyEnvironment from '@percy/env';
-import { git } from '@percy/env/dist/git';
+import { git } from '@percy/env/dist/utils';
 import pkg from '../package.json';
 
 import {

--- a/packages/env/src/utils.js
+++ b/packages/env/src/utils.js
@@ -1,4 +1,5 @@
 import { execSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
 
 const GIT_COMMIT_FORMAT = [
   'COMMIT_SHA:%H',
@@ -15,10 +16,8 @@ export function git(args) {
   try {
     return execSync(`git ${args}`, { encoding: 'utf-8' });
   } catch (e) {
-    // do something?
+    return '';
   }
-
-  return '';
 }
 
 // get raw commit data
@@ -50,4 +49,13 @@ export function getJenkinsSha() {
     data.authorEmail === 'nobody@nowhere' &&
     data.message.match(/^Merge commit [^\s]+ into HEAD$/) &&
     git('rev-parse HEAD^');
+}
+
+// github actions are triggered by webhook events which are saved to the filesystem
+export function github({ GITHUB_EVENT_PATH }) {
+  if (!github.payload && GITHUB_EVENT_PATH && existsSync(GITHUB_EVENT_PATH)) {
+    try { github.payload = JSON.parse(readFileSync(GITHUB_EVENT_PATH, 'utf8')); } catch (e) {}
+  }
+
+  return (github.payload ||= {});
 }

--- a/packages/env/test/helpers.js
+++ b/packages/env/test/helpers.js
@@ -30,6 +30,6 @@ mock('child_process', {
 });
 
 mock.reRequire('child_process');
-mock.reRequire('../src/git');
+mock.reRequire('../src/utils');
 mock.reRequire('../src/environment');
 mock.reRequire('../src');


### PR DESCRIPTION
## What is this?

This adds better support for GH Actions by reading from the event payload file created in workflows by their corresponding webhook events.

In our official GH Actions, we use `@actions/github` to read environment information such as the PR number and branch name. This package (and specifically the properties used in our actions) are actually a thin wrapper around [reading from the file](https://github.com/actions/toolkit/blob/fc005283374f1cea5e03ea1caf959cd9ff12fdc2/packages/github/src/context.ts#L27-L36) located at `GITHUB_EVENT_PATH`.

We can eliminate the need for specific actions, and that library, by reading from this event file directly ourselves.

This is done with a new util function. The existing utils were all `git` based, so the file was named `git.js`. However with the addition of this util, the file exports vary and so was renamed to `utils.js`