### PR TITLE
🐛 Ensure core schemas are loaded before dependent snapshot schemas

### DIFF
--- a/packages/cli-command/test/command.test.js
+++ b/packages/cli-command/test/command.test.js
@@ -1,9 +1,10 @@
 import logger from '@percy/logger/test/helpers';
 import PercyConfig from '@percy/config';
+import { configSchema } from '@percy/core/dist/config';
 import PercyCommand, { flags } from '../src';
 
 // add config schema to test discovery flags
-PercyConfig.addSchema(require('@percy/core/dist/config').schema);
+PercyConfig.addSchema(configSchema);
 
 describe('PercyCommand', () => {
   let results;

--- a/packages/cli-exec/src/hooks/init.js
+++ b/packages/cli-exec/src/hooks/init.js
@@ -1,8 +1,8 @@
 import PercyConfig from '@percy/config';
-import { schema, migration } from '@percy/core/dist/config';
+import * as CoreConfig from '@percy/core/dist/config';
 
 // ensures the core schema and migration is loaded
 export default function() {
-  PercyConfig.addSchema(schema);
-  PercyConfig.addMigration(migration);
+  PercyConfig.addSchema(CoreConfig.schemas);
+  PercyConfig.addMigration(CoreConfig.migration);
 }

--- a/packages/cli-snapshot/src/commands/snapshot.js
+++ b/packages/cli-snapshot/src/commands/snapshot.js
@@ -7,7 +7,7 @@ import logger from '@percy/logger';
 import globby from 'globby';
 import picomatch from 'picomatch';
 import YAML from 'yaml';
-import { schema } from '../config';
+import { configSchema } from '../config';
 import pkg from '../../package.json';
 
 // Throw a better error message for invalid urls
@@ -43,13 +43,13 @@ export class Snapshot extends Command {
     // static only flags
     files: flags.string({
       description: 'one or more globs matching static file paths to snapshot',
-      default: schema.static.properties.files.default,
+      default: configSchema.static.properties.files.default,
       percyrc: 'static.files',
       multiple: true
     }),
     ignore: flags.string({
       description: 'one or more globs matching static file paths to ignore',
-      default: schema.static.properties.ignore.default,
+      default: configSchema.static.properties.ignore.default,
       percyrc: 'static.ignore',
       multiple: true
     })

--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -1,7 +1,7 @@
 import { snapshotSchema } from '@percy/core/dist/config';
 
 // Config schema for static directories
-export const schema = {
+export const configSchema = {
   static: {
     type: 'object',
     additionalProperties: false,
@@ -66,6 +66,11 @@ export const snapshotListSchema = {
     }
   }]
 };
+
+export const schemas = [
+  configSchema,
+  snapshotListSchema
+];
 
 export function migration(config, { map, del }) {
   /* eslint-disable curly */

--- a/packages/cli-snapshot/src/hooks/init.js
+++ b/packages/cli-snapshot/src/hooks/init.js
@@ -1,12 +1,7 @@
 import PercyConfig from '@percy/config';
-import {
-  schema,
-  snapshotListSchema,
-  migration
-} from '../config';
+import * as SnapshotConfig from '../config';
 
 export default function() {
-  PercyConfig.addSchema(schema);
-  PercyConfig.addSchema(snapshotListSchema);
-  PercyConfig.addMigration(migration);
+  PercyConfig.addSchema(SnapshotConfig.schemas);
+  PercyConfig.addMigration(SnapshotConfig.migration);
 }

--- a/packages/cli-snapshot/src/hooks/init.js
+++ b/packages/cli-snapshot/src/hooks/init.js
@@ -1,7 +1,9 @@
 import PercyConfig from '@percy/config';
+import * as CoreConfig from '@percy/core/dist/config';
 import * as SnapshotConfig from '../config';
 
 export default function() {
+  PercyConfig.addSchema(CoreConfig.schemas);
   PercyConfig.addSchema(SnapshotConfig.schemas);
   PercyConfig.addMigration(SnapshotConfig.migration);
 }

--- a/packages/cli-upload/src/hooks/init.js
+++ b/packages/cli-upload/src/hooks/init.js
@@ -1,7 +1,7 @@
 import PercyConfig from '@percy/config';
-import { schema, migration } from '../config';
+import * as UploadConfig from '../config';
 
 export default function() {
-  PercyConfig.addSchema(schema);
-  PercyConfig.addMigration(migration);
+  PercyConfig.addSchema(UploadConfig.schema);
+  PercyConfig.addMigration(UploadConfig.migration);
 }

--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -73,10 +73,16 @@ export function getSchema(name) {
 
 // Adds schemas to the config schema's properties. The config schema is removed, modified, and
 // replaced after the new schemas are added to clear any compiled caches. Existing schemas are
-// removed and replaced as well. If a schema id is provided as the second argument, the schema
-// will be set independently and not added to config schema's properties.
+// removed and replaced as well. If a schema has an existing $id, the schema will not be added
+// as config schema properties.
 export function addSchema(schemas) {
-  if (isArray(schemas) || schemas.$id) {
+  if (isArray(schemas)) {
+    return schemas.map(addSchema);
+  }
+
+  if (schemas.$id) {
+    let { $id } = schemas;
+    if (ajv.getSchema($id)) ajv.removeSchema($id);
     return ajv.addSchema(schemas);
   }
 
@@ -90,7 +96,7 @@ export function addSchema(schemas) {
     ajv.addSchema(schema, $id);
   }
 
-  ajv.addSchema(config, '/config');
+  return ajv.addSchema(config, '/config');
 }
 
 // Resets the schema by removing all schemas and inserting a new default schema.

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -118,6 +118,39 @@ describe('PercyConfig', () => {
         message: 'must be a string, received null'
       }]);
     });
+
+    it('can add schemas to replace existing schemas', () => {
+      PercyConfig.addSchema({
+        $id: 'foo',
+        type: 'string'
+      });
+
+      PercyConfig.addSchema({
+        $id: 'foo',
+        type: 'number'
+      });
+
+      expect(PercyConfig.validate('foo', 'foo')).toEqual([{
+        path: '',
+        message: 'must be a number, received a string'
+      }]);
+    });
+
+    it('can add multiple schemas at a time', () => {
+      PercyConfig.addSchema([{
+        foo: { type: 'string' }
+      }, {
+        bar: { $ref: '/config/foo' }
+      }]);
+
+      expect(PercyConfig.validate({
+        foo: 'bar',
+        bar: 100
+      })).toEqual([{
+        path: 'bar',
+        message: 'must be a string, received a number'
+      }]);
+    });
   });
 
   describe('.getDefaults()', () => {

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -3,7 +3,7 @@ import PercyConfig from '@percy/config';
 import { merge } from '@percy/config/dist/utils';
 
 // Common config options used in Percy commands
-export const schema = {
+export const configSchema = {
   snapshot: {
     type: 'object',
     additionalProperties: false,
@@ -208,6 +208,13 @@ export const snapshotDOMSchema = {
     ...snapshotSchema.properties
   }
 };
+
+// Convinient reference for schema registration
+export const schemas = [
+  configSchema,
+  snapshotSchema,
+  snapshotDOMSchema
+];
 
 // Migration function
 export function migration(config, { map, del, log }) {

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -2,12 +2,8 @@
 const { default: PercyConfig } = require('@percy/config');
 const CoreConfig = require('./config');
 
-PercyConfig.addSchema(CoreConfig.schema);
+PercyConfig.addSchema(CoreConfig.schemas);
 PercyConfig.addMigration(CoreConfig.migration);
-
-// used for per-snapshot validation
-PercyConfig.addSchema(CoreConfig.snapshotSchema);
-PercyConfig.addSchema(CoreConfig.snapshotDOMSchema);
 
 // Export the Percy class with commonjs compatibility
 module.exports = require('./percy').default;


### PR DESCRIPTION
## What is this?

In tests, schemas are loaded where needed. In practice however, core schemas are not loaded in time for references in the snapshot schema. The answer is to register core schemas before they are needed, however by default this causes AJV to error about existing schema `$id`s when core get's around to registering schemas for itself.

The `addSchema` util was updated to replace existing `$id` schemas just as it already does for config file schemas. A test was added for this, but because the array handling was moved, coverage became low. Another test for an array of schemas was added to account for this missing coverage.

Since arrays of schemas are handled by our util now rather than forwarded directly onto AJV, a new pattern was adopted in the appropriate places. Where multiple schemas are defined, the file exports a single `schemas` array that can be passed to the `addSchema` call made when registering schemas. This reduces some boilerplate around adding schemas and also makes it simple to add all possible required core schemas in one go before they are needed, which was the original intent of this PR.

This will fix #429