### PR TITLE
✨ Allow setting discovery browser cookies

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -52,6 +52,7 @@ The following options can also be defined within a Percy config file
   - `authorization` — Basic auth `username` and `password` for protected snapshot assets
   - `disableCache` — Disable asset caching (**default** `false`)
   - `userAgent` — Custom user-agent string used when requesting assets
+  - `cookies` — Browser cookies to use when requesting assets
   - `networkIdleTimeout` — Milliseconds to wait for the network to idle (**default** `100`)
   - `concurrency` — Asset discovery concerrency (**default** `5`)
   - `launchOptions` — Asset discovery browser launch options

--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -59,6 +59,10 @@ export default class Browser extends EventEmitter {
     this.executable = executable;
     this.headless = headless;
     this.args = args;
+
+    // transform cookies object to an array of cookie params
+    this.cookies = Array.isArray(cookies) ? cookies
+      : Object.entries(cookies).map(([name, value]) => ({ name, value }));
   }
 
   async launch() {

--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -46,30 +46,40 @@ export default class Browser extends EventEmitter {
     '--remote-debugging-port=0'
   ];
 
-  async launch({
+  constructor({
     executable = process.env.PERCY_BROWSER_EXECUTABLE,
-    args: uargs = [],
     headless = true,
+    cookies = [],
+    args = [],
     timeout
-  } = {}) {
+  }) {
+    super();
+
+    this.launchTimeout = timeout;
+    this.executable = executable;
+    this.headless = headless;
+    this.args = args;
+  }
+
+  async launch() {
     if (this.isConnected()) return;
 
     // check if any provided executable exists
-    if (executable && !existsSync(executable)) {
-      this.log.error(`Browser executable not found: ${executable}`);
-      executable = null;
+    if (this.executable && !existsSync(this.executable)) {
+      this.log.error(`Browser executable not found: ${this.executable}`);
+      this.executable = null;
     }
 
     // download and install the browser if not already present
-    this.executable = executable || await install.chromium();
+    this.executable ||= await install.chromium();
     // create a temporary profile directory
     this.profile = await fs.mkdtemp(path.join(os.tmpdir(), 'percy-browser-'));
 
     // collect args to pass to the browser process
     let args = [...this.defaultArgs, `--user-data-dir=${this.profile}`];
     /* istanbul ignore next: only false for debugging */
-    if (headless) args.push('--headless', '--hide-scrollbars', '--mute-audio');
-    for (let a of uargs) if (!args.includes(a)) args.push(a);
+    if (this.headless) args.push('--headless', '--hide-scrollbars', '--mute-audio');
+    for (let a of this.args) if (!args.includes(a)) args.push(a);
 
     // spawn the browser process detached in its own group and session
     this.process = spawn(this.executable, args, {
@@ -77,9 +87,8 @@ export default class Browser extends EventEmitter {
     });
 
     // connect a websocket to the devtools address
-    this.ws = new WebSocket(await this.address(timeout), {
-      perMessageDeflate: false
-    });
+    let addr = await this.address(this.launchTimeout);
+    this.ws = new WebSocket(addr, { perMessageDeflate: false });
 
     // wait until the websocket has connected before continuing
     await new Promise(resolve => this.ws.once('open', resolve));

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -54,6 +54,22 @@ export const schema = {
           password: { type: 'string' }
         }
       },
+      cookies: {
+        anyOf: [{
+          type: 'object',
+          additionalProperties: { type: 'string' }
+        }, {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['name', 'value'],
+            properties: {
+              name: { type: 'string' },
+              value: { type: 'string' }
+            }
+          }
+        }]
+      },
       userAgent: {
         type: 'string'
       },

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -19,7 +19,6 @@ import {
 // finalized until all snapshots have been handled.
 export default class Percy {
   log = logger('core');
-  browser = new Browser();
   readyState = null;
 
   #cache = new Map();
@@ -66,6 +65,10 @@ export default class Percy {
       token,
       clientInfo,
       environmentInfo
+    });
+
+    this.browser = new Browser({
+      ...this.config.discovery.launchOptions,
     });
 
     if (server) {

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -267,14 +267,14 @@ export default class Percy {
         maybeDebug(conf.widths, v => `-> widths: ${v.join('px, ')}px`);
         maybeDebug(conf.minHeight, v => `-> minHeight: ${v}px`);
         maybeDebug(conf.enableJavaScript, v => `-> enableJavaScript: ${v}`);
-        maybeDebug(discovery.allowedHostnames, v => `-> discovery.allowedHostnames: ${v}`);
-        maybeDebug(discovery.requestHeaders, v => `-> discovery.requestHeaders: ${JSON.stringify(v)}`);
-        maybeDebug(discovery.authorization, v => `-> discovery.authorization: ${JSON.stringify(v)}`);
-        maybeDebug(discovery.disableCache, v => `-> discovery.disableCache: ${v}`);
-        maybeDebug(discovery.userAgent, v => `-> discovery.userAgent: ${v}`);
-        maybeDebug(waitForTimeout, v => `-> waitForTimeout: ${v}`);
-        maybeDebug(waitForSelector, v => `-> waitForSelector: ${v}`);
-        maybeDebug(execute, v => `-> execute: ${v}`);
+        maybeDebug(options.discovery?.allowedHostnames, v => `-> discovery.allowedHostnames: ${v}`);
+        maybeDebug(options.discovery?.requestHeaders, v => `-> discovery.requestHeaders: ${JSON.stringify(v)}`);
+        maybeDebug(options.discovery?.authorization, v => `-> discovery.authorization: ${JSON.stringify(v)}`);
+        maybeDebug(options.discovery?.disableCache, v => `-> discovery.disableCache: ${v}`);
+        maybeDebug(options.discovery?.userAgent, v => `-> discovery.userAgent: ${v}`);
+        maybeDebug(options.waitForTimeout, v => `-> waitForTimeout: ${v}`);
+        maybeDebug(options.waitForSelector, v => `-> waitForSelector: ${v}`);
+        maybeDebug(options.execute, v => `-> execute: ${v}`);
         maybeDebug(conf.clientInfo, v => `-> clientInfo: ${v}`);
         maybeDebug(conf.environmentInfo, v => `-> environmentInfo: ${v}`);
 

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -69,6 +69,7 @@ export default class Percy {
 
     this.browser = new Browser({
       ...this.config.discovery.launchOptions,
+      cookies: this.config.discovery.cookies
     });
 
     if (server) {

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -301,9 +301,9 @@ describe('Discovery', () => {
       environmentInfo: 'test env info',
       widths: [400, 1200],
       discovery: {
-        requestHeaders: {
-          'X-Foo': 'Bar'
-        }
+        allowedHostnames: ['example.com'],
+        requestHeaders: { 'X-Foo': 'Bar' },
+        disableCache: true
       }
     });
 
@@ -318,8 +318,9 @@ describe('Discovery', () => {
       '[percy:core] -> url: http://localhost:8000',
       '[percy:core] -> widths: 400px, 1200px',
       '[percy:core] -> minHeight: 1024px',
-      '[percy:core] -> discovery.allowedHostnames: localhost',
+      '[percy:core] -> discovery.allowedHostnames: example.com',
       '[percy:core] -> discovery.requestHeaders: {"X-Foo":"Bar"}',
+      '[percy:core] -> discovery.disableCache: true',
       '[percy:core] -> clientInfo: test client info',
       '[percy:core] -> environmentInfo: test env info',
       '[percy:core:page] Initialize page',


### PR DESCRIPTION
## Purpose

Sometimes, cookies sent via a `Cookie` header don't always seem to work (#374). While I couldn't exactly reproduce a scenario where the header wouldn't work, I thought it would be helpful to have a dedicated `cookies` option anyway. The dedicated option can help avoid confusion for people who are unfamiliar with the associated header, and also allow setting cookies for specific domains or paths.

## Approach

The config schema was updated to allow a `discovery.cookies` option that can either be an object containing key-value pairs of cookies, or an array containing [cookie parameters](https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-CookieParam) with `name`, `value`, and other cookie properties.

While it was straightforward to add cookies within page initialization, I discovered that a cookie's `url` or `domain` property is also required. The cookies' object-to-param mapping was moved up into snapshot config merging so we could default a snapshot's cookie `url` to the snapshot's own URL. 

However, I then also discovered that even when used within a page session, cookies are stored for the entire browser session. This fact made it difficult to reason about whether to override clashing cookies, or clear cookies for each page. Either scenario would not be viable for concurrent pages with differing cookies.

It was then decided that cookies could not be made into per-snapshot options. Cookie normalization was moved into the browser class. The browser class was also updated to move launch options into class initialization. This makes it so some SDKs, like Storybook, can launch the browser without needing to provide redundant launch options.

Cookies still cannot be set until a page URL is known, since we need to account for default cookie URLs. If we ignored the url/domain requirement and set cookies eagerly, we would not be able to accept a key-value object and users would also need to know the url/domain in advance in their config; which makes the config less reusable for projects with dynamic staging URLs. Due to this, cookies are set (if provided) whenever a page is navigated to, before actual page navigation occurs.

## Other changes

While cookies were allowed as per-snapshot options, the per-snapshot debug log output would be merged with global config options. While it would be nice to include global config in per-snapshot logs, it can be done in a much better way in a follow up PR if desired (using log filtering). Now only provided options are logged, without merged config.