### PR TITLE
✨ Add static snapshot overrides option

### DIFF
--- a/packages/cli-snapshot/README.md
+++ b/packages/cli-snapshot/README.md
@@ -47,20 +47,6 @@ EXAMPLES
 
 ## Usage
 
-### Static Directory
-
-When providing a static directory, it will be served locally and pages matching the `files` argument
-(and excluding the `ignore` argument) will be navigated to and snapshotted.
-
-```sh-session
-$ percy snapshot ./public
-[percy] Percy has started!
-[percy] Snapshot taken: /index.html
-[percy] Snapshot taken: /about.html
-[percy] Snapshot taken: /contact.html
-[percy] Finalized build #1: https://percy.io/org/project/123
-```
-
 ### Page Listing
 
 When providing a file containing a list of pages to snapshot, the file must be YAML, JSON, or a JS
@@ -70,8 +56,8 @@ using a browser.
 `pages.yml`:
 
 ```yaml
-- url: http://localhost:8080
-- url: http://localhost:8080/two
+- http://localhost:8080
+- http://localhost:8080/two
 ```
 
 Snapshotting `pages.yml`:
@@ -84,7 +70,7 @@ $ percy snapshot pages.yml
 [percy] Finalized build #1: https://percy.io/org/project/123
 ```
 
-### Page Options
+#### Page Options
 
 A `name` can be provided which will override the default snapshot name generated from the url
 path. The options `waitForTimeout` and `waitForSelector` can also be provided to wait for a timeout
@@ -161,4 +147,35 @@ module.exports = async () => {
   let urls = await getSnapshotUrls()
   return urls.map(url => ({ name: url, url }))
 }
+```
+
+### Static Directory
+
+When providing a static directory, it will be served locally and pages matching the `files` argument
+(and excluding the `ignore` argument) will be navigated to and snapshotted.
+
+```sh-session
+$ percy snapshot ./public
+[percy] Percy has started!
+[percy] Snapshot taken: /index.html
+[percy] Snapshot taken: /about.html
+[percy] Snapshot taken: /contact.html
+[percy] Finalized build #1: https://percy.io/org/project/123
+```
+
+#### Static Overrides
+
+Just like [page listing options](#page-options) above, static snapshots may also contain
+per-snapshot configuration options. However, since pages are matched against the `static.files`
+option, so are per-snapshot configuration options via an array of `static.overrides`. If multiple
+overrides match a snapshot, they will be merged with previously matched overrides.
+
+``` yaml
+static:
+  files: **/*.{html,htm}
+  overrides:
+  - files: /foo-bar.html
+    waitForSelector: .is-ready
+    execute: |
+      document.querySelector('.button').click()
 ```

--- a/packages/cli-snapshot/package.json
+++ b/packages/cli-snapshot/package.json
@@ -35,6 +35,7 @@
     "@percy/dom": "^1.0.0-beta.58",
     "@percy/logger": "^1.0.0-beta.58",
     "globby": "^11.0.1",
+    "picomatch": "^2.3.0",
     "serve-handler": "^6.1.3",
     "yaml": "^1.10.0"
   }

--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -1,3 +1,5 @@
+import { snapshotSchema } from '@percy/core/dist/config';
+
 // Config schema for static directories
 export const schema = {
   static: {
@@ -25,6 +27,19 @@ export const schema = {
           { type: 'array', items: { type: 'string' } }
         ],
         default: ''
+      },
+      overrides: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            files: { $ref: '#/properties/files' },
+            ignore: { $ref: '#/properties/ignore' },
+            // schemas have no concept of inheritance, but we can leverage JS for brevity
+            ...snapshotSchema.properties
+          }
+        }
       }
     }
   }

--- a/packages/cli-snapshot/test/snapshot.test.js
+++ b/packages/cli-snapshot/test/snapshot.test.js
@@ -74,6 +74,12 @@ describe('percy snapshot', () => {
       fs.writeFileSync(path.join('public', 'test-4.xml'), '<p>Test 4</p>');
     });
 
+    afterEach(() => {
+      if (fs.existsSync('.percy.yml')) {
+        fs.unlinkSync('.percy.yml');
+      }
+    });
+
     it('errors when the base-url is invalid', async () => {
       await expectAsync(Snapshot.run(['./public', '--base-url=wrong']))
         .toBeRejectedWithError('EEXIT: 1');
@@ -122,6 +128,31 @@ describe('percy snapshot', () => {
         '[percy] Snapshot found: /test-1.html',
         '[percy] Snapshot found: /test-2.html',
         '[percy] Snapshot found: /test-3.htm'
+      ]);
+    });
+
+    it('accepts snapshot config overrides', async () => {
+      fs.writeFileSync('.percy.yml', [
+        'version: 2',
+        'static:',
+        '  overrides:',
+        '  - additionalSnapshots:',
+        '    - suffix: " (2)"',
+        '  - files: "*-1.html"',
+        '    name: First'
+      ].join('\n'));
+
+      await Snapshot.run(['./public', '--dry-run']);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Found 3 snapshots',
+        '[percy] Snapshot found: First',
+        '[percy] Snapshot found: First (2)',
+        '[percy] Snapshot found: /test-2.html',
+        '[percy] Snapshot found: /test-2.html (2)',
+        '[percy] Snapshot found: /test-3.htm',
+        '[percy] Snapshot found: /test-3.htm (2)'
       ]);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7072,6 +7072,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
+picomatch@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
+  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"


### PR DESCRIPTION
## What is this?

This allows static snapshots to be configured with per-snapshot options!

``` yaml
static:
  files: **/*.{html,htm}
  overrides:
  - files: /foo-bar.html
    waitForSelector: .is-ready
    execute: |
      document.querySelector('.button').click()
```

I'm not too thrilled with the `overrides` name; could be `options`, `snapshotOptions`, `etc`?