### PR TITLE
🐛 Fix percy-specific css resource url

### DIFF
--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -322,14 +322,13 @@ export default class Percy {
         for (let width of widths) await page.resize({ width });
 
         // create and add a percy-css resource
-        let percyCSS = conf.percyCSS && createPercyCSSResource(conf.percyCSS);
+        let percyCSS = createPercyCSSResource(url, conf.percyCSS);
         if (percyCSS) resources.set(percyCSS.url, percyCSS);
-        root &&= injectPercyCSS(root, percyCSS);
 
         if (root) {
           // ensure asset discovery has finished before uploading
           await page.network.idle();
-
+          root = injectPercyCSS(root, percyCSS);
           this.log.info(`Snapshot taken: ${name}`, meta);
           this._scheduleUpload(name, conf, [root, ...resources.values()]);
         } else {

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -30,15 +30,22 @@ export function createLogResource(logs) {
 }
 
 // Creates a Percy CSS resource object.
-export function createPercyCSSResource(css) {
-  return createResource(`/percy-specific.${Date.now()}.css`, css, 'text/css');
+export function createPercyCSSResource(url, css) {
+  if (css) {
+    let { href, pathname } = new URL(`/percy-specific.${Date.now()}.css`, url);
+    return createResource(href, css, 'text/css', { pathname });
+  }
 }
 
 // returns a new root resource with the injected Percy CSS
 export function injectPercyCSS(root, percyCSS) {
-  return percyCSS ? createRootResource(root.url, root.content.replace(/(<\/body>)(?!.*\1)/is, (
-    `<link data-percy-specific-css rel="stylesheet" href="${percyCSS.url}"/>`
-  ) + '$&')) : root;
+  if (percyCSS) {
+    return createRootResource(root.url, root.content.replace(/(<\/body>)(?!.*\1)/is, (
+      `<link data-percy-specific-css rel="stylesheet" href="${percyCSS.pathname}"/>`
+    ) + '$&'));
+  } else {
+    return root;
+  }
 }
 
 // Polls for the predicate to be truthy within a timeout or the returned promise rejects. If

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -461,7 +461,7 @@ describe('Snapshot', () => {
       let resources = getResourceData();
       expect(resources[1].id).toBe(sha256hash('p { color: purple; }'));
       expect(resources[1].attributes['resource-url'])
-        .toMatch(/\/percy-specific\.\d+\.css$/);
+        .toMatch(/localhost:8000\/percy-specific\.\d+\.css$/);
     });
 
     it('creates a resource for per-snapshot percy-css', async () => {
@@ -478,7 +478,7 @@ describe('Snapshot', () => {
       let resources = getResourceData();
       expect(resources[1].id).toBe(sha256hash('body { color: purple; }'));
       expect(resources[1].attributes['resource-url'])
-        .toMatch(/\/percy-specific\.\d+\.css$/);
+        .toMatch(/localhost:8000\/percy-specific\.\d+\.css$/);
     });
 
     it('concatenates global and per-snapshot percy-css', async () => {
@@ -494,7 +494,7 @@ describe('Snapshot', () => {
       expect(resources[1].id)
         .toBe(sha256hash('p { color: purple; }\np { font-size: 2rem; }'));
       expect(resources[1].attributes['resource-url'])
-        .toMatch(/\/percy-specific\.\d+\.css$/);
+        .toMatch(/localhost:8000\/percy-specific\.\d+\.css$/);
     });
 
     it('injects the percy-css resource into the dom snapshot', async () => {
@@ -510,9 +510,9 @@ describe('Snapshot', () => {
       await percy.idle();
 
       let root = mockAPI.requests['/builds/123/resources'][0].body.data;
-      let cssURL = getResourceData()[1].attributes['resource-url'];
+      let cssURL = new URL(getResourceData()[1].attributes['resource-url']);
       let injectedDOM = testDOM.replace('</body>', (
-       `<link data-percy-specific-css rel="stylesheet" href="${cssURL}"/>`
+       `<link data-percy-specific-css rel="stylesheet" href="${cssURL.pathname}"/>`
       ) + '</body>');
 
       expect(root.id).toEqual(sha256hash(injectedDOM));


### PR DESCRIPTION
## What is this?

Resource URLs should include the root origin, otherwise our infrastructure proxy fails to properly proxy the request over secure connections. This behavior is likely due to a default origin somewhere being http attempting to validate against https.

This PR takes advantage of `new URL(input, base)` behavior, where the origin of the second argument is used as the base of the input when the input is an absolute or relative pathname.