### PR TITLE
✨ Allow setting discoverer user-agent

### DIFF
--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -51,6 +51,9 @@ export const schema = {
           password: { type: 'string' }
         }
       },
+      userAgent: {
+        type: 'string'
+      },
       concurrency: {
         type: 'integer'
       },

--- a/packages/core/test/asset-discovery.test.js
+++ b/packages/core/test/asset-discovery.test.js
@@ -283,6 +283,28 @@ describe('Asset Discovery', () => {
     ]));
   });
 
+  it('allows setting a custom discovery user-agent', async () => {
+    let userAgent;
+
+    server.reply('/img.gif', req => {
+      userAgent = req.headers['user-agent'];
+      return [200, 'image/gif', pixel];
+    });
+
+    await percy.snapshot({
+      name: 'test ua',
+      url: 'http://localhost:8000',
+      domSnapshot: testDOM,
+      discovery: { userAgent: 'fake/ua' }
+    });
+
+    expect(logger.stdout).toEqual(jasmine.arrayContaining([
+      '[percy] Snapshot taken: test ua'
+    ]));
+
+    expect(userAgent).toEqual('fake/ua');
+  });
+
   describe('resource caching', () => {
     let snapshot = async n => {
       await percy.snapshot({


### PR DESCRIPTION
## What is this?

Adds the ability to set a custom user-agent string via a config file or per snapshot option, `discovery.userAgent`.

By default, it will use the normal Chrome user agent without the `Headless` part in an attempt to prevent servers from blocking headless requests from asset discovery. SDKs can gather a more suitable user agent from the browser where the DOM was captured from and provide this user agent to the CLI automatically.