### PR TITLE
🐛 Fix additional snapshot options

### DIFF
--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -339,7 +339,7 @@ export default class Percy {
             this.log.debug(`Taking snapshot: ${name}`, meta);
 
             // will wait for timeouts, selectors, and additional network activity
-            let { url, dom } = await page.snapshot({ ...opts, ...conf, execute });
+            let { url, dom } = await page.snapshot({ ...conf, ...opts });
             let root = injectPercyCSS(createRootResource(url, dom), percyCSS);
             resources.delete(root.url); // remove any discovered root resource
 


### PR DESCRIPTION
## What is this?

@chris-dura helped point out in #392 that additional snapshot options were being passed incorrectly to the `page.snapshot()` method.

The additional options (`opts`) should override parent options (`conf`). We also don't need to explicitly provide `execute` since it is included in `opts` and wasn't being extracted from the additional snapshot anyway.