### PR TITLE
✨ Better progress logging

### DIFF
--- a/packages/cli-build/test/wait.test.js
+++ b/packages/cli-build/test/wait.test.js
@@ -20,7 +20,7 @@ describe('percy build:wait', () => {
   beforeEach(() => {
     process.env.PERCY_TOKEN = '<<PERCY_TOKEN>>';
     mockAPI.start();
-    logger.mock();
+    logger.mock({ isTTY: true });
   });
 
   afterEach(() => {

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -229,8 +229,8 @@ export default class PercyClient {
         }
 
         // call progress every update after the first update
-        if ((last || pending) && updated && onProgress) {
-          onProgress(data);
+        if ((last || pending) && updated) {
+          onProgress?.(data);
         }
 
         // not finished, poll again
@@ -239,6 +239,8 @@ export default class PercyClient {
 
         // build finished
         } else {
+          // ensure progress is called at least once
+          if (!last) onProgress?.(data);
           resolve({ data });
         }
       } catch (err) {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -94,11 +94,11 @@ queues are cleared and closed to prevent queued snapshots from running.
 
 ``` js
 await percy.stop()
-// [percy] Waiting for snapshots to finish processing...
+// [percy] Processing 3 snapshots...
 // [percy] Snapshot taken: Snapshot one
 // [percy] Snapshot taken: Snapshot two
 // [percy] Snapshot taken: Snapshot three
-// [percy] Uploading snapshots...
+// [percy] Uploading 3 snapshots...
 // [percy] Finalized build #1: https://percy.io/org/project/123
 
 await percy.stop(true)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,6 @@
     "@percy/logger": "^1.0.0-beta.52",
     "cross-spawn": "^7.0.3",
     "extract-zip": "^2.0.1",
-    "progress": "^2.0.3",
     "rimraf": "^3.0.2",
     "ws": "^7.4.1"
   }

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -181,14 +181,18 @@ export default class Percy {
 
     // close the snapshot queue and wait for it to empty
     if (this.#snapshots.close().length) {
-      this.log.info('Waiting for snapshots to finish processing...', meta);
-      await this.#snapshots.empty();
+      await this.#snapshots.empty(len => {
+        this.log.progress(`Processing ${len}` + (
+          ` snapshot${len !== 1 ? 's' : ''}...`), !!len);
+      });
     }
 
     // run, close, and wait for the upload queue to empty
     if (this.#uploads.run().close().length) {
-      this.log.info('Uploading snapshots...', meta);
-      await this.#uploads.empty();
+      await this.#uploads.empty(len => {
+        this.log.progress(`Uploading ${len}` + (
+          ` snapshot${len !== 1 ? 's' : ''}...`), !!len);
+      });
     }
 
     // close the any running server and browser

--- a/packages/core/src/queue.js
+++ b/packages/core/src/queue.js
@@ -66,8 +66,11 @@ export default class Queue {
     await waitFor(() => !this.#pending.size, { idle: 10 });
   }
 
-  async empty() {
-    await waitFor(() => !this.length, { idle: 10 });
+  async empty(onCheck) {
+    await waitFor(() => {
+      onCheck?.(this.length);
+      return !this.length;
+    }, { idle: 10 });
   }
 
   async flush() {

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -322,7 +322,7 @@ describe('Percy', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual(jasmine.arrayContaining([
-        '[percy] Waiting for snapshots to finish processing...',
+        '[percy] Processing 1 snapshot...',
         '[percy] Snapshot taken: test snapshot',
         '[percy] Finalized build #1: https://percy.io/test/test/123'
       ]));

--- a/packages/core/test/unit/install.test.js
+++ b/packages/core/test/unit/install.test.js
@@ -41,7 +41,7 @@ describe('Unit / Install', () => {
 
     // all options are required
     options = {
-      name: 'Test Download',
+      name: 'Archive',
       revision: 'v0',
       url: 'https://fake-download.org/archive.zip',
       extract: jasmine.createSpy('extract').and.resolveTo(),
@@ -82,9 +82,9 @@ describe('Unit / Install', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Test Download not found, downloading...',
-      '[percy] 16B (v0) [====================] 100% 0.0s', '',
-      '[percy] Successfully downloaded Test Download'
+      '[percy] Downloading Archive v0...',
+      '[percy] Downloading Archive v0 [====================] 16B/16B 100% 00:00',
+      '[percy] Successfully downloaded Archive v0'
     ]);
   });
 
@@ -127,7 +127,7 @@ describe('Unit / Install', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toContain(
-      '[percy] 19.1MB (v0) [====================] 100% 0.0s'
+      '[percy] Downloading Archive v0 [====================] 19.1MB/19.1MB 100% 00:00'
     );
   });
 
@@ -202,11 +202,10 @@ describe('Unit / Install', () => {
         expect(dlcallback).toHaveBeenCalledOnceWith(expected.url);
 
         expect(logger.stderr).toEqual([]);
-        expect(logger.stdout).toEqual([
-          '[percy] Chromium not found, downloading...',
-          jasmine.stringMatching(`(${expected.revision})`), '',
-          '[percy] Successfully downloaded Chromium'
-        ]);
+        expect(logger.stdout).toEqual(jasmine.arrayContaining([
+          `[percy] Downloading Chromium ${expected.revision}...`,
+          `[percy] Successfully downloaded Chromium ${expected.revision}`
+        ]));
       });
     }
   });

--- a/packages/logger/src/browser.js
+++ b/packages/logger/src/browser.js
@@ -13,4 +13,8 @@ export default class BrowserLogger extends PercyLogger {
 
     console[out](message, ...colors);
   }
+
+  progress() {
+    console.error('The log.progress() method is not supported in browsers');
+  }
 }

--- a/packages/logger/test/helpers.js
+++ b/packages/logger/test/helpers.js
@@ -22,6 +22,10 @@ function TestIO(data, options) {
     let { Writable } = require('stream');
 
     return Object.assign(new Writable(), {
+      isTTY: options?.isTTY,
+      cursorTo() {},
+      clearLine() {},
+
       _write(chunk, encoding, callback) {
         data.push(sanitizeLog(chunk.toString(), options));
         callback();

--- a/packages/logger/test/helpers.js
+++ b/packages/logger/test/helpers.js
@@ -22,7 +22,7 @@ function TestIO(data, options) {
     let { Writable } = require('stream');
 
     return Object.assign(new Writable(), {
-      isTTY: options?.isTTY,
+      isTTY: options && options.isTTY,
       cursorTo() {},
       clearLine() {},
 

--- a/scripts/chromium-revision
+++ b/scripts/chromium-revision
@@ -17,7 +17,6 @@ EXAMPLE
 `), process.exit());
 
 // Required after usage for speedy help output
-const readline = require('readline');
 const { request } = require('@percy/client/dist/utils');
 const logger = require('@percy/logger');
 const log = logger('script');
@@ -42,25 +41,14 @@ const G_STORAGE_PREFIXES = {
 // Runs a stateful async function repeatedly until it returns a truthy value while updating a log
 // message with ellipses for each iteration of the task function
 async function task({ message, state: init, function: fn }) {
-  try {
-    return await (async function run(state) {
-      let i = state.i = (state.i || 0) + 1;
+  return await (async function run(state) {
+    // log the message with an additional period for each iteration
+    let i = state.i = (state.i || 0) + 1;
+    log.progress(message(state, '.'.repeat(i)));
 
-      // clear the current line
-      readline.clearLine(logger.stdout);
-      readline.cursorTo(logger.stdout, 0);
-      // log the message with an additional period for each iteration
-      logger.stdout.write(
-        logger.format(message(state, '.'.repeat(i)), 'script')
-      );
-
-      // if the function does not return, run again
-      return await fn(state) || run(state);
-    })((init?.() || {}));
-  } finally {
-    // this ensures errors will log on their own line
-    logger.stdout.write('\n');
-  }
+    // if the function does not return, run again
+    return await fn(state) || run(state);
+  })((init?.() || {}));
 }
 
 // The actual script that prints a revision corresponding to the provided version for each platform

--- a/yarn.lock
+++ b/yarn.lock
@@ -7180,7 +7180,7 @@ process-on-spawn@^1.0.0:
   dependencies:
     fromentries "^1.2.0"
 
-progress@^2.0.0, progress@^2.0.3:
+progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==


### PR DESCRIPTION
## Purpose

There are two logs in particular that would be nice to have some progress associated with them. The processing snapshot queue log and the snapshot uploading queue log.

When SDKs such as Storybook or the snapshot command quickly take and process snapshots via asset discovery, the end result could be waiting for hundreds of snapshots to upload. To prevent clogging up processes with hundreds of in-flight requests at once, uploads are queued just as asset discovery is. 

This results in a single log at the end of snapshot processing, before finalizing the build, when snapshots are uploading: `Waiting for X snapshots to finish uploading`. With #369, the message was changed to be more generic: `Uploading snapshots...`. Which is arguably less helpful, but in either case the CLI could be waiting for up to a minute while snapshots are uploaded. Meanwhile there is no feedback from the user's perspective.

## Approach

During the refactor, while updating the CLI build plugin to work with client changes, I noticed that the code we use to log progress for the wait command was fairly simple and straightforward; and could be adapted to the above use case. The core pieces of progress logging code was moved into a new `logger.progress()` method and exposed for loggers. This method will not capture message to the internal log store since it is meant for visual purposes and not for debugging.

Where the wait command would always clear the line and not log progress before finished or failed logs were printed, we can take a slightly different approach to achieve the same effect. Rather than always clear the entire line, we can clear the line to the right of the cursor after printing a new message over the existing line. This helps to prevent some flicker between when the line was cleared and when new logs are printed. 

For the snapshot queue logs, snapshots can continue to be taken once the queue is awaited one. The build will only be finalized once both the snapshot and upload queues have completely emptied. Because other logs can be printed while waiting on the snapshot queue, a `persist` option can be provided which will re-print the progress log after other logs clear it.

I also updated the install script progress logger to use our new method. Likewise with the build command that inspired the method, and even the browser revision script.

## Preview

https://user-images.githubusercontent.com/5005153/122619596-68dcd580-d056-11eb-8367-1603488d26a1.mp4

(sped up a little for brevity)



