### PR TITLE
✨  Add basic parallel nonce support for GitHub actions

### DIFF
--- a/packages/env/src/environment.js
+++ b/packages/env/src/environment.js
@@ -240,6 +240,8 @@ export default class PercyEnvironment {
           return this.vars.BUILD_ID;
         case 'bitbucket':
           return this.vars.BITBUCKET_BUILD_NUMBER;
+        case 'github':
+          return this.vars.GITHUB_RUN_ID;
       }
     })();
 

--- a/packages/env/test/github.test.js
+++ b/packages/env/test/github.test.js
@@ -22,7 +22,7 @@ describe('GitHub', () => {
 
     env = new PercyEnvironment({
       PERCY_PARALLEL_TOTAL: '-1',
-      PERCY_PARALLEL_NONCE: 'job-id',
+      GITHUB_RUN_ID: 'job-id',
       GITHUB_ACTIONS: 'true',
       GITHUB_EVENT_PATH: ghEventFile
     });

--- a/packages/env/test/github.test.js
+++ b/packages/env/test/github.test.js
@@ -21,6 +21,8 @@ describe('GitHub', () => {
     }));
 
     env = new PercyEnvironment({
+      PERCY_PARALLEL_TOTAL: '-1',
+      PERCY_PARALLEL_NONCE: 'job-id',
       GITHUB_ACTIONS: 'true',
       GITHUB_EVENT_PATH: ghEventFile
     });
@@ -38,8 +40,8 @@ describe('GitHub', () => {
     expect(env).toHaveProperty('target.commit', null);
     expect(env).toHaveProperty('target.branch', null);
     expect(env).toHaveProperty('pullRequest', 10);
-    expect(env).toHaveProperty('parallel.nonce', null);
-    expect(env).toHaveProperty('parallel.total', null);
+    expect(env).toHaveProperty('parallel.nonce', 'job-id');
+    expect(env).toHaveProperty('parallel.total', -1);
   });
 
   it('has env info for custom actions', () => {


### PR DESCRIPTION
## What is this?

This will at least get the happy path of parallel builds going. We'll need an advanced doc to highlight the issues with this (`GITHUB_RUN_ID` is not unique on rebuilds, which will cause Percy to fail). Touches on #296, but doesn't completely solve it. 