### PR TITLE
✨ Allow setting client's API url via an environment variable

### DIFF
--- a/packages/client/test/proxy.test.js
+++ b/packages/client/test/proxy.test.js
@@ -170,6 +170,20 @@ describe('Proxied PercyClient', () => {
     expect(proxy.connects).toEqual([]);
   });
 
+  it('is not proxied when not using a secure https api url', async () => {
+    await server.close();
+    server = await createTestServer(http, 8080).start();
+
+    client = new PercyClient({
+      token: 'PERCY_TOKEN',
+      apiUrl: 'http://localhost:8080'
+    });
+
+    await client.get('foo');
+    await expectAsync(client.get('foo')).toBeResolvedTo('test');
+    expect(proxy.connects).toEqual([]);
+  });
+
   it('is sent with basic proxy auth username', async () => {
     process.env.HTTP_PROXY = 'http://user@localhost:1337';
     await expectAsync(client.get('foo')).toBeResolvedTo('test proxied');


### PR DESCRIPTION
## What is this?

In the world of `@percy/agent`, setting the `PERCY_API` environment variable allowed you to override the URL used by client to communicate with the Percy API. That behavior was lost when moving to the new `@percy/cli` world, but can be useful when manually testing or interacting with a local development API.

With client's proxy agent, we indiscriminately proxy all API requests through HTTPS since our production API server is guaranteed to be HTTPS. However, with the potential to change the API URL to a locally hosted URL, it might not always be HTTPS. So we need to check the protocol of the API URL to disable the HTTPS proxy agent and allow the `request` util to default to the appropriate agent based on the request's protocol.

This shouldn't be used by end users, so `PERCY_API` felt too user friendly. I decided on `PERCY_CLIENT_API_URL` (to be hyper specific) but am open to changing it.