### PR TITLE
♻️ Update `build:wait` example output

### DIFF
--- a/packages/cli-build/src/commands/build/wait.js
+++ b/packages/cli-build/src/commands/build/wait.js
@@ -46,7 +46,7 @@ export class Wait extends Command {
   };
 
   static examples = [
-    '$ percy build:wait --build 123',
+    '$ percy build:wait --build 2222222',
     '$ percy build:wait --project org-slug/test --commit HEAD'
   ];
 

--- a/packages/cli-build/src/commands/build/wait.js
+++ b/packages/cli-build/src/commands/build/wait.js
@@ -47,7 +47,7 @@ export class Wait extends Command {
 
   static examples = [
     '$ percy build:wait --build 2222222',
-    '$ percy build:wait --project org-slug/test --commit HEAD'
+    '$ percy build:wait --project org/project --commit HEAD'
   ];
 
   log = logger('cli:build:wait');

--- a/packages/cli-build/src/commands/build/wait.js
+++ b/packages/cli-build/src/commands/build/wait.js
@@ -47,7 +47,7 @@ export class Wait extends Command {
 
   static examples = [
     '$ percy build:wait --build 123',
-    '$ percy build:wait --project test --commit HEAD'
+    '$ percy build:wait --project org-slug/test --commit HEAD'
   ];
 
   log = logger('cli:build:wait');


### PR DESCRIPTION
## What is this?

The `build:wait` command requires a full org/project slug and the example only gave the project slug (that will error). This PR updates the example to give an org/project slug. 