### PR TITLE
🐛 Stop core config reloading when already loaded via the CLI

### DIFF
--- a/packages/cli-command/src/command.js
+++ b/packages/cli-command/src/command.js
@@ -59,9 +59,14 @@ export default class PercyCommand extends Command {
     ), {});
 
     // will also validate config and log warnings
-    return PercyConfig.load({
+    let config = PercyConfig.load({
       path: this.flags.config,
       overrides
+    });
+
+    // set config: false to prevent core from reloading config
+    return Object.assign(config, {
+      config: false
     });
   }
 }

--- a/packages/cli-command/test/command.test.js
+++ b/packages/cli-command/test/command.test.js
@@ -131,6 +131,7 @@ describe('PercyCommand', () => {
 
       expect(results[0].percyrc()).toEqual({
         version: 2,
+        config: false,
         snapshot: {
           widths: [375, 1280],
           minHeight: 1024,


### PR DESCRIPTION
## What is this?

I've noticed (especially without a config file present) that the config debug logs will log twice. This is because we load the config in the CLI using `this.percyrc()` and core also auto loads the config itself.

By automatically setting the `config: false` option in `this.percyrc()`, when passed to core it will not reload the config file and instead merge defaults with the provided options already loaded from the file.