### PR TITLE
🐛 Serialize iframe document URLs

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -22,6 +22,11 @@ module.exports = config => config.set({
     { pattern: 'test/**/*.test.js', watched: false }
   ],
 
+  proxies: {
+    // useful when the contents of a fake asset do not matter
+    '/_/': 'localhost/'
+  },
+
   // create dedicated bundles for src, test helpers, and each test suite
   preprocessors: {
     'src/index.js': ['rollup'],

--- a/packages/dom/src/serialize-frames.js
+++ b/packages/dom/src/serialize-frames.js
@@ -2,26 +2,46 @@ import serializeDOM from './serialize-dom';
 
 // List of attributes that accept URIs that should be transformed
 const URI_ATTRS = ['href', 'src', 'srcset', 'poster', 'background'];
-const URI_SELECTOR = URI_ATTRS.map(a => `[${a}]`).join(',');
+const URI_SELECTOR = URI_ATTRS.map(a => `[${a}]`).join(',') + (
+  ',[style*="url("]'); // include elements with url style attributes
 
 // A loose srcset image candidate regex split into capture groups
 // https://html.spec.whatwg.org/multipage/images.html#srcset-attribute
 const SRCSET_REGEX = /(\s*)([^,]\S*[^,])((?:\s+[^,]+)*\s*(?:,|$))/g;
 
+// A loose CSS url() regex split into capture groups
+const CSS_URL_REGEX = /(url\((["']?))((?:\\.|(?!\2).|[^)])+)(\2\))/g;
+
 // Transforms URL attributes within a document to be fully qualified URLs. This is necessary when
 // embedded documents are serialized and their contents become root-relative.
 function transformRelativeUrls(dom) {
+  // transform style elements that might contain URLs
+  for (let style of dom.querySelectorAll('style')) {
+    style.innerHTML &&= style.innerHTML
+      .replace(CSS_URL_REGEX, (_, $1, $2, uri, $4) => (
+        `${$1}${new URL(uri, style.baseURI).href}${$4}`
+      ));
+  }
+
+  // transform element attributes that might contain URLs
   for (let el of dom.querySelectorAll(URI_SELECTOR)) {
-    for (let attr of URI_ATTRS) {
-      if (!(attr in el) || !el[attr]) continue;
+    for (let attr of URI_ATTRS.concat('style')) {
+      if (!(attr in el) || !el[attr] || !el.hasAttribute(attr)) continue;
       let value = el[attr];
 
-      if (attr === 'srcset') {
-        // the srcset attribute needs to be parsed
+      if (attr === 'style') {
+        // transform inline style url() usage
+        value = el.getAttribute('style')
+          .replace(CSS_URL_REGEX, (_, $1, $2, uri, $4) => (
+            `${$1}${new URL(uri, el.baseURI).href}${$4}`
+          ));
+      } else if (attr === 'srcset') {
+        // transform each srcset URL
         value = value.replace(SRCSET_REGEX, (_, $1, uri, $3) => (
           `${$1}${new URL(uri, el.baseURI).href}${$3}`
         ));
       } else {
+        // resolve the URL with the node's base URI
         value = new URL(value, el.baseURI).href;
       }
 

--- a/packages/dom/test/serialize-frames.test.js
+++ b/packages/dom/test/serialize-frames.test.js
@@ -29,6 +29,8 @@ describe('serializeFrames', () => {
       <iframe id="frame-with-urls" src="javascript:void(
         (this.document.body.background = '_/bg.png'),
         (this.document.body.innerHTML = \`
+          <style>@font-face { src: url('_/font.woff2') }</style>
+          <h1 style='background-image:url(_/head.png)'>Testing</h1>
           <link rel='stylesheet' href='_/style.css'>
           <img src='_/img.gif' srcset='/_/img.png 2x,
             //example.com/img.png 400w'>
@@ -95,6 +97,8 @@ describe('serializeFrames', () => {
 
     expect($('#frame-with-urls')[0].getAttribute('srcdoc')).toBe([
       `<!DOCTYPE html><html><head></head><body background="${url('_/bg.png')}">`,
+      `<style>@font-face { src: url('${url('_/font.woff2')}') }</style>`,
+      `<h1 style="background-image:url(${url('_/head.png')})">Testing</h1>`,
       `<link rel="stylesheet" href="${url('_/style.css')}">`,
       `<img src="${url('_/img.gif')}" srcset="${url('/_/img.png')} 2x,`,
       '  http://example.com/img.png 400w">',


### PR DESCRIPTION
## What is this?

As per #396, when a same-origin frame is serialized, all of its content becomes relative to the frame parent, which can then result in invalid resource URLs. Like the issue suggests, we can transform the URLs within the frame document to be fully qualified URLs based on the frame document's URL.

During the recursive DOM serialization, we can provide a custom transform function to be applied to iframe documents after cloning but before the function returns a string. In this transformation we can then find all relevant elements to transform their respective URLs.

According to HTML 4/5 spec the `href`, `src`, `srcset`, `poster`, and `background` attributes are attributes that may contain URIs (and that we care about transforming). Most attributes' property counterparts are already resolved, however that is not always the case (such as `background`). The `srcset` property is also not resolved, and requires parsing to properly replace URLs within the list of image candidates. 

In addition to those attributes, CSS within `style` elements or inline `style` attributes may also contain URLs using the `url()` CSS function and therefore are also transformed.

In adding a test, Karma complained about assets being missing. I found a workaround by setting a `proxy` option to a semi-valid URL so it doesn't proxy and doesn't log. If logs crop up in the future, we probably want to host a single fake asset to silence them.

Fixes #396