### PR TITLE
🐛 Do not serialize frames without document elements

### DIFF
--- a/packages/dom/src/serialize-frames.js
+++ b/packages/dom/src/serialize-frames.js
@@ -12,13 +12,13 @@ export default function serializeFrames(dom, clone, { enableJavaScript }) {
     if (clone.head.contains(cloneEl)) {
       cloneEl.remove();
 
-    // if the frame document is accessible, we can serialize it
-    } else if (frame.contentDocument) {
+    // if the frame document is accessible and not empty, we can serialize it
+    } else if (frame.contentDocument && frame.contentDocument.documentElement) {
       // js is enabled and this frame was built with js, don't serialize it
-      if (enableJavaScript && builtWithJs) { continue; }
+      if (enableJavaScript && builtWithJs) continue;
 
       // the frame has yet to load and wasn't built with js, it is unsafe to serialize
-      if (!builtWithJs && !frame.contentWindow.performance.timing.loadEventEnd) { continue; }
+      if (!builtWithJs && !frame.contentWindow.performance.timing.loadEventEnd) continue;
 
       // recersively serialize contents
       let serialized = serializeDOM({

--- a/packages/dom/test/serialize-frames.test.js
+++ b/packages/dom/test/serialize-frames.test.js
@@ -22,6 +22,10 @@ describe('serializeFrames', () => {
         this.document.body.innerHTML = '<p>made with js src</p>'
       )"></iframe>
       <iframe id="frame-js-no-src"></iframe>
+      <iframe id="frame-empty" srcdoc="<input/>"></iframe>
+      <iframe id="frame-empty-self" src="javascript:void(
+        Object.defineProperty(this.document, 'documentElement', { value: null })
+      )"></iframe>
     `);
 
     let $frameInput = await getFrame('frame-input');
@@ -29,6 +33,10 @@ describe('serializeFrames', () => {
 
     let $frameJS = await getFrame('frame-js-no-src');
     $frameJS.contentDocument.body.innerHTML = '<p>generated iframe</p>';
+
+    let $frameEmpty = await getFrame('frame-empty');
+    await I.type(() => $frameEmpty.contentDocument.querySelector('input'), 'no document element');
+    Object.defineProperty($frameEmpty.contentDocument, 'documentElement', { value: null });
 
     let $frameHead = document.createElement('iframe');
     $frameHead.id = 'frame-head';
@@ -86,6 +94,12 @@ describe('serializeFrames', () => {
     expect($('#frame-js')[0].getAttribute('src')).not.toBeNull();
     expect($('#frame-js')[0].getAttribute('srcdoc')).toBeNull();
     expect($('#frame-js-no-src')[0].getAttribute('srcdoc')).toBeNull();
+  });
+
+  it('does not serialize iframes without document elements', () => {
+    expect($('#frame-empty')[0]).toBeDefined();
+    expect($('#frame-empty')[0].getAttribute('srcdoc')).toBe('<input/>');
+    expect($('#frame-empty-self')).toHaveSize(0);
   });
 
   it('removes iframes from the head element', () => {


### PR DESCRIPTION
## Purpose

It seems that in some circumstances an iframe's `documentElement` may be null which then causes serialization errors. After some research, it appears this property may be null when accessed before the document has finished loading, if the document does not contain an element such as empty documents, or if a script purposefully unsets the property.

## Approach

Add another check, in addition to the `contentDocument` check, for `documentElement`. Tests are performed by unsetting the property before serialization.

Fixes #329