### PR TITLE
🐛 Fix AMD bundle

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -80,7 +80,7 @@ const plugins = {
             `(function() {\n${indent(bundle[file].code)}}).call(window);\n`,
             // support amd & commonjs modules by referencing the global
             'if (typeof define === "function" && define.amd) {',
-            `  define(["${pkg.name}"], () => window.${options.name});`,
+            `  define([], () => window.${options.name});`,
             '} else if (typeof module === "object" && module.exports) {',
             `  module.exports = window.${options.name};`,
             '}\n'


### PR DESCRIPTION
## What is this?

AMD bundles have two syntaxes: `define(id, deps[], factory)` and `define(deps[], factory)` (filename becomes the ID). We were inadvertently combing the syntaxes into `define([id], factory)`. 

While our incorrect syntax is technically valid (circular dep on itself), we had another compounding issue. We were using `pkg.name` for the ID even when the package contains multiple bundles (like for test helpers).

While requiring the AMD bundle in Ember SDK tests, this compounded issue caused the test helpers to re-require the main package bundle which caused duplicate bundles to be included causing the test helpers to use outdated references.

This PR simply removes AMD deps from our bundles since our bundles do not actually contain external deps.