### PR TITLE
Set Parallel Total from CircleCI Config

### DIFF
--- a/packages/env/src/environment.js
+++ b/packages/env/src/environment.js
@@ -202,7 +202,16 @@ export default class PercyEnvironment {
   // parallel total & nonce
   get parallel() {
     let total = parseInt(this.vars.PERCY_PARALLEL_TOTAL, 10);
-    if (!Number.isInteger(total)) total = null;
+    if (!Number.isInteger(total)) {
+      switch (this.ci) {
+        case 'circle':
+          total = parseInt(this.vars.CIRCLE_NODE_TOTAL, 10);
+          break;
+      }
+      if (!Number.isInteger(total)) {
+        total = null;
+      }
+    }
 
     // no nonce if no total
     let nonce = total && (() => {

--- a/packages/env/test/circle.test.js
+++ b/packages/env/test/circle.test.js
@@ -29,4 +29,9 @@ describe('CircleCI', () => {
     env = new PercyEnvironment({ ...env.vars, CIRCLE_WORKFLOW_ID: 'workflow-id' });
     expect(env).toHaveProperty('parallel.nonce', 'workflow-id');
   });
+
+  it('has the correct parallel total', () => {
+    env = new PercyEnvironment({ ...env.vars, PERCY_PARALLEL_TOTAL: '', CIRCLE_NODE_TOTAL: '15' });
+    expect(env).toHaveProperty('parallel.total', 15);
+  });
 });


### PR DESCRIPTION
When setting up [`parallelism` in CircleCI](https://circleci.com/docs/2.0/parallelism-faster-jobs/), an environment variable [`CIRCLE_NODE_TOTAL`](https://circleci.com/docs/2.0/env-vars/?section=pipelines#built-in-environment-variables) is set.

This change picks up the above when detecting the parallel build total for the CircleCI environment.