### PR TITLE
🐛 Fix unintentionally removing the default queue concurrency

### DIFF
--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -58,7 +58,8 @@ export default class Percy {
       ? PercyConfig.getDefaults(options)
       : PercyConfig.load({ path: config, overrides: options });
 
-    this.#snapshots.concurrency = this.config.discovery.concurrency;
+    let { concurrency } = this.config.discovery;
+    if (concurrency) this.#snapshots.concurrency = concurrency;
     if (this.deferUploads) this.#uploads.pause();
 
     this.client = new PercyClient({

--- a/packages/core/src/queue.js
+++ b/packages/core/src/queue.js
@@ -42,13 +42,11 @@ export default class Queue {
   }
 
   run() {
-    if (!this.running && !this.closed) {
-      this.running = true;
+    this.running = !this.closed;
 
-      while (this.running && this.#queued.size && (
-        this.#pending.size < this.concurrency
-      )) this._dequeue();
-    }
+    while (this.running && this.#queued.size && (
+      this.#pending.size < this.concurrency
+    )) this._dequeue();
 
     return this;
   }


### PR DESCRIPTION
## What is this?

With recent changes from #369, when `config.discovery.concurrency` is not defined, it is still being set on the queue causing the default of 5 to be removed. This enables infinite concurrency which is not what we want since it causes a huge slowdown as more and more resources are consumed in parallel