### PR TITLE
🥅 Check version of Node, exit if not supported

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -1,5 +1,5 @@
-/* istanbul ignore if */
-if (parseInt(process.version.split('.')[0].substring(1), 10) <= 11) {
+/* istanbul ignore if: hard to test without actually using an unsupported version */
+if (parseInt(process.version.split('.')[0].substring(1), 10) < 12) {
   console.error(`Node ${process.version} is not supported. Percy only supports the current LTS of Node. Please upgrade to Node v12+`);
   process.exit(1);
 }

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -1,3 +1,9 @@
+/* istanbul ignore if */
+if (parseInt(process.version.split('.')[0].substring(1), 10) <= 11) {
+  console.error(`Node ${process.version} is not supported. Percy only supports the current LTS of Node. Please upgrade to Node v12+`);
+  process.exit(1);
+}
+
 const { promises: fs } = require('fs');
 const path = require('path');
 


### PR DESCRIPTION
## What is this?

Even though NPM/yarn checks on install, due to the number of warnings/errors in a given JS project, it's never noticed. We're going to hard error and exit on any unsupported versions of Node now to prevent support requests based on this.