### PR TITLE
🐛 Ignore env git stderr logs

### DIFF
--- a/packages/env/src/utils.js
+++ b/packages/env/src/utils.js
@@ -14,7 +14,10 @@ const GIT_COMMIT_FORMAT = [
 
 export function git(args) {
   try {
-    return execSync(`git ${args}`, { encoding: 'utf-8' });
+    return execSync(`git ${args}`, {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf-8'
+    });
   } catch (e) {
     return '';
   }


### PR DESCRIPTION
## What is this?

If you look at our CI logs, you'll see plenty of `fatal error` messages related to git. The root of the message is because the `checkout` step of our CI does a shallow (0 history) checkout of the repo. When the git command is run with the commit sha, it cannot find the associate commit object and logs this error. 

Similarly, if the CLI is run outside of a git repo, git errors are also logged.

Turns out, this is because `execSync` defaults stderr to `inherit` rather than `pipe` which is the default of stdout, stdin, and stdio for spawn functions.

This PR explicitly sets this stdio to ignore stderr, stdin, and pipe stdout.

No test here since the only thing we could write would be "is called with the right stdio options." Which doesn't feel like a useful test anyway since those options aren't likely to change accidentally.