### PR TITLE
✨ Validate snapshot command page listings

### DIFF
--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -38,7 +38,7 @@ export const snapshotListSchema = {
     items: {
       oneOf: [
         { $ref: '/snapshot' },
-        { type: '/snapshot#/properties/url' }
+        { $ref: '/snapshot#/properties/url' }
       ]
     }
   }, {

--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -1,3 +1,4 @@
+// Config schema for static directories
 export const schema = {
   static: {
     type: 'object',
@@ -27,6 +28,28 @@ export const schema = {
       }
     }
   }
+};
+
+// Page listing schema
+export const snapshotListSchema = {
+  $id: '/snapshot/list',
+  oneOf: [{
+    type: 'array',
+    items: {
+      oneOf: [
+        { $ref: '/snapshot' },
+        { type: '/snapshot#/properties/url' }
+      ]
+    }
+  }, {
+    type: 'object',
+    required: ['snapshots'],
+    properties: {
+      snapshots: {
+        $ref: '#/oneOf/0'
+      }
+    }
+  }]
 };
 
 export function migration(config, { map, del }) {

--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -38,7 +38,7 @@ export const snapshotListSchema = {
     items: {
       oneOf: [
         { $ref: '/snapshot' },
-        { $ref: '/snapshot#/properties/url' }
+        { type: 'string' }
       ]
     }
   }, {

--- a/packages/cli-snapshot/src/hooks/init.js
+++ b/packages/cli-snapshot/src/hooks/init.js
@@ -1,7 +1,12 @@
 import PercyConfig from '@percy/config';
-import { schema, migration } from '../config';
+import {
+  schema,
+  snapshotListSchema,
+  migration
+} from '../config';
 
 export default function() {
   PercyConfig.addSchema(schema);
+  PercyConfig.addSchema(snapshotListSchema);
   PercyConfig.addMigration(migration);
 }

--- a/packages/cli-snapshot/test/snapshot.test.js
+++ b/packages/cli-snapshot/test/snapshot.test.js
@@ -283,5 +283,25 @@ describe('percy snapshot', () => {
         '[percy] Snapshot found: Other JS Snapshot'
       ]);
     });
+
+    it('logs validation warnings', async () => {
+      fs.writeFileSync('invalid.yml', [
+        'snapshots:',
+        '  - foo: bar',
+        '    name: Test snap'
+      ].join('\n'));
+
+      await expectAsync(
+        Snapshot.run(['./invalid.yml', '--dry-run'])
+      ).toBeRejected();
+
+      expect(logger.stdout).toEqual([]);
+      expect(logger.stderr).toEqual([
+        '[percy] Invalid snapshot options:',
+        '[percy] - snapshots[0].url: missing required property',
+        '[percy] - snapshots[0].foo: unknown property',
+        '[percy] Error: No snapshots found'
+      ]);
+    });
   });
 });


### PR DESCRIPTION
## What is this?

This resolves #305 and piggybacks off of #406 & #416 to validate page listings passed to the snapshot command. In addition to validations, page listing files can now contain a top-level `snapshots` key which references the list of snapshots. This enables YAML files to utilize [anchors, references, and extending](https://blog.daemonl.com/2016/02/yaml.html).

Tests were also reorganized a little and cleanup is done with the help of a rimraf transient dep.