### PR TITLE
✨ Allow snapshotting a list of pages to utilize the base-url flag

### DIFF
--- a/packages/cli-command/src/command.js
+++ b/packages/cli-command/src/command.js
@@ -48,7 +48,7 @@ export default class PercyCommand extends Command {
   // respective `percyrc` parameter. The flag input is then merged with options
   // loaded from a config file and default config options. The PERCY_TOKEN
   // environment variable is also included as a convenience.
-  percyrc() {
+  percyrc(initialOverrides = {}) {
     let flags = Object.entries(this.constructor.flags);
     let overrides = flags.reduce((conf, [name, flag]) => (
       flag.percyrc?.split('.').reduce((target, key, i, paths) => {
@@ -56,7 +56,7 @@ export default class PercyCommand extends Command {
         target[key] = last ? this.flags[name] : (target[key] ?? {});
         return last ? conf : target[key];
       }, conf) ?? conf
-    ), {});
+    ), initialOverrides);
 
     // will also validate config and log warnings
     let config = PercyConfig.load({

--- a/packages/cli-snapshot/src/commands/snapshot.js
+++ b/packages/cli-snapshot/src/commands/snapshot.js
@@ -72,7 +72,7 @@ export class Snapshot extends Command {
     }
 
     let { 'base-url': baseUrl, 'dry-run': dry } = this.flags;
-    let isStatic = fs.lstatSync(pathname).isDirectory()
+    let isStatic = fs.lstatSync(pathname).isDirectory();
 
     if (baseUrl) {
       if (isStatic && !baseUrl.startsWith('/')) {

--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -5,7 +5,11 @@ export const schema = {
     properties: {
       baseUrl: {
         type: 'string',
-        default: '/'
+        pattern: '^/',
+        default: '/',
+        errors: {
+          pattern: 'must start with a forward slash (/)'
+        }
       },
       files: {
         anyOf: [

--- a/packages/cli-snapshot/test/snapshot.test.js
+++ b/packages/cli-snapshot/test/snapshot.test.js
@@ -42,7 +42,7 @@ describe('percy snapshot', () => {
     }], { depth: null }) + ')');
     fs.writeFileSync('nope', 'not here');
     fs.writeFileSync('urls.yml', [
-      '- /', '- /one', '- /two',
+      '- /', '- /one', '- /two'
     ].join('\n'));
   });
 
@@ -282,7 +282,7 @@ describe('percy snapshot', () => {
         '[percy] Found 1 snapshot',
         '[percy] Snapshot found: JS Snapshot',
         '[percy] Snapshot found: JS Snapshot 2',
-        '[percy] Snapshot found: Other JS Snapshot',
+        '[percy] Snapshot found: Other JS Snapshot'
       ]);
     });
   });

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -115,7 +115,7 @@ describe('PercyConfig', () => {
     it('returns a passing result with no errors', () => {
       expect(PercyConfig.validate({
         version: 2,
-        test: { value: 'testing' },
+        test: { value: 'testing' }
       })).toEqual({
         result: true,
         errors: []
@@ -145,7 +145,7 @@ describe('PercyConfig', () => {
       expect(PercyConfig.validate({
         test: { value: 1, foo: 'bar' },
         foo: 'He11o',
-        bar: 'qux',
+        bar: 'qux'
       })).toEqual({
         result: false,
         errors: [{

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -115,7 +115,7 @@ describe('PercyConfig', () => {
     it('returns a passing result with no errors', () => {
       expect(PercyConfig.validate({
         version: 2,
-        test: { value: 'testing' }
+        test: { value: 'testing' },
       })).toEqual({
         result: true,
         errors: []
@@ -123,8 +123,29 @@ describe('PercyConfig', () => {
     });
 
     it('returns a failing result with errors', () => {
+      PercyConfig.addSchema({
+        foo: {
+          type: 'string',
+          pattern: '^[a-zA-z]*$',
+          errors: {
+            pattern: 'must not contain numbers'
+          }
+        },
+        bar: {
+          type: 'string',
+          const: 'baz',
+          errors: {
+            const({ data }) {
+              return `must not be ${data}`;
+            }
+          }
+        }
+      });
+
       expect(PercyConfig.validate({
-        test: { value: 1, foo: 'bar' }
+        test: { value: 1, foo: 'bar' },
+        foo: 'He11o',
+        bar: 'qux',
       })).toEqual({
         result: false,
         errors: [{
@@ -133,6 +154,12 @@ describe('PercyConfig', () => {
         }, {
           path: ['test', 'value'],
           message: 'must be a string, received a number'
+        }, {
+          path: ['foo'],
+          message: 'must not contain numbers'
+        }, {
+          path: ['bar'],
+          message: 'must not be qux'
         }]
       });
     });

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -153,10 +153,10 @@ export function getSnapshotConfig({
     additionalSnapshots ??= deprecated.snapshots;
   }
 
-  // default name to the URL /path?search#hash
+  // default name to the URL /pathname?search#hash
   if (!name) {
     let uri = new URL(url);
-    name = `${uri.path}${uri.search}${uri.hash}`;
+    name = `${uri.pathname}${uri.search}${uri.hash}`;
   }
 
   // additional snapshots must be named but allow inheritance with a prefix/suffix


### PR DESCRIPTION
## What is this?

This PR refactors and tweaks the `percy snapshot` command to be a little more friendly.

First, a page listing no longer needs to be a list of objects containing at least a `url` property. Now the file can contain just a list of URLs in the appropriate format:

```yaml
# snapshots.yml
- https://example.com
- https://example.com/about
- https://example.com/contact
```

Second, the `--base-url` flag was made to work with page listings in addition to the existing static directory usage. Since usage differs between page listings and static directories however, some other small adjustments were necessary.

For static directories, the base URL should be the base **_PATHNAME_** that the site would be hosted at. Most sites are hosted at the domain root (`/`), however some sites might be hosted at other paths (e.g. `/blog`). This requirement has been present since the `@percy/agent` snapshot command and continues to remain a requirement.

For page listings, the base URL should be the _entire base URL_ including the **protocol** and **hostname**. For example, the above list of URLs can be simplified to remove the common base URL:

```yaml
# snapshots.yml
- /
- /about
- /contact
```

```sh
$ percy snapshot --base-url https://example.com snapshots.yml
```

To prevent mixing up the `static.base-url` configuration option with the page listing flag, a couple other changes were also made. The flag is no longer auto-mapped to the configuration option via the `percyrc` flag property. Instead, it is passed along to the `.percyrc()` method which now accepts an initial overrides argument. 

The `static.base-url` configuration option was no longer being checked for the leading forward slash (only the flag is checked by the command now). A pattern requirement was added to the schema, and custom errors messages were added to config validation to print a better error message than what is normally printed for pattern failures. We can also utilize this pattern to do other better config validations in the future such as for certain discovery options.

The `--dry-run` flag will now print a better list of snapshots, however the default `name` in core is only created when calling the snapshot method. The default name was also added here so dry runs can properly print it. When adding the default name here, I discovered a small bug in the core implementation in which `uri.path` needed to be replaced with `uri.pathname`.