### PR TITLE
✨ Improved config migrate

### DIFF
--- a/packages/cli-config/test/migrate.test.js
+++ b/packages/cli-config/test/migrate.test.js
@@ -6,8 +6,8 @@ import { Migrate } from '../src/commands/config/migrate';
 describe('percy config:migrate', () => {
   beforeEach(() => {
     mockConfig('.percy.yml', 'version: 1\n');
-    PercyConfig.addMigration((input, set) => {
-      if (input.migrate != null) set('migrated', input.migrate.replace('old', 'new'));
+    PercyConfig.addMigration((config, util) => {
+      if (config.migrate) util.map('migrate', 'migrated', v => v.replace('old', 'new'));
     });
   });
 

--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -25,15 +25,13 @@ export const schema = {
   }
 };
 
-export function migration(input, set) {
+export function migration(config, { map, del }) {
   /* eslint-disable curly */
-  if (input.version < 2) {
+  if (config.version < 2) {
     // static-snapshots and options were renamed
-    if (input.staticSnapshots?.baseUrl != null)
-      set('static.baseUrl', input.staticSnapshots.baseUrl);
-    if (input.staticSnapshots?.snapshotFiles != null)
-      set('static.files', input.staticSnapshots.snapshotFiles);
-    if (input.staticSnapshots?.ignoreFiles != null)
-      set('static.ignore', input.staticSnapshots.ignoreFiles);
+    map('staticSnapshots.baseUrl', 'static.baseUrl');
+    map('staticSnapshots.snapshotFiles', 'static.files');
+    map('staticSnapshots.ignoreFiles', 'static.ignore');
+    del('staticSnapshots');
   }
 }

--- a/packages/cli-upload/src/config.js
+++ b/packages/cli-upload/src/config.js
@@ -21,13 +21,12 @@ export const schema = {
   }
 };
 
-export function migration(input, set) {
+export function migration(config, { map, del }) {
   /* eslint-disable curly */
-  if (input.version < 2) {
+  if (config.version < 2) {
     // image-snapshots and options were renamed
-    if (input.imageSnapshots?.files != null)
-      set('upload.files', input.imageSnapshots.files);
-    if (input.imageSnapshots?.ignore != null)
-      set('upload.ignore', input.imageSnapshots.ignore);
+    map('imageSnapshots.files', 'upload.files');
+    map('imageSnapshots.ignore', 'upload.ignore');
+    del('imageSnapshots');
   }
 }

--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -70,11 +70,9 @@ export default function load({
           if (version < 2) {
             log.warn('Found older config file version, please run ' + (
               '`percy config:migrate` to update to the latest version'));
-            config = migrate(result.config);
-          } else {
-            config = result.config;
           }
 
+          config = migrate(result.config);
           cache.set(path, config);
         }
       } else {

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -69,26 +69,15 @@ export const schema = {
 };
 
 // Migration function
-export function migration(input, set) {
+export function migration(config, { map, del }) {
   /* eslint-disable curly */
-  if (input.version < 2) {
-    // previous snapshot options map 1:1
-    if (input.snapshot != null)
-      set('snapshot', input.snapshot);
-    // request-headers option moved
-    if (input.agent?.assetDiscovery?.requestHeaders != null)
-      set('snapshot.requestHeaders', input.agent.assetDiscovery.requestHeaders);
-    // allowed-hostnames moved
-    if (input.agent?.assetDiscovery?.allowedHostnames != null)
-      set('discovery.allowedHostnames', input.agent.assetDiscovery.allowedHostnames);
-    // network-idle-timeout moved
-    if (input.agent?.assetDiscovery?.networkIdleTimeout != null)
-      set('discovery.networkIdleTimeout', input.agent.assetDiscovery.networkIdleTimeout);
-    // page pooling was rewritten to be a concurrent task queue
-    if (input.agent?.assetDiscovery?.pagePoolSizeMax != null)
-      set('discovery.concurrency', input.agent.assetDiscovery.pagePoolSizeMax);
-    // cache-responses was renamed to match the CLI flag
-    if (input.agent?.assetDiscovery?.cacheResponses != null)
-      set('discovery.disableCache', !input.agent.assetDiscovery.cacheResponses);
+  if (config.version < 2) {
+    // discovery options have moved
+    map('agent.assetDiscovery.allowedHostnames', 'discovery.allowedHostnames');
+    map('agent.assetDiscovery.networkIdleTimeout', 'discovery.networkIdleTimeout');
+    map('agent.assetDiscovery.cacheResponses', 'discovery.disableCache', v => !v);
+    map('agent.assetDiscovery.requestHeaders', 'discovery.requestHeaders');
+    map('agent.assetDiscovery.pagePoolSizeMax', 'discovery.concurrency');
+    del('agent');
   }
 }


### PR DESCRIPTION
## What is this?

This improves the config migration pattern to support migrating deprecated options within the current config version. To support this, migrations are always performed. As such, they no longer result in a fresh object, but instead mutate the provided config using util functions. Internally, the provided config is never a reference in danger of harmful mutations.

Previously, only a `set` util was provided. Now there is also `map` and `del` which can map and delete config options respectively. A fresh logger is also provided so migrations can log deprecation warnings.

This shouldn't break anything externally unless a 3rd party CLI plugin is already relying on beta config migration patterns.