### PR TITLE
✨ Add per-snapshot config validation!

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -161,8 +161,8 @@ percy.snapshot({
 
 #### Options
 
-- `name` — Snapshot name (**required**)
 - `url` — Snapshot URL (**required**)
+- `name` — Snapshot name
 - `domSnapshot` — Snapshot DOM string
 - `clientInfo` — Additional client info
 - `environmentInfo` — Additional environment info

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -1,8 +1,8 @@
 import { strict as assert } from 'assert';
+import PercyConfig from '@percy/config';
 import { merge } from '@percy/config/dist/utils';
-import { hostname } from './utils';
 
-// Common options used in Percy commands
+// Common config options used in Percy commands
 export const schema = {
   snapshot: {
     type: 'object',
@@ -10,12 +10,18 @@ export const schema = {
     properties: {
       widths: {
         type: 'array',
-        items: { type: 'integer' },
-        default: [375, 1280]
+        default: [375, 1280],
+        items: {
+          type: 'integer',
+          maximum: 2000,
+          minimum: 10
+        }
       },
       minHeight: {
         type: 'integer',
-        default: 1024
+        default: 1024,
+        maximum: 2000,
+        minimum: 10
       },
       percyCSS: {
         type: 'string',
@@ -32,12 +38,23 @@ export const schema = {
     properties: {
       allowedHostnames: {
         type: 'array',
-        items: { type: 'string' },
-        default: []
+        default: [],
+        items: {
+          type: 'string',
+          allOf: [{
+            not: { pattern: '[^/]/' },
+            error: 'must not include a pathname'
+          }, {
+            not: { pattern: '^([a-zA-Z]+:)?//' },
+            error: 'must not include a protocol'
+          }]
+        }
       },
       networkIdleTimeout: {
         type: 'integer',
-        default: 100
+        default: 100,
+        maximum: 750,
+        minimum: 1
       },
       disableCache: {
         type: 'boolean'
@@ -74,7 +91,8 @@ export const schema = {
         type: 'string'
       },
       concurrency: {
-        type: 'integer'
+        type: 'integer',
+        minimum: 1
       },
       launchOptions: {
         type: 'object',
@@ -87,6 +105,107 @@ export const schema = {
         }
       }
     }
+  }
+};
+
+// Common per-snapshot capture options
+export const snapshotSchema = {
+  $id: '/snapshot',
+  type: 'object',
+  required: ['url'],
+  additionalProperties: false,
+  properties: {
+    url: { type: 'string' },
+    name: { type: 'string' },
+    widths: { $ref: '/config/snapshot#/properties/widths' },
+    minHeight: { $ref: '/config/snapshot#/properties/minHeight' },
+    percyCSS: { $ref: '/config/snapshot#/properties/percyCSS' },
+    enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },
+
+    discovery: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        allowedHostnames: { $ref: '/config/discovery#/properties/allowedHostnames' },
+        requestHeaders: { $ref: '/config/discovery#/properties/requestHeaders' },
+        authorization: { $ref: '/config/discovery#/properties/authorization' },
+        disableCache: { $ref: '/config/discovery#/properties/disableCache' },
+        userAgent: { $ref: '/config/discovery#/properties/userAgent' }
+      }
+    },
+
+    waitForSelector: {
+      type: 'string'
+    },
+
+    waitForTimeout: {
+      type: 'integer',
+      minimum: 1,
+      maximum: 30000
+    },
+
+    execute: {
+      oneOf: [
+        { type: 'string' },
+        { instanceof: 'Function' }
+      ]
+    },
+
+    additionalSnapshots: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        oneOf: [{
+          required: ['name']
+        }, {
+          anyOf: [
+            { required: ['prefix'] },
+            { required: ['suffix'] }
+          ]
+        }],
+        properties: {
+          prefix: { type: 'string' },
+          suffix: { type: 'string' },
+          name: { $ref: '/snapshot#/properties/name' },
+          waitForTimeout: { $ref: '/snapshot#/properties/waitForTimeout' },
+          waitForSelector: { $ref: '/snapshot#/properties/waitForSelector' },
+          execute: { $ref: '/snapshot#/properties/execute' }
+        },
+        errors: {
+          oneOf: ({ params }) => (
+            params.passingSchemas
+              ? 'prefix & suffix are ignored when a name is provided'
+              : 'missing required name, prefix, or suffix'
+          )
+        }
+      }
+    }
+  }
+};
+
+// Disallow capture options for dom snapshots
+export const snapshotDOMSchema = {
+  $id: '/snapshot/dom',
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'url',
+    'domSnapshot'
+  ],
+  disallowed: [
+    'additionalSnapshots',
+    'waitForTimeout',
+    'waitForSelector',
+    'execute'
+  ],
+  errors: {
+    disallowed: 'not accepted with DOM snapshots'
+  },
+  properties: {
+    domSnapshot: { type: 'string' },
+    // schemas have no concept of inheritance, but we can leverage JS for brevity
+    ...snapshotSchema.properties
   }
 };
 
@@ -105,9 +224,8 @@ export function migration(config, { map, del, log }) {
     // snapshot discovery options have moved
     for (let k of ['authorization', 'requestHeaders']) {
       if (config.snapshot?.[k]) {
-        log.deprecated(
-          `The config option \`snapshot.${k}\` will be removed in 1.0.0. ` +
-          `Use \`discovery.${k}\` instead.`);
+        log.deprecated(`The config option \`snapshot.${k}\` ` + (
+          `will be removed in 1.0.0. Use \`discovery.${k}\` instead.`));
         map(`snapshot.${k}`, `discovery.${k}`);
       }
     }
@@ -115,104 +233,63 @@ export function migration(config, { map, del, log }) {
 }
 
 // Validate and merge per-snapshot configuration options with global configuration options.
-export function getSnapshotConfig({
-  url,
-  name,
-  // per-snapshot options
-  widths,
-  minHeight,
-  percyCSS,
-  enableJavaScript,
-  discovery,
-  // use a specific dom snapshot
-  domSnapshot,
-  // capture a fresh dom snapshot
-  execute,
-  waitForTimeout,
-  waitForSelector,
-  additionalSnapshots,
-  // sdk options
-  clientInfo,
-  environmentInfo,
-  // deprecated options
-  ...deprecated
-}, config, log) {
-  // required per-snapshot
-  assert(url, 'Missing required URL for snapshot');
+export function getSnapshotConfig(options, { snapshot, discovery }, log) {
+  // throw an error when missing required options
+  assert(options.url, 'Missing required URL for snapshot');
+  assert((options.widths ?? snapshot.widths)?.length, 'Missing required widths for snapshot');
 
-  // override and sort widths
-  widths = [...(widths?.length ? widths : config.snapshot.widths)].sort((a, b) => a - b);
-  assert(widths?.length, 'Missing required widths for snapshot');
-  assert(widths.length <= 10, `Too many widths requested: maximum is 10, requested ${widths}`);
-
-  // dom snapshot and capture options are exclusive
-  if (domSnapshot != null) {
-    let conflict = Object
-      .entries({ execute, waitForTimeout, waitForSelector, additionalSnapshots })
-      .find(option => option[1] != null)?.[0];
-    assert(!conflict, `Conflicting options: domSnapshot, ${conflict}`);
-  }
-
-  // discovery options have moved
-  for (let k of ['authorization', 'requestHeaders']) {
-    if (deprecated[k]) {
-      log.warn(`Warning: The snapshot option \`${k}\` ` +
-        `will be removed in 1.0.0. Use \`discovery.${k}\` instead.`);
-      (discovery ??= {})[k] ??= deprecated[k];
+  // prune options from being validated
+  let config = merge([options, {
+    clientInfo: null,
+    environmentInfo: null
+  }], (path, prev, next) => {
+    // move deprecated options before validating
+    switch (path.join('.')) {
+      case 'authorization':
+      case 'requestHeaders': // discovery options have moved
+        log.warn(`Warning: The snapshot option \`${path}\` ` + (
+          `will be removed in 1.0.0. Use \`discovery.${path}\` instead.`));
+        return [path.unshift('discovery')];
+      case 'snapshots': // snapshots was renamed
+        log.warn('Warning: The `snapshots` option will be ' + (
+          'removed in 1.0.0. Use `additionalSnapshots` instead.'));
+        return ['additionalSnapshots'];
     }
+  });
+
+  // validate and scrub according to dom snaphot presence
+  let errors = PercyConfig.validate(config, (
+    config.domSnapshot ? '/snapshot/dom' : '/snapshot'));
+
+  if (errors) {
+    log.warn('Invalid snapshot options:');
+    for (let e of errors) log.warn(`- ${e.path}: ${e.message}`);
   }
 
-  // snapshots option was renamed
-  if (deprecated.snapshots) {
-    log.warn('Warning: The `snapshots` option will be ' +
-      'removed in 1.0.0. Use `additionalSnapshots` instead.');
-    additionalSnapshots ??= deprecated.snapshots;
-  }
+  // parse the URL to construct defaults
+  let url = new URL(options.url);
 
-  // default name to the URL /pathname?search#hash
-  if (!name) {
-    let uri = new URL(url);
-    name = `${uri.pathname}${uri.search}${uri.hash}`;
-  }
-
-  // additional snapshots must be named but allow inheritance with a prefix/suffix
-  additionalSnapshots = (additionalSnapshots || [])
-    .map(({ name: n, prefix = '', suffix = '', ...opts }) => {
-      assert(n || prefix || suffix, 'Missing additional snapshot name, prefix, or suffix');
-      return { name: n || `${prefix}${name}${suffix}`, ...opts };
-    });
-
-  // concatenate percy css
-  percyCSS = [config.snapshot.percyCSS, percyCSS].filter(Boolean).join('\n');
-
-  // default options
-  minHeight ??= config.snapshot.minHeight;
-  enableJavaScript ??= config.snapshot.enableJavaScript;
-
-  // merge common discovery options
-  discovery = merge([{
-    // always allow the root hostname
-    allowedHostnames: [hostname(url), ...config.discovery.allowedHostnames],
-    requestHeaders: config.discovery.requestHeaders,
-    authorization: config.discovery.authorization,
-    disableCache: config.discovery.disableCache,
-    userAgent: config.discovery.userAgent
-  }, discovery]);
-
-  return {
-    url,
-    name,
-    widths,
-    minHeight,
-    percyCSS,
-    enableJavaScript,
-    discovery,
-    domSnapshot,
-    execute,
-    waitForTimeout,
-    waitForSelector,
-    additionalSnapshots,
-    clientInfo,
-    environmentInfo
-  };
+  // inherit options from the config
+  return merge([snapshot, {
+    // default to the URL /pathname?search#hash
+    name: `${url.pathname}${url.search}${url.hash}`,
+    // add back client and environment information
+    clientInfo: options.clientInfo,
+    environmentInfo: options.environmentInfo,
+    // only specific discovery options are used per-snapshot
+    discovery: {
+      allowedHostnames: [url.hostname, ...discovery.allowedHostnames],
+      requestHeaders: discovery.requestHeaders,
+      authorization: discovery.authorization,
+      disableCache: discovery.disableCache,
+      userAgent: discovery.userAgent
+    }
+  }, config], (path, prev, next) => {
+    switch (path.join('.')) {
+      case 'widths': // override and sort widths
+        return [path, next.sort((a, b) => a - b)];
+      case 'percyCSS': // concatenate percy css
+        return [path, [prev, next].filter(Boolean).join('\n')];
+    }
+  });
 }

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -5,5 +5,9 @@ const CoreConfig = require('./config');
 PercyConfig.addSchema(CoreConfig.schema);
 PercyConfig.addMigration(CoreConfig.migration);
 
+// used for per-snapshot validation
+PercyConfig.addSchema(CoreConfig.snapshotSchema);
+PercyConfig.addSchema(CoreConfig.snapshotDOMSchema);
+
 // Export the Percy class with commonjs compatibility
 module.exports = require('./percy').default;

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -337,9 +337,11 @@ export default class Percy {
           this._scheduleUpload(name, conf, [root, ...resources.values()]);
         } else {
           // capture additional snapshots sequentially
-          let snapshot = { name, waitForTimeout, waitForSelector, execute };
+          let rootSnapshot = { name, waitForTimeout, waitForSelector, execute };
+          let allSnapshots = [rootSnapshot, ...(additionalSnapshots || [])];
 
-          for (let { name, ...opts } of [snapshot, ...additionalSnapshots]) {
+          for (let { name, prefix = '', suffix = '', ...opts } of allSnapshots) {
+            name ||= `${prefix}${rootSnapshot.name}${suffix}`;
             this.log.debug(`Taking snapshot: ${name}`, meta);
 
             // will wait for timeouts, selectors, and additional network activity


### PR DESCRIPTION
## What is this?

While working on #305, the decision was made to have the config schema for snapshot options included in `@percy/core` since that is where the options are consumed. Initially however, core only registered the schema while the snapshot command used it to validate snapshot listing options.

With #406 refactoring the `merge` and `validate` utils, the `getSnapshotConfig` helper can now be refactored to utilize their new features to better merge and now validate options! This brings config validation to all of the SDKs as warnings logged whenever `percySnapshot` is called with unrecognized or invalid options.

Speaking of invalid options, this PR also adds more restrictions to existing config options:
- The `widths` and `minHeight` options have min and max values. These values are derived from the upload command clamping, which itself was derived from our API restrictions.
- Hostnames in `allowedHostnames` must be actual hostnames, meaning no protocols and no paths. Including protocols and paths never worked and this validation will help clear up that confusion.
- The `networkIdleTimeout` should never really be larger than 500ms, but is restricted to 750ms to give it some breathing room. This restriction is imposed because long timeouts cause slow tests and don't actually address the underlying network issues.
- Discovery `concurrency` has a minimum value of 1 because having a negative or zero value causes the queue to lock up.

For new per-snapshot validations other restrictions are also imposed:
- Disallowed capture options, like `waitForSelector`, when performing discovery for an existing `domSnapshot`.
- The `waitForTimeout` option must be between `1ms` and `30000ms`.
- The `execute` option must be a string or function.
- For `additionalSnapshots`, a `name`, `prefix`, or `suffix` is required.
- For `additionalSnapshots`, a `prefix` or `suffix` cannot be provided with a `name`.

Tests were updated accordingly and a couple things that were previously taken care of in the config helper are now taken care of where necessary, such as defaulting an additional snapshot name using a prefix/suffix.

This will close #389 