### PR TITLE
♻️ Post core refactor tweaks

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -28,7 +28,9 @@ export function createRequestHandler({ disableCache, getResource }, m) {
       log.debug(`Encountered an error handling request: ${url}`, meta);
       log.debug(error);
 
-      await request.abort(error);
+      /* istanbul ignore next: race condition */
+      await request.abort(error)
+        .catch(e => log.debug(e, meta));
     }
   };
 }

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -25,7 +25,10 @@ export default class Network {
     this.page.on('Network.eventSourceMessageReceived', this._handleEventSourceMessageReceived);
     this.page.on('Network.loadingFinished', this._handleLoadingFinished);
     this.page.on('Network.loadingFailed', this._handleLoadingFailed);
-    this.page.send('Network.enable');
+
+    /* istanbul ignore next: race condition */
+    this.page.send('Network.enable')
+      .catch(e => this.log.debug(e, this.page.meta));
   }
 
   // Enable request interception

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -88,6 +88,9 @@ export default class Page extends EventEmitter {
 
     await this.#browser.send('Target.closeTarget', {
       targetId: this.#targetId
+    }).catch(error => {
+      /* istanbul ignore next: race condition */
+      this.log.debug(error, this.meta);
     });
   }
 

--- a/packages/core/test/unit/queue.test.js
+++ b/packages/core/test/unit/queue.test.js
@@ -18,7 +18,7 @@ describe('Unit / Tasks Queue', () => {
   });
 
   it('has a default concurrency', () => {
-    expect(new Queue()).toHaveProperty('concurrency', 5);
+    expect(new Queue()).toHaveProperty('concurrency', 10);
   });
 
   it('can set a specific concurrency', () => {
@@ -44,9 +44,9 @@ describe('Unit / Tasks Queue', () => {
       await expectAsync(q.push(1, task(100, () => n++))).toBeResolvedTo(1);
       expect(n).toBe(2);
 
-      await expectAsync(q.push(2, task(0, () => {
+      await expectAsync(q.push(2, () => {
         throw new Error('some error');
-      }))).toBeRejectedWithError('some error');
+      })).toBeRejectedWithError('some error');
     });
 
     it('can run tasks according to priority', async () => {


### PR DESCRIPTION
## What is this?

Following #369 and subsequently #372, I've since found a couple other minor thing that need to be tweaked.

- In agent, up to 10 browser pages were pooled to be running at once. It was lowered in the CLI since moving to a proper queue with a concurrency. Now that queue performance has gotten much better, let's up it to 10 again. Even in previous versions of the CLI up to 10 browser pages could be running when using the capture method, so being able to set this more accurately is a win from #369.

- Rename `queue.pause()` to `queue.stop()` (🚲 🏠). Pause implies that there is still more to run, while stop implies that it won't run regardless if there is more to run. Stop also feels more complimentary to `run()`.

- Add ability for `close()` to abort. This will stop and clear the queue while closing it, exactly what is really needed by the `percy.close()` method.

- Abort queue when force stopping the Percy instance. Rather than clear the queues which will be closed, when force stopping we can utilize `percy.close()` to wholesale abort any currently queued tasks. 

- Catch sync errors when running queued tasks. While wrapping the dequeued callback in a resolve served to catch async errors, sync errors could still happen which would cause pending tasks to never be cleared.

- While testing Storybook and sending a SIGTERM event, I noticed that there were occasional unhandled promise rejections caused by page/browser closed errors bubbling from random event callbacks. The closed errors always bubble and get raised from other methods, so in these few unhandled rejections, we can simply log a debug message to handle it. Coverage was skipped for these catches since they all only occur in specific race conditions.