### PR TITLE
🔨 Add `repository` field to `package.json` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,9 @@
     "nyc": "^15.1.0",
     "rollup": "^2.53.2",
     "tsd": "^0.17.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli"
   }
 }

--- a/packages/cli-build/package.json
+++ b/packages/cli-build/package.json
@@ -35,5 +35,10 @@
     "@percy/client": "1.0.0-beta.60",
     "@percy/env": "1.0.0-beta.60",
     "@percy/logger": "1.0.0-beta.60"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/cli-build"
   }
 }

--- a/packages/cli-command/package.json
+++ b/packages/cli-command/package.json
@@ -27,5 +27,10 @@
     "@oclif/plugin-help": "^3.2.0",
     "@percy/config": "1.0.0-beta.60",
     "@percy/logger": "1.0.0-beta.60"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/cli-command"
   }
 }

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -35,5 +35,10 @@
     "@oclif/config": "^1.17.0",
     "@percy/config": "1.0.0-beta.60",
     "@percy/logger": "1.0.0-beta.60"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/cli-config"
   }
 }

--- a/packages/cli-exec/package.json
+++ b/packages/cli-exec/package.json
@@ -40,5 +40,10 @@
     "@percy/logger": "1.0.0-beta.60",
     "cross-spawn": "^7.0.3",
     "which": "^2.0.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/cli-exec"
   }
 }

--- a/packages/cli-snapshot/package.json
+++ b/packages/cli-snapshot/package.json
@@ -38,5 +38,10 @@
     "picomatch": "^2.3.0",
     "serve-handler": "^6.1.3",
     "yaml": "^1.10.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/cli-snapshot"
   }
 }

--- a/packages/cli-upload/package.json
+++ b/packages/cli-upload/package.json
@@ -35,5 +35,10 @@
     "@percy/logger": "1.0.0-beta.60",
     "globby": "^11.0.4",
     "image-size": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/cli-upload"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,5 +40,10 @@
     "@percy/cli-exec": "1.0.0-beta.60",
     "@percy/cli-snapshot": "1.0.0-beta.60",
     "@percy/cli-upload": "1.0.0-beta.60"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/cli"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -25,5 +25,10 @@
   "dependencies": {
     "@percy/env": "1.0.0-beta.60",
     "@percy/logger": "1.0.0-beta.60"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/client"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -29,5 +29,10 @@
   },
   "devDependencies": {
     "json-schema-typed": "^7.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/config"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,5 +33,10 @@
     "extract-zip": "^2.0.1",
     "rimraf": "^3.0.2",
     "ws": "^7.5.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/core"
   }
 }

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -28,5 +28,10 @@
   },
   "devDependencies": {
     "interactor.js": "^2.0.0-beta.10"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/dom"
   }
 }

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -20,5 +20,10 @@
   },
   "devDependencies": {
     "mock-require": "^3.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/env"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -25,5 +25,10 @@
     "output": {
       "name": "PercyLogger"
     }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/logger"
   }
 }

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -47,5 +47,10 @@
   },
   "dependencies": {
     "@percy/logger": "1.0.0-beta.60"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/percy/cli",
+    "directory": "packages/sdk-utils"
   }
 }


### PR DESCRIPTION
Close #435

This change is created by the following Bash script:

```bash
#!/usr/bin/env bash
set -eu -o pipefail

files=$(git ls-files | grep package.json)
for file in $files; do
  echo "Adding repository to ${file} ..."
  dir=$(dirname $file)
  if [[ $dir == "." ]]; then
    npm pkg set repository.type="git" repository.url="https://github.com/percy/cli"
  else
    npm pkg set repository.type="git" repository.url="https://github.com/percy/cli" repository.directory="$dir" --workspace="$dir"
  fi
done
```

(Note: `npm pkg` is available since [npm@7.20.0](https://github.com/npm/cli/releases/tag/v7.20.0))

Also, the changed `package.json` files can be verified by the following command:

```console
$ cat .npmpackagejsonlintrc.json
{
  "rules": {
    "require-repository": "error"
  }
}
$ npx npm-package-json-lint .
```

See also:
- https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository
- https://npmpackagejsonlint.org