### PR TITLE
✨ Add retry options to internal request util

### DIFF
--- a/packages/client/src/request.js
+++ b/packages/client/src/request.js
@@ -129,7 +129,7 @@ function shouldRetryRequest(error) {
 // when a non-successful response is received. The rejected error contains
 // response data and any received error details. Server 500 errors are retried
 // up to 5 times at 50ms intervals.
-export default function request(url, { body, retries, interval, ...options } = {}) {
+export default function request(url, { body, retries, interval, ...options }) {
   /* istanbul ignore next: the client api is https only, but this helper is borrowed in some
    * cli-exec commands for its retryability with the internal api */
   let { request } = url.startsWith('https:') ? https : http;

--- a/packages/client/src/request.js
+++ b/packages/client/src/request.js
@@ -129,7 +129,7 @@ function shouldRetryRequest(error) {
 // when a non-successful response is received. The rejected error contains
 // response data and any received error details. Server 500 errors are retried
 // up to 5 times at 50ms intervals.
-export default function request(url, { body, ...options }) {
+export default function request(url, { body, retries, interval, ...options } = {}) {
   /* istanbul ignore next: the client api is https only, but this helper is borrowed in some
    * cli-exec commands for its retryability with the internal api */
   let { request } = url.startsWith('https:') ? https : http;
@@ -169,5 +169,5 @@ export default function request(url, { body, ...options }) {
       })
       .on('error', handleError)
       .end(body);
-  });
+  }, { retries, interval });
 }

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -59,7 +59,7 @@ export function pool(generator, context, concurrency) {
 // will recursively call the function at the specified interval until retries
 // are exhausted, at which point the promise will reject with the last error
 // passed to `retry`.
-export function retry(fn, { retries = 5, interval = 50 } = {}) {
+export function retry(fn, { retries = 5, interval = 50 }) {
   return new Promise((resolve, reject) => {
     // run the function, decrement retries
     let run = () => {


### PR DESCRIPTION
## What is this?

When utilizing this util outside of client, it can be useful to configure retry options. These options are available, but never used by client itself since the defaults are acceptable.