### PR TITLE
🐛 Use correct Chromium download path for win32

### DIFF
--- a/packages/core/src/install.js
+++ b/packages/core/src/install.js
@@ -24,13 +24,13 @@ function installChromium({
       linux: `Linux_x64/${revision}/chrome-linux.zip`,
       darwin: `Mac/${revision}/chrome-mac.zip`,
       win64: `Win_x64/${revision}/chrome-win.zip`,
-      win32: `Win/${revision}/chrome-win32.zip`
+      win32: `Win/${revision}/chrome-win.zip`
     });
 
   let executable = selectByPlatform({
     linux: path.join('chrome-linux', 'chrome'),
     win64: path.join('chrome-win', 'chrome.exe'),
-    win32: path.join('chrome-win32', 'chrome.exe'),
+    win32: path.join('chrome-win', 'chrome.exe'),
     darwin: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium')
   });
 


### PR DESCRIPTION
## What is this?

After a revision somewhere around ~600000, zip files for the win32 platform dropped the 32 from their suffix. Before the recent-ish Chromium upgrade, we actually used a revision from before this change. Now that we have passed this range, we shouldn't need the 32 suffix unless Chromium changes again.