### PR TITLE
✨ Add per-snapshot discovery cache and hostnames options

### DIFF
--- a/packages/core/src/discovery/browser.js
+++ b/packages/core/src/discovery/browser.js
@@ -168,11 +168,11 @@ export default class Browser extends EventEmitter {
     }));
   }
 
-  async page({ meta }) {
+  async page(options) {
     // create and attach to a new page target returning the resulting page instance
     let { targetId } = await this.send('Target.createTarget', { url: 'about:blank' });
     let { sessionId } = await this.send('Target.attachToTarget', { targetId, flatten: true });
-    return this.pages.get(sessionId).init({ meta });
+    return this.pages.get(sessionId).init(options);
   }
 
   async send(method, params) {

--- a/packages/core/src/utils/url.js
+++ b/packages/core/src/utils/url.js
@@ -27,24 +27,30 @@ function domainCheck(domain, host, isWild) {
 }
 
 // Returns true or false if `url` matches the provided domain `pattern`.
-export function domainMatch(pattern, url) {
-  if (pattern === '*') {
-    return true;
-  } else if (!pattern) {
-    return false;
+export function domainMatch(patterns, url) {
+  for (let pattern of [].concat(patterns)) {
+    if (pattern === '*') {
+      return true;
+    } else if (!pattern) {
+      continue;
+    }
+
+    // check for wildcard patterns
+    let isWild = (pattern.indexOf('*.') === 0) || (pattern.indexOf('*/') === 0);
+    // get the pattern's domain and path prefix
+    let slashed = pattern.split('/');
+    let domain = isWild ? slashed.shift().substr(2) : slashed.shift();
+    let pathprefix = `/${slashed.join('/')}`;
+
+    // parse the provided URL
+    let { hostname, pathname } = new URL(url);
+
+    // check that the URL matches the pattern's domain and path prefix
+    if (domainCheck(domain, hostname, isWild) &&
+        pathname.indexOf(pathprefix) === 0) {
+      return true;
+    }
   }
 
-  // check for wildcard patterns
-  let isWild = (pattern.indexOf('*.') === 0) || (pattern.indexOf('*/') === 0);
-  // get the pattern's domain and path prefix
-  let slashed = pattern.split('/');
-  let domain = isWild ? slashed.shift().substr(2) : slashed.shift();
-  let pathprefix = `/${slashed.join('/')}`;
-
-  // parse the provided URL
-  let { hostname, pathname } = new URL(url);
-
-  // check that the URL matches the pattern's domain and path prefix
-  return domainCheck(domain, hostname, isWild) &&
-    pathname.indexOf(pathprefix) === 0;
+  return false;
 }

--- a/packages/core/test/asset-discovery.test.js
+++ b/packages/core/test/asset-discovery.test.js
@@ -311,7 +311,7 @@ describe('Asset Discovery', () => {
     });
 
     it('does not cache resource requests when disabled', async () => {
-      percy.discoverer.disableCache = true;
+      percy.discoverer.config.disableCache = true;
 
       // repeat above test
       await snapshot(1);
@@ -332,7 +332,7 @@ describe('Asset Discovery', () => {
   describe('with resource errors', () => {
     it('logs unhandled request errors gracefully', async () => {
       // sabotage this property to trigger unexpected error handling
-      Object.defineProperty(percy.discoverer, 'disableCache', {
+      Object.defineProperty(percy.discoverer.config, 'disableCache', {
         get() { throw new Error('some unhandled request error'); }
       });
 
@@ -356,7 +356,7 @@ describe('Asset Discovery', () => {
 
     it('logs unhandled response errors gracefully', async () => {
       // sabotage this property to trigger unexpected error handling
-      Object.defineProperty(percy.discoverer, 'disableCache', {
+      Object.defineProperty(percy.discoverer.config, 'disableCache', {
         // only throw ever other time when accessed within the response handler
         get() {
           let error = new Error('some unhandled response error');

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -12,6 +12,8 @@ interface AuthCredentials {
 interface DiscoveryOptions {
   requestHeaders?: Pojo;
   authorization?: AuthCredentials;
+  allowedHostnames?: string[];
+  disableCache?: boolean;
 }
 
 interface DiscoveryLaunchOptions {
@@ -22,9 +24,7 @@ interface DiscoveryLaunchOptions {
 }
 
 interface AllDiscoveryOptions extends DiscoveryOptions {
-  allowedHostnames?: string[];
   networkIdleTimeout?: number;
-  disableCache?: boolean;
   concurrency?: number;
   launchOptions?: DiscoveryLaunchOptions;
 }

--- a/packages/core/types/index.test-d.ts
+++ b/packages/core/types/index.test-d.ts
@@ -65,7 +65,9 @@ expectType<Promise<void>>(percy.snapshot({
   enableJavaScript: true,
   discovery: {
     authorization: { username: 'u', password: '*' },
-    requestHeaders: { 'x-testing': 'test' }
+    requestHeaders: { 'x-testing': 'test' },
+    allowedHostnames: ['foobar'],
+    disableCache: true
   }
 }));
 


### PR DESCRIPTION
## What is this?

This adds `disableCache` and `allowedHostnames` to the new per-snapshot `discovery` options. Some refactoring was done to make future options much simpler to add:

- At the `percy.snapshot` method, specific options (including per-snapshot discovery options) are passed along to the `discoverer.gatherResources` method. This method then explicitly provides other methods with appropriate options; such as providing size/javascript/network options to the `page` method and discovery options to the various discovery handlers.

  Now, `gatherResources` and subsequent intermediary functions will only reference options as needed and then pass all other options along down the call chain. Any option can then be plucked where needed — such as these new discovery options only needing to be added to the discovery handlers, or in the future a user-agent option can be added to the page creation method.

- Page creation was also refactored slightly. All page configuration events were moved to the page init method which is called by the discoverer when requesting a new page from the browser. This is just so all page configuration options can live inside of the page class and not need to be handled by the discoverer instance.

- The `domainMatch` util was made to accept an array of patterns so we can avoid concatenating all hostnames.