### PR TITLE
✨ Replace dotenv with custom implementation

### DIFF
--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -20,8 +20,5 @@
   },
   "devDependencies": {
     "mock-require": "^3.0.3"
-  },
-  "dependencies": {
-    "dotenv": "^10.0.0"
   }
 }

--- a/packages/env/src/dotenv.js
+++ b/packages/env/src/dotenv.js
@@ -1,25 +1,76 @@
-const dotenv = require('dotenv');
+import fs from 'fs';
 
-// mimic dotenv-rails file hierarchy
-// https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
-export function config() {
-  let {
-    NODE_ENV: env,
-    PERCY_DISABLE_DOTENV: disable
-  } = process.env;
+// Heavily inspired by dotenv-rails
+// https://github.com/bkeepers/dotenv
 
+// matches each valid line of a dotenv file
+const LINE_REG = new RegExp([
+  // key with optional export
+  '^\\s*(?:export\\s+)?(?<key>[\\w.]+)',
+  // separator
+  '(?:\\s*=\\s*?|:\\s+?)(?:',
+  // single quoted value or
+  '\\s*(?<squote>\')(?<sval>(?:\\\\\'|[^\'])*)\'|',
+  // double quoted value or
+  '\\s*(?<dquote>")(?<dval>(?:\\\\"|[^"])*)"|',
+  // unquoted value
+  '(?<uval>[^#\\r\\n]+))?',
+  // optional comment
+  '\\s*(?:#.*)?$'
+].join(''), 'gm');
+
+// interpolate variable substitutions
+const INTERPOLATE_REG = /(.?)(\${?([a-zA-Z0-9_]+)?}?)/g;
+// expand newlines
+const EXPAND_CRLF_REG = /\\(?:(r)|n)/g;
+// unescape characters
+const UNESC_CHAR_REG = /\\([^$])/g;
+
+export function load() {
   // don't load dotenv files when disabled
-  if (disable) return;
+  if (process.env.PERCY_DISABLE_DOTENV) return;
+  let { NODE_ENV } = process.env;
 
+  // dotenv filepaths ordered by priority
   let paths = [
-    env && `.env.${env}.local`,
-    // .env.local is not loaded in test environments
-    env === 'test' ? null : '.env.local',
-    env && `.env.${env}`,
+    NODE_ENV && `.env.${NODE_ENV}.local`,
+    NODE_ENV !== 'test' && '.env.local',
+    NODE_ENV && `.env.${NODE_ENV}`,
     '.env'
-  ].filter(Boolean);
+  ];
 
+  // load each dotenv file synchronously
   for (let path of paths) {
-    dotenv.config({ path });
+    try {
+      let src = fs.readFileSync(path, { encoding: 'utf-8' });
+
+      // iterate over each matching line
+      for (let { groups: match } of src.matchAll(LINE_REG)) {
+        let value = match.sval ?? match.dval ?? match.uval ?? '';
+
+        // if double quoted, expand newlines
+        if (match.dquote) {
+          value = value.replace(EXPAND_CRLF_REG, (_, r) => r ? '\r' : '\n');
+        }
+
+        // unescape characters
+        value = value.replace(UNESC_CHAR_REG, '$1');
+
+        // if not single quoted, interpolate substitutions
+        if (!match.squote) {
+          value = value.replace(INTERPOLATE_REG, (_, pre, ref, key) => {
+            if (pre === '\\') return ref; // escaped reference
+            return pre + (process.env[key] ?? '');
+          });
+        }
+
+        // set process.env if not already
+        if (!Object.prototype.hasOwnProperty.call(process.env, match.key)) {
+          process.env[match.key] = value;
+        }
+      }
+    } catch (e) {
+      // silent error
+    }
   }
 }

--- a/packages/env/src/index.js
+++ b/packages/env/src/index.js
@@ -1,2 +1,2 @@
 export { default } from './environment';
-require('./dotenv').config();
+require('./dotenv').load();

--- a/packages/env/test/dotenv.test.js
+++ b/packages/env/test/dotenv.test.js
@@ -30,6 +30,13 @@ describe('dotenv files', () => {
     expect(process.env).toHaveProperty('TEST_3', '3');
   });
 
+  it('does not override existing environment variables', () => {
+    process.env.TEST_1 = 'uno';
+    mock.reRequire('../src');
+
+    expect(process.env).toHaveProperty('TEST_1', 'uno');
+  });
+
   it('loads environment specific .env and .env.local files', () => {
     dotenvs['.env.dev'] = 'TEST_3=dev_3';
     dotenvs['.env.dev.local'] = 'TEST_2=dev_two';
@@ -55,5 +62,45 @@ describe('dotenv files', () => {
     process.env.PERCY_DISABLE_DOTENV = 'true';
     mock.reRequire('../src');
     expect(process.env).toEqual({ PERCY_DISABLE_DOTENV: 'true' });
+  });
+
+  it('expands newlines within double quotes', () => {
+    dotenvs['.env'] = 'TEST_NEWLINES="foo\nbar\r\nbaz\\nqux\\r\\nxyzzy"';
+    mock.reRequire('../src');
+
+    expect(process.env).toHaveProperty('TEST_NEWLINES', 'foo\nbar\r\nbaz\nqux\r\nxyzzy');
+  });
+
+  it('interpolates variable substitutions', () => {
+    // eslint-disable-next-line no-template-curly-in-string
+    dotenvs['.env'] += '\nTEST_4=$TEST_1${TEST_2}\nTEST_5=$TEST_4${TEST_3}four';
+    mock.reRequire('../src');
+
+    expect(process.env).toHaveProperty('TEST_4', '1two');
+    expect(process.env).toHaveProperty('TEST_5', '1two3four');
+  });
+
+  it('interpolates undefined variables with empty strings', () => {
+    // eslint-disable-next-line no-template-curly-in-string
+    dotenvs['.env'] += '\nTEST_TWO=2 > ${TEST_ONE}\nTEST_THREE=';
+    mock.reRequire('../src');
+
+    expect(process.env).not.toHaveProperty('TEST_ONE');
+    expect(process.env).toHaveProperty('TEST_TWO', '2 > ');
+    expect(process.env).toHaveProperty('TEST_THREE', '');
+  });
+
+  it('does not interpolate single quoted strings', () => {
+    dotenvs['.env'] += "\nTEST_STRING='$TEST_1'";
+    mock.reRequire('../src');
+
+    expect(process.env).toHaveProperty('TEST_STRING', '$TEST_1');
+  });
+
+  it('does not interpolate escaped dollar signs', () => {
+    dotenvs['.env'] += '\nTEST_ESC=\\$TEST_1';
+    mock.reRequire('../src');
+
+    expect(process.env).toHaveProperty('TEST_ESC', '$TEST_1');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3643,11 +3643,6 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
-  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
-
 duplexer@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"


### PR DESCRIPTION
## What is this?

As requested by #410, it's nice to be able to interpolate environment variables within other environment variables. As suggested in the issue, I started with the `dotenv-expand` package and added it as a dependency. Upon a quick review of its internals, I noticed that not only was it small and still did more than we needed, but it was also a bit inefficient with several loops and unnecessary regular expression creations within those loops.

After implementing a more succinct variable expansion helper, I was checking against dotenv-rails, which is what we always intended to mimic. I then noticed there were several other differences with the dotenv package we were using related to variable interpolation, escaping, file parsing, and other features.

The dotenv package we were using was pretty small, so it was fairly straightforward to copy it over and trim away everything we didn't need. For example, we always want to set `process.env` when it isn't already, while dotenv libraries are split up to allow parsing without setting `process.env`. After cutting away the fat, changes were made to align with dotenv-rails, including variable substitution (the original goal of this PR).

Most changes were ported over from dotenv-rails directly, such as the regular expression used to parse the file and the logic behind expanding, unescaping, and interpolating values. 