### PR TITLE
♻️ Refactor percy/config utils

### DIFF
--- a/packages/config/src/defaults.js
+++ b/packages/config/src/defaults.js
@@ -1,21 +1,22 @@
-import { merge } from './normalize';
+import { merge } from './utils';
 import { getSchema } from './validate';
 
+const { isArray } = Array;
 const { assign, entries } = Object;
 
 // Recursively walks a schema and collects defaults. When no schema is provided,
 // the default config schema is used.
-function getDefaultFromSchema(schema) {
+function getDefaultsFromSchema(schema) {
   if (!schema || typeof schema.$ref === 'string') {
     // get the schema from ajv
-    return getDefaultFromSchema(getSchema(schema?.$ref ?? 'config'));
+    return getDefaultsFromSchema(getSchema(schema?.$ref ?? '/config'));
   } else if (schema.default != null) {
     // return the default for this schema
     return schema.default;
   } else if (schema.type === 'object' && schema.properties) {
     // return an object of default properties
     return entries(schema.properties).reduce((acc, [prop, schema]) => {
-      let def = getDefaultFromSchema(schema);
+      let def = getDefaultsFromSchema(schema);
       return def != null ? assign(acc || {}, { [prop]: def }) : acc;
     }, undefined);
   } else {
@@ -24,7 +25,8 @@ function getDefaultFromSchema(schema) {
 }
 
 export default function getDefaults(overrides = {}) {
-  return merge(getDefaultFromSchema(), overrides, {
-    replaceArrays: true
+  return merge([getDefaultsFromSchema(), overrides], (path, prev, next) => {
+    // override default array instead of merging
+    return isArray(next) && [path, next];
   });
 }

--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -85,17 +85,11 @@ export default function load({
 
   // merge found config with overrides and validate
   config = normalize(config, { overrides });
-  let validation = config && validate(config);
+  let errors = config && validate(config);
 
-  if (validation && !validation.result) {
+  if (errors) {
     log.warn('Invalid config:');
-
-    for (let { message, path } of validation.errors) {
-      log.warn(`- ${path.join('.')}: ${message}`);
-      let [k, t] = [path.pop(), path.reduce((d, p) => d[p], config)];
-      if (t && k in t) delete t[k];
-    }
-
+    for (let e of errors) log.warn(`- ${e.path}: ${e.message}`);
     if (bail) return;
   }
 

--- a/packages/config/src/migrate.js
+++ b/packages/config/src/migrate.js
@@ -1,4 +1,5 @@
 import logger from '@percy/logger';
+import { set, del, map, merge } from './utils';
 import normalize from './normalize';
 
 // Global set of registered migrations
@@ -14,39 +15,6 @@ export function clearMigrations() {
   migrations.clear();
 }
 
-// Sets a value to the object at the path creating any necessary nested
-// objects along the way
-function set(obj, path, value) {
-  path.split('.').reduce((loc, key, i, a) => (
-    loc[key] = i === a.length - 1 ? value : (loc[key] || {})
-  ), obj);
-
-  return obj;
-}
-
-// Maps a value from one path to another, deleting the first path
-function map(obj, from, to, map = v => v) {
-  let val = from.split('.').reduce((loc, key, i, a) => {
-    let val = loc && loc[key];
-    if (loc && i === a.length - 1) delete loc[key];
-    return val;
-  }, obj);
-
-  return set(obj, to, map(val));
-}
-
-// Deletes properties from an object at the paths
-function del(obj, ...paths) {
-  for (let path of paths) {
-    path.split('.').reduce((loc, key, i, a) => {
-      if (loc && i === a.length - 1) delete loc[key];
-      return loc && loc[key];
-    }, obj);
-  }
-
-  return obj;
-}
-
 // Calls each registered migration function with a normalize provided config
 // and util functions for working with the config object
 export default function migrate(config) {
@@ -59,11 +27,11 @@ export default function migrate(config) {
     log: logger('config')
   };
 
-  migrations.forEach(migration => {
+  for (let migration of migrations) {
     migration(config, util);
-  });
+  }
 
-  return normalize(config, {
-    overrides: { version: 2 }
-  });
+  return merge([config, {
+    version: 2
+  }]);
 }

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -1,11 +1,17 @@
-const { isArray } = Array;
-const { entries, assign } = Object;
+import { merge } from './utils';
 
 // Edge case camelizations
 const CAMELCASE_MAP = new Map([
   ['css', 'CSS'],
   ['javascript', 'JavaScript']
 ]);
+
+// Do not change casing of nested options
+const SKIP_CASING_OPTIONS = [
+  'request-headers',
+  'requestHeaders',
+  'cookies'
+];
 
 // Converts kebab-cased and snake_cased strings to camelCase.
 const KEBAB_SNAKE_REG = /[-_]([^-_]+)/g;
@@ -29,33 +35,21 @@ function kebabcase(str) {
     ));
 }
 
-// Merges source values into the target object unless empty. When `options.replaceArrays` is truthy,
-// target arrays are replaced by their source arrays rather than concatenated together.
-export function merge(target, source, options) {
-  let isSourceArray = isArray(source);
-  if (options?.replaceArrays && isSourceArray) return source;
-  if (typeof source !== 'object') return source != null ? source : target;
-  let convertcase = options?.kebab ? kebabcase : camelcase;
-  let skipMerge = [convertcase('request-headers')];
-
-  return entries(source).reduce((result, [key, value]) => {
-    let k = convertcase(key);
-
-    value = skipMerge.includes(k) ? value
-      : merge(result?.[key], value, options);
-
-    return value == null ? result
-      : isSourceArray ? (result || []).concat(value)
-        : assign(result || {}, { [k]: value });
-  }, target);
-}
-
 // Recursively reduces config objects and arrays to remove undefined and empty values and rename
 // kebab-case properties to camelCase. Optionally allows deep merging of a second overrides
 // argument, and converting keys to kebab-case with a third options.kebab argument.
 export default function normalize(object, options) {
-  object = merge(undefined, object, options);
-  return options?.overrides
-    ? merge(object, options.overrides, options)
-    : object;
+  let keycase = options?.kebab ? kebabcase : camelcase;
+
+  return merge([object, options?.overrides], (path, prev, next) => {
+    let skip = false;
+
+    path = path.map(k => {
+      if (!skip && typeof k === 'string') k = keycase(k);
+      skip = SKIP_CASING_OPTIONS.includes(k);
+      return k;
+    });
+
+    return [path];
+  });
 }

--- a/packages/config/src/utils.js
+++ b/packages/config/src/utils.js
@@ -1,0 +1,119 @@
+const { isArray } = Array;
+const { isInteger } = Number;
+const { entries } = Object;
+
+// Creates an empty object or array
+function create(array) {
+  return array ? [] : {};
+}
+
+// Gets a value in the object at the path
+export function get(object, path, find) {
+  /* istanbul ignore next: a string path is never actually used here */
+  return (isArray(path) ? path : path.split('.'))
+    .reduce((target, key) => target?.[key], object);
+}
+
+// Sets a value to the object at the path creating any necessary nested
+// objects or arrays along the way
+const ARRAY_PATH_KEY_REG = /^\[\d+]$/;
+
+export function set(object, path, value) {
+  return (isArray(path) ? path : path.split('.'))
+    .reduce((target, key, index, path) => {
+      if (index < path.length - 1) {
+        let childKey = path[index + 1];
+        return (target[key] ??= create(
+          isInteger(childKey) ||
+            ARRAY_PATH_KEY_REG.test(childKey)
+        ));
+      } else {
+        target[key] = value;
+        return object;
+      }
+    }, object);
+}
+
+// Deletes properties from an object at the paths
+export function del(object, ...paths) {
+  return paths.reduce((object, path) => {
+    return (isArray(path) ? path : path.split('.'))
+      .reduce((target, key, index, path) => {
+        if (index < path.length - 1) {
+          return target?.[key];
+        } else {
+          delete target?.[key];
+          return object;
+        }
+      }, object);
+  }, object);
+}
+
+// Maps a value from one path to another, deleting the first path
+export function map(object, from, to, transform = v => v) {
+  return set(object, to, transform(
+    ((isArray(from) ? from : from.split('.')))
+      .reduce((target, key, index, path) => {
+        let value = target?.[key];
+
+        if (index === path.length - 1) {
+          delete target?.[key];
+        }
+
+        return value;
+      }, object)
+  ));
+}
+
+// Steps through an object's properties calling the function with the path and value of each
+function walk(object, fn, path = []) {
+  if (path.length && fn([...path], object) === false) return;
+
+  if (object != null && typeof object === 'object') {
+    let isArrayObject = isArray(object);
+
+    for (let [key, value] of entries(object)) {
+      if (isArrayObject) key = parseInt(key, 10);
+      walk(value, fn, [...path, key]);
+    }
+  }
+}
+
+// Merges source values and returns a new merged value. The map function will be called with a
+// property's path, previous value, and next value; it should return an array containing any
+// replacement path and value; when a replacement value not defined, values will be merged.
+export function merge(sources, map) {
+  return sources.reduce((target, source, i) => {
+    let isSourceArray = isArray(source);
+
+    walk(source, (path, value) => {
+      let ctx = get(target, path.slice(0, -1));
+      let key = path[path.length - 1];
+      let prev = ctx?.[key];
+
+      // maybe map the property path and/or value
+      let [p, next] = map?.(path, prev, value) || [];
+      if (p) path = [...p];
+
+      // adjust path to concat array values when necessary
+      if (next !== null && (isArray(ctx) || isInteger(key))) {
+        path.splice(-1, 1, ctx?.length ?? 0);
+      }
+
+      // delete prev values
+      if (next === null || (next == null && value === null)) {
+        del(target, path);
+      }
+
+      // set the next or default value if there is one
+      if (next != null || (next !== null && value != null && typeof value !== 'object')) {
+        set(target ??= create(isSourceArray), path, next ?? value);
+      }
+
+      // do not recurse mapped objects
+      return next === undefined;
+    });
+
+    return target;
+  }, undefined);
+}

--- a/packages/config/src/utils.js
+++ b/packages/config/src/utils.js
@@ -117,3 +117,28 @@ export function merge(sources, map) {
     return target;
   }, undefined);
 }
+
+// Recursively mutate and filter empty values from arrays and objects
+export function filterEmpty(subject) {
+  if (typeof subject === 'object') {
+    if (isArray(subject)) {
+      for (let i = 0; i < subject.length; i++) {
+        if (!filterEmpty(subject[i])) {
+          subject.splice(i--, 1);
+        }
+      }
+
+      return subject.length > 0;
+    } else {
+      for (let k in subject) {
+        if (!filterEmpty(subject[k])) {
+          delete subject[k];
+        }
+      }
+
+      return entries(subject).length > 0;
+    }
+  } else {
+    return subject != null;
+  }
+}

--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -1,5 +1,10 @@
 import AJV from 'ajv';
-import { set, del, filterEmpty } from './utils';
+import {
+  set,
+  del,
+  filterEmpty,
+  joinPropertyPath
+} from './utils';
 
 const { isArray } = Array;
 const { assign, entries } = Object;
@@ -153,7 +158,7 @@ export default function validate(data, key = '/config') {
       }
 
       // joined for error messages
-      path = path.join('.');
+      path = joinPropertyPath(path);
 
       // map one error per path
       errors.set(path, { path, message });

--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -1,19 +1,21 @@
-import Ajv from 'ajv';
+import AJV from 'ajv';
+import { set, del } from './utils';
+
+const { isArray } = Array;
 const { assign, entries } = Object;
 
-// Ajv manages and validates schemas.
-const ajv = new Ajv({
+// AJV manages and validates schemas.
+const ajv = new AJV({
+  strict: false,
   verbose: true,
   allErrors: true,
-  strict: false,
-  schemas: {
-    config: getDefaultSchema()
-  }
+  schemas: [getDefaultSchema()]
 });
 
 // Returns a new default schema.
 function getDefaultSchema() {
   return {
+    $id: '/config',
     type: 'object',
     additionalProperties: false,
     properties: {
@@ -27,62 +29,90 @@ export function getSchema(name) {
   return ajv.getSchema(name).schema;
 }
 
-// Adds schemas to the config schema's properties. The config schema is removed,
-// modified, and replaced after the new schemas are added to clear any compiled
-// caches. Existing schemas are removed and replaced as well.
+// Adds schemas to the config schema's properties. The config schema is removed, modified, and
+// replaced after the new schemas are added to clear any compiled caches. Existing schemas are
+// removed and replaced as well. If a schema id is provided as the second argument, the schema
+// will be set independently and not added to config schema's properties.
 export function addSchema(schemas) {
-  let config = getSchema('config');
-  ajv.removeSchema('config');
+  if (isArray(schemas) || schemas.$id) {
+    return ajv.addSchema(schemas);
+  }
 
-  for (let [$id, schema] of entries(schemas)) {
+  let config = getSchema('/config');
+  ajv.removeSchema('/config');
+
+  for (let [key, schema] of entries(schemas)) {
+    let $id = `/config/${key}`;
     if (ajv.getSchema($id)) ajv.removeSchema($id);
-    assign(config.properties, { [$id]: { $ref: $id } });
+    assign(config.properties, { [key]: { $ref: $id } });
     ajv.addSchema(schema, $id);
   }
 
-  ajv.addSchema(config, 'config');
+  ajv.addSchema(config, '/config');
 }
 
 // Resets the schema by removing all schemas and inserting a new default schema.
 export function resetSchema() {
   ajv.removeSchema();
-  ajv.addSchema(getDefaultSchema(), 'config');
-}
-
-// Validates config data according to the config schema and logs warnings to the
-// console. Optionallly scrubs invalid values from the provided config. Returns
-// true when the validation success, false otherwise.
-export default function validate(config) {
-  let result = ajv.validate('config', config);
-  let errors = [];
-
-  if (!result) {
-    for (let error of ajv.errors) {
-      let { instancePath, keyword, params, message, parentSchema, data } = error;
-      let path = instancePath ? instancePath.substr(1).split('/') : [];
-
-      if (parentSchema.errors?.[keyword]) {
-        let custom = parentSchema.errors[keyword];
-        message = typeof custom === 'function' ? custom(error) : custom;
-      } else if (keyword === 'required') {
-        message = 'missing required property';
-        path.push(params.missingProperty);
-      } else if (keyword === 'additionalProperties') {
-        message = 'unknown property';
-        path.push(params.additionalProperty);
-      } else if (keyword === 'type') {
-        let dataType = Array.isArray(data) ? 'array' : typeof data;
-        message = `must be ${a(params.type)}, received ${a(dataType)}`;
-      }
-
-      errors.push({ message, path });
-    }
-  }
-
-  return { result, errors };
+  ajv.addSchema(getDefaultSchema(), '/config');
 }
 
 // Adds "a" or "an" to a word for readability.
 function a(word) {
+  if (word === 'undefined' || word === 'null') return word;
   return `${('aeiou').includes(word[0]) ? 'an' : 'a'} ${word}`;
+}
+
+// Default errors anywhere within these keywords can be confusing
+const HIDE_NESTED_KEYWORDS = ['oneOf', 'anyOf', 'allOf', 'not'];
+
+function shouldHideError({ parentSchema, keyword, schemaPath }) {
+  return !(parentSchema.error || parentSchema.errors?.[keyword]) &&
+    HIDE_NESTED_KEYWORDS.some(k => schemaPath.includes(`/${k}`));
+}
+
+// Validates data according to the associated schema and returns a list of errors, if any.
+export default function validate(data, key = '/config') {
+  if (!ajv.validate(key, data)) {
+    let errors = new Map();
+
+    for (let error of ajv.errors) {
+      if (shouldHideError(error)) continue;
+      let { instancePath, parentSchema, keyword, message, params } = error;
+      let path = instancePath ? instancePath.substr(1).split('/') : [];
+
+      // generate a custom error message
+      if (parentSchema.error || parentSchema.errors?.[keyword]) {
+        let custom = parentSchema.error || parentSchema.errors[keyword];
+        message = typeof custom === 'function' ? custom(error) : custom;
+      } else if (keyword === 'type') {
+        let dataType = error.data === null ? 'null' : (
+          isArray(error.data) ? 'array' : typeof error.data);
+        message = `must be ${a(params.type)}, received ${a(dataType)}`;
+      } else if (keyword === 'required') {
+        message = 'missing required property';
+      } else if (keyword === 'additionalProperties') {
+        message = 'unknown property';
+      }
+
+      // fix paths
+      if (params.missingProperty) {
+        path.push(params.missingProperty);
+      } else if (params.additionalProperty) {
+        path.push(params.additionalProperty);
+      }
+
+      // scrub invalid data
+      del(data, path);
+
+      // joined for error messages
+      path = path.join('.');
+
+      // map one error per path
+      errors.set(path, { path, message });
+    }
+
+    // return an array of errors
+    return Array.from(errors.values());
+  }
 }

--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -146,6 +146,8 @@ export default function validate(data, key = '/config') {
         set(data, path, Math.max(error.data, error.schema));
       } else if (keyword === 'maximum') {
         set(data, path, Math.min(error.data, error.schema));
+      } else if (keyword === 'required') {
+        del(data, path.slice(0, -1));
       } else {
         del(data, path);
       }

--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -9,7 +9,23 @@ const ajv = new AJV({
   strict: false,
   verbose: true,
   allErrors: true,
-  schemas: [getDefaultSchema()]
+  schemas: [
+    getDefaultSchema()
+  ],
+  keywords: [{
+    // custom instanceof schema validation
+    keyword: 'instanceof',
+    metaSchema: {
+      enum: ['Function', 'RegExp']
+    },
+    error: {
+      message: cxt => AJV.str`must be an instanceof ${cxt.schemaCode}`,
+      params: cxt => AJV._`{ instanceof: ${cxt.schemaCode} }`
+    },
+    code: cxt => cxt.fail(
+      AJV._`!(${cxt.data} instanceof ${AJV._([cxt.schema])})`
+    )
+  }]
 });
 
 // Returns a new default schema.

--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -1,5 +1,5 @@
 import AJV from 'ajv';
-import { set, del } from './utils';
+import { set, del, filterEmpty } from './utils';
 
 const { isArray } = Array;
 const { assign, entries } = Object;
@@ -158,6 +158,9 @@ export default function validate(data, key = '/config') {
       // map one error per path
       errors.set(path, { path, message });
     }
+
+    // filter empty values as a result of scrubbing
+    filterEmpty(data);
 
     // return an array of errors
     return Array.from(errors.values());

--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -102,8 +102,14 @@ export default function validate(data, key = '/config') {
         path.push(params.additionalProperty);
       }
 
-      // scrub invalid data
-      del(data, path);
+      // fix invalid data
+      if (keyword === 'minimum') {
+        set(data, path, Math.max(error.data, error.schema));
+      } else if (keyword === 'maximum') {
+        set(data, path, Math.min(error.data, error.schema));
+      } else {
+        del(data, path);
+      }
 
       // joined for error messages
       path = path.join('.');

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -240,10 +240,10 @@ describe('PercyConfig', () => {
       let conf = { foo: [{}, { baz: 'qux' }, { qux: 'quux' }] };
 
       expect(PercyConfig.validate(conf)).toEqual([{
-        path: 'foo.0',
+        path: 'foo[0]',
         message: 'missing metasyntactic variable'
       }, {
-        path: 'foo.2.qux',
+        path: 'foo[2].qux',
         message: 'must be equal to constant'
       }]);
 
@@ -379,6 +379,22 @@ describe('PercyConfig', () => {
         value: 'testing'
       })).toEqual({
         version: 2
+      });
+    });
+
+    it('can handle array and array-like paths', () => {
+      PercyConfig.addMigration((config, util) => {
+        if (config.arr) util.map('arr', 'arr[1].foo[bar][baz]');
+      });
+
+      expect(PercyConfig.migrate({
+        version: 1,
+        arr: 'qux'
+      })).toEqual({
+        version: 2,
+        arr: [undefined, {
+          foo: { bar: { baz: 'qux' } }
+        }]
       });
     });
   });
@@ -663,7 +679,7 @@ describe('PercyConfig', () => {
         path: '.invalid.yml',
         overrides: {
           test: { value: 1 },
-          arr: { 1: 'one' },
+          arr: { one: 1 },
           obj: { foo: 'bar', bar: 'baz' }
         }
       })).toEqual({
@@ -700,7 +716,7 @@ describe('PercyConfig', () => {
         bail: true,
         overrides: {
           test: { value: 1 },
-          arr: { 1: 'one' }
+          arr: { one: 1 }
         }
       })).toBeUndefined();
 

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -213,6 +213,29 @@ describe('PercyConfig', () => {
 
       expect(conf).toEqual({ min: 10, max: 20 });
     });
+
+    it('can validate functions and regular expressions', () => {
+      PercyConfig.addSchema({
+        func: { instanceof: 'Function' },
+        regex: { instanceof: 'RegExp' }
+      });
+
+      expect(PercyConfig.validate({
+        func: () => {},
+        regex: /foobar/g
+      })).toBeUndefined();
+
+      expect(PercyConfig.validate({
+        func: '() => {}',
+        regex: '/foobar/g'
+      })).toEqual([{
+        path: 'func',
+        message: 'must be an instanceof Function'
+      }, {
+        path: 'regex',
+        message: 'must be an instanceof RegExp'
+      }]);
+    });
   });
 
   describe('.migrate()', () => {

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -194,6 +194,25 @@ describe('PercyConfig', () => {
         message: 'must pass a single schema, passed 0'
       }]);
     });
+
+    it('clamps minimum and maximum schemas', () => {
+      PercyConfig.addSchema({
+        min: { type: 'number', minimum: 10 },
+        max: { type: 'number', maximum: 20 }
+      });
+
+      let conf = { min: 5, max: 50 };
+
+      expect(PercyConfig.validate(conf)).toEqual([{
+        path: 'min',
+        message: 'must be >= 10'
+      }, {
+        path: 'max',
+        message: 'must be <= 20'
+      }]);
+
+      expect(conf).toEqual({ min: 10, max: 20 });
+    });
   });
 
   describe('.migrate()', () => {

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -236,6 +236,31 @@ describe('PercyConfig', () => {
         message: 'must be an instanceof RegExp'
       }]);
     });
+
+    it('can validate disallowed properties', () => {
+      PercyConfig.addSchema({
+        test: {
+          type: 'object',
+          additionalProperties: false,
+          disallowed: ['foo', 'bar'],
+          properties: {
+            foo: { type: 'number' },
+            bar: { type: 'number' },
+            baz: { type: 'number' }
+          }
+        }
+      });
+
+      expect(PercyConfig.validate({
+        test: { foo: 1, bar: 2, baz: 3 }
+      })).toEqual([{
+        path: 'test.foo',
+        message: 'disallowed property'
+      }, {
+        path: 'test.bar',
+        message: 'disallowed property'
+      }]);
+    });
   });
 
   describe('.migrate()', () => {

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { merge } from '@percy/config/dist/normalize';
+import { merge } from '@percy/config/dist/utils';
 import { hostname } from './utils';
 
 // Common options used in Percy commands
@@ -190,14 +190,14 @@ export function getSnapshotConfig({
   enableJavaScript ??= config.snapshot.enableJavaScript;
 
   // merge common discovery options
-  discovery = merge({
+  discovery = merge([{
     // always allow the root hostname
     allowedHostnames: [hostname(url), ...config.discovery.allowedHostnames],
     requestHeaders: config.discovery.requestHeaders,
     authorization: config.discovery.authorization,
     disableCache: config.discovery.disableCache,
     userAgent: config.discovery.userAgent
-  }, discovery);
+  }, discovery]);
 
   return {
     url,


### PR DESCRIPTION
## Purpose

While adding better validations for config options and per-snapshot validations, data must be validated against schemas other than the global config schema. To facilitate this, the validate util was refactored slightly. The merge util is also used within the core snapshot options config function to merge and validate provided options with config options and defaults while also handling deprecated options. Due to the merge util's limitation of only merging two objects at a time while mutating the first object, it had to be used several times in a row in order to merge all of the snapshot options together into a new object. Furthermore, it's options argument was limited in it's abilities and the merge function itself was centered around config normalization, so wasn't generic enough to use outside of said normalization function.

## Approach

The `validate` utils were refactored so default schema `$id`s now start with a forward slash (`/`) to help distinguish them from local schema references. The function will also now only return an array of errors on failure and `undefined` on success. The associated `addSchema` util was updated to accept schemas without automatically adding them to the global Percy config schema (via an explicit `$id`). This allows the validate util to be used with other registered schemas and not just the global Percy config schema.

The `merge` util was refactored to accept an array of objects instead of only two objects. It also always returns a deep clone rather than mutating the first argument. The limited `options` argument was replaced with a `map` callback argument. The callback will be called for each property within each object, recursively, with the path, previous value, and next value of the property. A path-value pair can be returned to override the default merge behavior. Some options previously handled by the old merge function were replaced by the new map callback in the appropriate places.

Other features were also added while refactoring that were found to be useful for better validations: 
- Schemas using `minimum` and `maximum` keywords will be clamped rather than scrubbed. 
- Schemas can use a custom `instanceof` keyword to allow functions or regular expressions. 
- Schemas can also use a custom `disallowed` keyword, based on the built-in `required` keyword (but negated).
- Nested objects that have missing required properties are now scrubbed. 
- Empty properties such as array items that are missing or deleted are now scrubbed.
   e.g. `['foo', <5 empty items>, 'xyzzy'] => ['foo', 'xyzzy']`
- Validation error paths were updated to show as proper array notation.
   before: `snapshots.widths.0: must be <= 2000`
   after: `snapshots.widths[0]: must be <= 2000`