### PR TITLE
🐛 Fix default proxy port

### DIFF
--- a/packages/client/src/request.js
+++ b/packages/client/src/request.js
@@ -13,6 +13,11 @@ const RETRY_ERROR_CODES = [
   'EHOSTUNREACH', 'EAI_AGAIN'
 ];
 
+// Returns the port number of a URL object. Defaults to port 443 for https
+// protocols or port 80 otherwise.
+const port = ({ port, protocol }) => port ||
+  (protocol === 'https:' && 443) || 80;
+
 // Proxified https agent
 export class ProxyHttpsAgent extends https.Agent {
   // enforce request options
@@ -57,7 +62,7 @@ export class ProxyHttpsAgent extends https.Agent {
     let socket = (isProxyHttps ? tls : net).connect({
       ...options,
       host: proxy.hostname,
-      port: proxy.port
+      port: port(proxy)
     });
 
     let handleError = err => {
@@ -91,8 +96,7 @@ export class ProxyHttpsAgent extends https.Agent {
     };
 
     // write proxy connect message to the socket
-    /* istanbul ignore next: port is always present for localhost tests */
-    let host = `${uri.hostname}:${uri.port || 443}`;
+    let host = `${uri.hostname}:${port(uri)}`;
     let connectMessage = [`CONNECT ${host} HTTP/1.1`, `Host: ${host}`];
 
     if (proxy.username) {

--- a/packages/client/test/proxy.test.js
+++ b/packages/client/test/proxy.test.js
@@ -36,8 +36,10 @@ function createTestServer(http, port, handler) {
     requests,
 
     async start() {
-      await new Promise(r => server.listen(port, r));
-      return this;
+      return new Promise((resolve, reject) => {
+        server.listen(port, () => resolve(this))
+          .on('error', reject);
+      });
     },
 
     async close() {
@@ -209,19 +211,35 @@ describe('Proxied PercyClient', () => {
   it('can be proxied through a proxy with a default port', async () => {
     proxy.close();
 
-    proxy = await createProxyServer(http, 80).start();
-    process.env.HTTP_PROXY = 'http://localhost';
+    // this is done for systems with restricted ports
+    let failed = false;
+    let spy = spyOn(require('net'), 'connect').and.callThrough();
+    proxy = await createProxyServer(http, 80).start()
+      .catch(() => { failed = true; });
 
-    await expectAsync(client.get('foo')).toBeResolvedTo('test proxied');
+    process.env.HTTP_PROXY = 'http://localhost';
+    let req = client.get('foo');
+
+    if (failed) await expectAsync(req).toBeRejected();
+    else await expectAsync(req).toBeResolvedTo('test proxied');
+    expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ port: 80 }));
   });
 
   it('can be proxied through an https proxy', async () => {
     proxy.close();
 
-    proxy = await createProxyServer(https, 443).start();
-    process.env.HTTPS_PROXY = 'https://localhost';
+    // this is done for systems with restricted ports
+    let failed = false;
+    let spy = spyOn(require('tls'), 'connect').and.callThrough();
+    proxy = await createProxyServer(https, 443).start()
+      .catch(() => { failed = true; });
 
-    await expectAsync(client.get('foo')).toBeResolvedTo('test proxied');
+    process.env.HTTPS_PROXY = 'https://localhost';
+    let req = client.get('foo');
+
+    if (failed) await expectAsync(req).toBeRejected();
+    else await expectAsync(req).toBeResolvedTo('test proxied');
+    expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ port: 443 }));
   });
 
   it('throws an error for unsupported proxy protocols', async () => {

--- a/packages/client/test/proxy.test.js
+++ b/packages/client/test/proxy.test.js
@@ -208,6 +208,15 @@ describe('Proxied PercyClient', () => {
     );
   });
 
+  it('can be proxied through an https proxy', async () => {
+    proxy.close();
+
+    proxy = await createProxyServer(https, 1337).start();
+    process.env.HTTPS_PROXY = 'https://localhost:1337';
+
+    await expectAsync(client.get('foo')).toBeResolvedTo('test proxied');
+  });
+
   it('can be proxied through a proxy with a default port', async () => {
     proxy.close();
 
@@ -225,7 +234,7 @@ describe('Proxied PercyClient', () => {
     expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ port: 80 }));
   });
 
-  it('can be proxied through an https proxy', async () => {
+  it('can be proxied through an https proxy with a default port', async () => {
     proxy.close();
 
     // this is done for systems with restricted ports

--- a/packages/client/test/proxy.test.js
+++ b/packages/client/test/proxy.test.js
@@ -206,11 +206,20 @@ describe('Proxied PercyClient', () => {
     );
   });
 
+  it('can be proxied through a proxy with a default port', async () => {
+    proxy.close();
+
+    proxy = await createProxyServer(http, 80).start();
+    process.env.HTTP_PROXY = 'http://localhost';
+
+    await expectAsync(client.get('foo')).toBeResolvedTo('test proxied');
+  });
+
   it('can be proxied through an https proxy', async () => {
     proxy.close();
 
-    proxy = await createProxyServer(https, 1337).start();
-    process.env.HTTPS_PROXY = 'https://localhost:1337';
+    proxy = await createProxyServer(https, 443).start();
+    process.env.HTTPS_PROXY = 'https://localhost';
 
     await expectAsync(client.get('foo')).toBeResolvedTo('test proxied');
   });


### PR DESCRIPTION
## What is this?

With `new URL()`, the default port is never included in the resulting object, even when explicitly defined.

```js
new URL('http://localhost:80').port
// => ""

new URL('https://localhost:443').port
// => ""
```

In the `@percy/client` proxy, the proxy address' port is passed along to the `(net|tls).connect` method. With the above in mind, this results in an empty string being passed along. Since the `port` option is a required argument of the method, this causes connections to immediately close, showing only a vague error.

This PR adds a small `port` util which will return a default port if one isn't specified, port 443 for HTTPS requests or port 80 otherwise. This util is then used in the two places where a URL port is referenced.

Fixes #402 