### PR TITLE
🐛 Always ignore existing root resources during asset discovery

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -52,7 +52,7 @@ export function createRequestFinishedHandler({
       let resource = getResource(url);
 
       // process and cache the response and resource
-      if (!resource || disableCache) {
+      if (!resource?.root && (!resource || disableCache)) {
         let response = request.response;
         let capture = response && hostnameMatches(allowedHostnames, url);
         let body = capture && await response.buffer();

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -290,6 +290,41 @@ describe('Discovery', () => {
     );
   });
 
+  it('does not capture duplicate root resources', async () => {
+    let reDOM = dedent`
+      <html><head></head><body>
+      <link rel="canonical" href="http://localhost:8000/">
+      <p>This isn't honey, Pooh. It's recursion!</p>
+      </body></html>
+    `;
+
+    await percy.snapshot({
+      name: 'test snapshot',
+      url: 'http://localhost:8000',
+      domSnapshot: reDOM,
+      discovery: {
+        // ensure root is requested from discovery
+        disableCache: true
+      }
+    });
+
+    await percy.idle();
+
+    expect(captured[0]).toEqual([
+      jasmine.objectContaining({
+        attributes: jasmine.objectContaining({
+          'resource-url': jasmine.stringMatching(/^\/percy\.\d+\.log$/)
+        })
+      }),
+      jasmine.objectContaining({
+        attributes: jasmine.objectContaining({
+          'resource-url': 'http://localhost:8000/',
+          'is-root': true
+        })
+      })
+    ]);
+  });
+
   it('logs detailed debug logs', async () => {
     percy.loglevel('debug');
 


### PR DESCRIPTION
## What is this?

In asset discovery when the cache is disabled, it doesn't matter if the `getResource` option returns an existing resource. The existing resource will always be overridden with new response. However, root resources aren't normally included with other resources. So when a root resource requests itself (such as a canonical link) and cache is disabled, a new resource is created for the root response (but `is-root` is not set since it happens during normal discovery). Later, when the root resource is added to the discovered resources, it ends up in the list of resources twice.

Fixing this is pretty straight forward. We just need to always skip capturing the root resource, even if the cache is disabled.

Fixes #388