### PR TITLE
♻️ Lockstep sub-package versions

### DIFF
--- a/packages/cli-build/package.json
+++ b/packages/cli-build/package.json
@@ -31,9 +31,9 @@
     }
   },
   "dependencies": {
-    "@percy/cli-command": "^1.0.0-beta.59",
-    "@percy/client": "^1.0.0-beta.59",
-    "@percy/env": "^1.0.0-beta.59",
-    "@percy/logger": "^1.0.0-beta.59"
+    "@percy/cli-command": "1.0.0-beta.59",
+    "@percy/client": "1.0.0-beta.59",
+    "@percy/env": "1.0.0-beta.59",
+    "@percy/logger": "1.0.0-beta.59"
   }
 }

--- a/packages/cli-command/package.json
+++ b/packages/cli-command/package.json
@@ -25,7 +25,7 @@
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
     "@oclif/plugin-help": "^3.2.0",
-    "@percy/config": "^1.0.0-beta.59",
-    "@percy/logger": "^1.0.0-beta.59"
+    "@percy/config": "1.0.0-beta.59",
+    "@percy/logger": "1.0.0-beta.59"
   }
 }

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
-    "@percy/config": "^1.0.0-beta.59",
-    "@percy/logger": "^1.0.0-beta.59"
+    "@percy/config": "1.0.0-beta.59",
+    "@percy/logger": "1.0.0-beta.59"
   }
 }

--- a/packages/cli-exec/package.json
+++ b/packages/cli-exec/package.json
@@ -35,9 +35,9 @@
     }
   },
   "dependencies": {
-    "@percy/cli-command": "^1.0.0-beta.59",
-    "@percy/core": "^1.0.0-beta.59",
-    "@percy/logger": "^1.0.0-beta.59",
+    "@percy/cli-command": "1.0.0-beta.59",
+    "@percy/core": "1.0.0-beta.59",
+    "@percy/logger": "1.0.0-beta.59",
     "cross-spawn": "^7.0.3",
     "which": "^2.0.2"
   }

--- a/packages/cli-snapshot/package.json
+++ b/packages/cli-snapshot/package.json
@@ -29,11 +29,11 @@
     }
   },
   "dependencies": {
-    "@percy/cli-command": "^1.0.0-beta.59",
-    "@percy/config": "^1.0.0-beta.59",
-    "@percy/core": "^1.0.0-beta.59",
-    "@percy/dom": "^1.0.0-beta.59",
-    "@percy/logger": "^1.0.0-beta.59",
+    "@percy/cli-command": "1.0.0-beta.59",
+    "@percy/config": "1.0.0-beta.59",
+    "@percy/core": "1.0.0-beta.59",
+    "@percy/dom": "1.0.0-beta.59",
+    "@percy/logger": "1.0.0-beta.59",
     "globby": "^11.0.4",
     "picomatch": "^2.3.0",
     "serve-handler": "^6.1.3",

--- a/packages/cli-upload/package.json
+++ b/packages/cli-upload/package.json
@@ -29,10 +29,10 @@
     }
   },
   "dependencies": {
-    "@percy/cli-command": "^1.0.0-beta.59",
-    "@percy/client": "^1.0.0-beta.59",
-    "@percy/config": "^1.0.0-beta.59",
-    "@percy/logger": "^1.0.0-beta.59",
+    "@percy/cli-command": "1.0.0-beta.59",
+    "@percy/client": "1.0.0-beta.59",
+    "@percy/config": "1.0.0-beta.59",
+    "@percy/logger": "1.0.0-beta.59",
     "globby": "^11.0.4",
     "image-size": "^1.0.0"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,10 +35,10 @@
   },
   "dependencies": {
     "@oclif/plugin-help": "^3.2.0",
-    "@percy/cli-build": "^1.0.0-beta.59",
-    "@percy/cli-config": "^1.0.0-beta.59",
-    "@percy/cli-exec": "^1.0.0-beta.59",
-    "@percy/cli-snapshot": "^1.0.0-beta.59",
-    "@percy/cli-upload": "^1.0.0-beta.59"
+    "@percy/cli-build": "1.0.0-beta.59",
+    "@percy/cli-config": "1.0.0-beta.59",
+    "@percy/cli-exec": "1.0.0-beta.59",
+    "@percy/cli-snapshot": "1.0.0-beta.59",
+    "@percy/cli-upload": "1.0.0-beta.59"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -23,7 +23,7 @@
     "mock-require": "^3.0.3"
   },
   "dependencies": {
-    "@percy/env": "^1.0.0-beta.59",
-    "@percy/logger": "^1.0.0-beta.59"
+    "@percy/env": "1.0.0-beta.59",
+    "@percy/logger": "1.0.0-beta.59"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@percy/logger": "^1.0.0-beta.59",
+    "@percy/logger": "1.0.0-beta.59",
     "ajv": "^8.6.2",
     "cosmiconfig": "^7.0.0",
     "yaml": "^1.10.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,10 +25,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@percy/client": "^1.0.0-beta.59",
-    "@percy/config": "^1.0.0-beta.59",
-    "@percy/dom": "^1.0.0-beta.59",
-    "@percy/logger": "^1.0.0-beta.59",
+    "@percy/client": "1.0.0-beta.59",
+    "@percy/config": "1.0.0-beta.59",
+    "@percy/dom": "1.0.0-beta.59",
+    "@percy/logger": "1.0.0-beta.59",
     "cross-spawn": "^7.0.3",
     "extract-zip": "^2.0.1",
     "rimraf": "^3.0.2",

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -46,6 +46,6 @@
     }
   },
   "dependencies": {
-    "@percy/logger": "^1.0.0-beta.59"
+    "@percy/logger": "1.0.0-beta.59"
   }
 }


### PR DESCRIPTION
## What is this?

We should be lock stepping all our sub-packages since they're all released together. This also makes it possible to downgrade the CLI to a specific version