### PR TITLE
🙈 Update coverage ignore statements for race conditions

### DIFF
--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -275,8 +275,7 @@ export default class Browser extends EventEmitter {
       let callback = this.#callbacks.get(data.id);
       this.#callbacks.delete(data.id);
 
-      /* istanbul ignore next:
-       *   currently does not happen during asset discovery but it's here just in case */
+      /* istanbul ignore next: races with page._handleMessage() */
       if (data.error) {
         callback.reject(Object.assign(callback.error, {
           message: `Protocol error (${callback.method}): ${data.error.message}` +

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -278,10 +278,10 @@ export default class Page extends EventEmitter {
       let callback = this.#callbacks.get(data.id);
       this.#callbacks.delete(data.id);
 
+      /* istanbul ignore next: races with browser._handleMessage() */
       if (data.error) {
         callback.reject(Object.assign(callback.error, {
           message: `Protocol error (${callback.method}): ${data.error.message}` +
-            /* istanbul ignore next: doesn't always exist so don't print undefined */
             ('data' in data.error ? `: ${data.error.data}` : '')
         }));
       } else {


### PR DESCRIPTION
## What is this?

Sometimes, we get an occasional flakey CI failure due to missing branch coverage, which doesn't highlight which line number the coverage was missed for in the CI summary.

The reason that coverage is flakey but tests pass is likely due to a close enough assertion. For example, a test that asserts the page was closed might test for `/closed/` because sometimes the message is `Browser closed` instead of `Page closed` (both messages mean the page is closed, so the test is still accurate).

All page/browser errors are handled in one of two places, and the resulting handling and desired outcome is the same. There was already a coverage ignore statement on one handler, and another nested within the second handler. Both ignore statements were adjusted to reflect that they race with one another.

Another possible solution here would be to pull out this error handling into a shared function. That way it wouldn't matter which browser/page method handled the error since the same coverage paths would be taken in either case. I didn't do that now since there was already coverage ignore statements in these places and it was quicker to adjust them.