### PR TITLE
✨ Roll asset discovery browser to Chrome 92

### DIFF
--- a/.github/.cache-key
+++ b/.github/.cache-key
@@ -1,1 +1,1 @@
-4
+Times we have broken CI: 1

--- a/packages/core/src/install.js
+++ b/packages/core/src/install.js
@@ -84,12 +84,12 @@ function installChromium({
   });
 }
 
-// default chromium revisions corresponds to v87.0.4280.x
+// default chromium revisions corresponds to v92.0.4515.x
 installChromium.revisions = {
-  linux: '812847',
-  win64: '812845',
-  win32: '812822',
-  darwin: '812851'
+  linux: '885264',
+  win64: '885282',
+  win32: '885263',
+  darwin: '885263'
 };
 
 // Installs an executable from a url to a local directory, returning the full path to the extracted

--- a/scripts/chromium-revision
+++ b/scripts/chromium-revision
@@ -17,7 +17,8 @@ EXAMPLE
 `), process.exit());
 
 // Required after usage for speedy help output
-const { request } = require('@percy/client/dist/utils');
+const readline = require('readline');
+const request = require('@percy/client/dist/request').default;
 const logger = require('@percy/logger');
 const log = logger('script');
 


### PR DESCRIPTION
## What is this?

This rolls the asset discovery browser used by `@percy/core` forward to Chrome 92 (from 87)

### Notes

This PR was originally for Chrome 91, but after a week of trying to debug/diagnose Windows issues with asset discovery in tests (and real life, likely), it made sense to move on and try a newer version. Chrome 92 passed all our tests on the first go, so we're going to roll forward with 92.