### PR TITLE
🐛 Default host port for proxy requests

### DIFF
--- a/packages/client/src/request.js
+++ b/packages/client/src/request.js
@@ -90,10 +90,9 @@ export class ProxyHttpsAgent extends https.Agent {
     };
 
     // write proxy connect message to the socket
-    let connectMessage = [
-      `CONNECT ${uri.host} HTTP/1.1`,
-      `Host: ${uri.host}`
-    ];
+    /* istanbul ignore next: port is always present for localhost tests */
+    let host = `${uri.hostname}:${uri.port || 443}`;
+    let connectMessage = [`CONNECT ${host} HTTP/1.1`, `Host: ${host}`];
 
     if (proxy.username) {
       let auth = proxy.username;

--- a/packages/core/src/install.js
+++ b/packages/core/src/install.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import https from 'https';
 import logger from '@percy/logger';
+import { ProxyHttpsAgent } from '@percy/client/dist/request';
 import readableBytes from './utils/bytes';
 
 // Returns an item from the map keyed by the current platform
@@ -75,7 +76,9 @@ async function install({
       await fs.promises.mkdir(outdir, { recursive: true });
 
       // download the file at the given URL
-      await new Promise((resolve, reject) => https.get(url, response => {
+      await new Promise((resolve, reject) => https.get(url, {
+        agent: new ProxyHttpsAgent() // allow proxied requests
+      }, response => {
         // on failure, resume the response before rejecting
         if (response.statusCode !== 200) {
           response.resume();


### PR DESCRIPTION
## What is this?

While the URL `host` is supposed to contain the `hostname` and `port`, it actually does not always. Similarly, sometimes `port` can be missing as well. In the proxy agent, we were relying on `host`,  but need to actually use `hostname` and `port` separately while also using a default port. This default port does get picked up by coverage since our `localhost` test URLs use specific ports.

This PR also adds proxy agent utilization to browser installation to allow browser downloads to flow through proxies as well.