### PR TITLE
🐛 Fix printed debug timestamps

### DIFF
--- a/packages/logger/src/logger.js
+++ b/packages/logger/src/logger.js
@@ -174,7 +174,7 @@ export default class PercyLogger {
       let elapsed = timestamp - (this.lastlog || timestamp);
       if (isError && this.level !== 'debug') message = error.toString();
       this.write(level, this.format(message, debug, error ? 'error' : level, elapsed));
-      this.lastlog ||= timestamp;
+      this.lastlog = timestamp;
     }
   }
 

--- a/packages/logger/test/index.test.js
+++ b/packages/logger/test/index.test.js
@@ -257,6 +257,7 @@ describe('logger', () => {
       log.error('Error log');
       await new Promise(r => setTimeout(r, 100));
       log.debug('Debug log');
+      log.error('Final log');
 
       expect(helpers.stdout).toEqual([
         jasmine.stringMatching('Info log \\(\\dms\\)')
@@ -265,7 +266,8 @@ describe('logger', () => {
       expect(helpers.stderr).toEqual([
         jasmine.stringMatching('Warn log \\(\\dms\\)'),
         jasmine.stringMatching('Error log \\(\\dms\\)'),
-        jasmine.stringMatching('Debug log \\((9[0-9]|1[01][0-9])ms\\)')
+        jasmine.stringMatching('Debug log \\((9[0-9]|1[01][0-9])ms\\)'),
+        jasmine.stringMatching('Final log \\(\\dms\\)')
       ]);
     });
   });


### PR DESCRIPTION
## What is this?

The printed debug messages are meant to show the time elapsed between logs. However, when it was implemented by saving the last timestamp accidentally with a logical or assignment, which means that it will only ever be set on the first log and never updated again. Removing the `||` fixes the accumulative timestamp and will show proper elapsed-between timestamps.

This might also relate to this specific test being flakey in CI. Probably because the time between the first log and last log was slow even though we only want to test the time between the last log and the previous log. An additional log was added to test that the timestamp is **not** accumulative. 