### PR TITLE
✨ Do not wait for remote requests to idle during asset discovery

### DIFF
--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -46,7 +46,7 @@ export default class Network {
   }
 
   // Resolves after the timeout when there are no more in-flight requests.
-  async idle(timeout = this.timeout || 100) {
+  async idle(filter = r => r, timeout = this.timeout || 100) {
     this.log.debug(`Wait for ${timeout}ms idle`, this.page.meta);
 
     await waitFor(() => {
@@ -54,7 +54,8 @@ export default class Network {
         throw new Error(`Network error: ${this.page.closedReason}`);
       }
 
-      return this.#requests.size === 0;
+      return Array.from(this.#requests.values())
+        .filter(filter).length === 0;
     }, {
       timeout: 30 * 1000, // 30 second error timeout
       idle: timeout

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -10,6 +10,7 @@ import {
   createRootResource,
   createLogResource,
   createPercyCSSResource,
+  hostnameMatches,
   injectPercyCSS
 } from './utils';
 
@@ -317,7 +318,7 @@ export default class Percy {
           }
         });
 
-        // navigate to the url, trigger resize events, then wait for network idle
+        // navigate to the url and trigger resize events
         await page.goto(url);
         for (let width of widths) await page.resize({ width });
 
@@ -327,7 +328,10 @@ export default class Percy {
 
         if (root) {
           // ensure asset discovery has finished before uploading
-          await page.network.idle();
+          await page.network.idle(({ url }) => (
+            hostnameMatches(discovery.allowedHostnames, url)
+          ));
+
           root = injectPercyCSS(root, percyCSS);
           this.log.info(`Snapshot taken: ${name}`, meta);
           this._scheduleUpload(name, conf, [root, ...resources.values()]);


### PR DESCRIPTION
## What is this?

As described in #399, when requests will not be captured, they can clog up network idle and cause snapshots to take longer to process. However, if we were to untrack remote requests, as that issue suggests, pages might not yet be ready to snapshot when capturing the DOM ourselves since external resources are sometimes required by sites to load properly.

Instead, this PR adds a new feature to the network idle method to filter requests that are awaited on. This new filter can be used when not capturing our own DOM snapshot to only wait on requests from allowed hostnames.

I added a test for capturing lazy images as a precursor to a new test for not awaiting on remote resources (this test will timeout when failing). Lazy images are used in these tests because non-lazy images are normally awaited on via the document's `load` event, while lazy images are requested after the document's `load` event.

The test diff looks a little weird because I also removed an older test that was included here for coverage of the `hostnameMatches` function. That function now lives in `@percy/client` with its own tests, so the test here was unnecessary.

I'm labelling this as an enhancement as oppose to a bugfix since it's not necessarily a bug that we're waiting on all requests from the network, and this fixes #399 by further enhancing how we handle resources.