### PR TITLE
✨ Add upload option to strip file extensions

### DIFF
--- a/packages/cli-upload/src/config.js
+++ b/packages/cli-upload/src/config.js
@@ -17,6 +17,10 @@ export const schema = {
         ],
         default: ''
       },
+      stripExtensions: {
+        type: 'boolean',
+        default: false
+      },
       concurrency: {
         type: 'number',
         minimum: 1

--- a/packages/cli-upload/src/resources.js
+++ b/packages/cli-upload/src/resources.js
@@ -26,8 +26,8 @@ function createImageResource(url, content, mimetype) {
 // filename, contents, and dimensions. The root resource is a generated DOM
 // designed to display an image at it's native size without margins or padding.
 export default function createImageResources(filename, content, width, height) {
-  let { name, ext } = path.parse(filename);
-  let rootUrl = `/${encodeURIComponent(name)}`;
+  let { dir, name, ext } = path.parse(filename);
+  let rootUrl = `/${encodeURIComponent(path.join(dir, name))}`;
   let imageUrl = `/${encodeURIComponent(filename)}`;
   let mimetype = ext === '.png' ? 'image/png' : 'image/jpeg';
 

--- a/packages/cli-upload/test/upload.test.js
+++ b/packages/cli-upload/test/upload.test.js
@@ -38,6 +38,7 @@ describe('percy upload', () => {
   afterEach(() => {
     delete process.env.PERCY_TOKEN;
     delete process.env.PERCY_ENABLE;
+    process.removeAllListeners();
 
     if (fs.existsSync('.percy.yml')) {
       fs.unlinkSync('.percy.yml');
@@ -124,6 +125,20 @@ describe('percy upload', () => {
         }
       }
     });
+  });
+
+  it('strips file extensions with `--strip-extensions`', async () => {
+    await Upload.run(['./images', '--strip-extensions']);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual(jasmine.arrayContaining([
+      '[percy] Percy has started!',
+      '[percy] Uploading 3 snapshots...',
+      '[percy] Snapshot uploaded: test-1',
+      '[percy] Snapshot uploaded: test-2',
+      '[percy] Snapshot uploaded: test-3',
+      '[percy] Finalized build #1: https://percy.io/test/test/123'
+    ]));
   });
 
   it('skips unsupported image types', async () => {


### PR DESCRIPTION
## What is this?

This implements and resolves #412 with a new `--strip-extensions` flag and accompanying config file option.

The upload config options spreading was growing, so was adjusted to reference the config object rather than spread each individual config option.

The extensions are removed from file paths by parsing the path and rejoining without the extension. While doing this, I realized that the `name` parameter does not include parent directories and updated the resource helper accordingly.

The allowed file type regular expression was also updated since it now tests the file extension only and not the entire path.