### PR TITLE
✨ Add queue concurrency to the upload command

### DIFF
--- a/packages/cli-upload/src/config.js
+++ b/packages/cli-upload/src/config.js
@@ -16,6 +16,10 @@ export const schema = {
           { type: 'array', items: { type: 'string' } }
         ],
         default: ''
+      },
+      concurrency: {
+        type: 'number',
+        minimum: 1
       }
     }
   }

--- a/packages/cli-upload/test/upload.test.js
+++ b/packages/cli-upload/test/upload.test.js
@@ -169,16 +169,16 @@ describe('percy upload', () => {
     fs.writeFileSync('.percy.yml', [
       'version: 2',
       'upload:',
-      '  concurrency: 1',
+      '  concurrency: 1'
     ].join('\n'));
 
     let upload = Upload.run(['./images']);
 
     // wait for the first upload before terminating
-    await new Promise(r => function check() {
+    await new Promise(r => (function check() {
       if (mockAPI.requests['/builds/123/snapshots']) r();
       else setTimeout(check, 10);
-    }());
+    }()));
 
     process.emit('SIGTERM');
     await upload;


### PR DESCRIPTION
## What is this?

This resolves #391 and utilizes core's queue class to parallelize the upload command. It adds a `upload.concurrency` option as well to allow control of the queue size. It also borrows a pattern from core by waiting on uploads at the "end" of the process and clearing the queue on error to allow the process to continue.