### PR TITLE
✨ Add static snapshot clean-urls and rewrites options

### DIFF
--- a/packages/cli-snapshot/README.md
+++ b/packages/cli-snapshot/README.md
@@ -18,24 +18,19 @@ ARGUMENTS
   PATHNAME  path to a directory or file containing a list of pages
 
 OPTIONS
-  -b, --base-url=base-url                          [default: /] the url path to serve the static directory from
+  -b, --base-url=base-url                          the base url pages are hosted at when snapshotting
   -c, --config=config                              configuration file path
   -d, --dry-run                                    prints a list of pages to snapshot without snapshotting
+  -h, --allowed-hostname=allowed-hostname          allowed hostnames
+  -q, --quiet                                      log errors only
+  -t, --network-idle-timeout=network-idle-timeout  asset discovery idle timeout
+  -v, --verbose                                    log everything
+  --disable-cache                                  disable asset discovery caches
 
-  -f, --files=files                                [default: **/*.{html,htm}] one or more globs matching static file
+  --files=files                                    [default: **/*.{html,htm}] one or more globs matching static file
                                                    paths to snapshot
 
-  -h, --allowed-hostname=allowed-hostname          allowed hostnames
-
-  -i, --ignore=ignore                              one or more globs matching static file paths to ignore
-
-  -q, --quiet                                      log errors only
-
-  -t, --network-idle-timeout=network-idle-timeout  asset discovery idle timeout
-
-  -v, --verbose                                    log everything
-
-  --disable-cache                                  disable asset discovery caches
+  --ignore=ignore                                  one or more globs matching static file paths to ignore
 
   --silent                                         log nothing
 
@@ -163,19 +158,60 @@ $ percy snapshot ./public
 [percy] Finalized build #1: https://percy.io/org/project/123
 ```
 
-#### Static Overrides
+#### Static Options
 
-Just like [page listing options](#page-options) above, static snapshots may also contain
-per-snapshot configuration options. However, since pages are matched against the `static.files`
-option, so are per-snapshot configuration options via an array of `static.overrides`. If multiple
-overrides match a snapshot, they will be merged with previously matched overrides.
+For snapshotting static directories, the following Percy config file options are also accepted:
 
 ``` yaml
+# .percy.yml
+version: 2
 static:
   files: **/*.{html,htm}
-  overrides:
-  - files: /foo-bar.html
-    waitForSelector: .is-ready
-    execute: |
-      document.querySelector('.button').click()
+  ignore: []
+  base-url: /
+  clean-urls: false
+  rewrites: {}
+  overrides: []
 ```
+
+- **files** - A glob or an arry of globs matching static file paths to snapshot.
+- **ignore** - A glob or an arry of globs matching static file paths to ignore.
+- **base-url** - The base URL path the static site should be served under.
+- **clean-urls** - When true, rewrite index and filepath URLs to be clean.
+
+<span/>
+
+- **rewrites** - An object containing source-destination pairs for rewriting URLs.
+
+  Paths for resources can sometimes be expected to be in a certain format that may not be covered by
+  the `clean-urls` option. For such paths, rewrites can map a short, clean, or pretty path to a
+  specific resource. Paths are matched using [path-to-regexp](https://github.com/pillarjs/path-to-regexp).
+
+  ``` yaml
+  # .percy.yml
+  version: 2
+  static:
+    base-url: /blog
+    rewrites:
+      /:year/:month/:title: /posts/:year-:month--:title.html
+      /:year/:month: /posts/index-:year-:month.html
+      /:year: /posts/index-:year.html
+  ```
+
+- **overrides** - An array of per-snapshot option overrides.
+
+  Just like [page listing options](#page-options), static snapshots may also contain
+  per-snapshot configuration options. However, since pages are matched against the `files`
+  option, so are per-snapshot configuration options via an array of `overrides`. If multiple
+  overrides match a snapshot, they will be merged with previously matched overrides.
+
+  ``` yaml
+  # .percy.yml
+  version: 2
+  static:
+    overrides:
+    - files: /foo-bar.html
+      waitForSelector: .is-ready
+      execute: |
+        document.querySelector('.button').click()
+  ```

--- a/packages/cli-snapshot/package.json
+++ b/packages/cli-snapshot/package.json
@@ -35,6 +35,7 @@
     "@percy/dom": "1.0.0-beta.60",
     "@percy/logger": "1.0.0-beta.60",
     "globby": "^11.0.4",
+    "path-to-regexp": "^6.2.0",
     "picomatch": "^2.3.0",
     "serve-handler": "^6.1.3",
     "yaml": "^1.10.0"

--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -9,7 +9,6 @@ export const configSchema = {
       baseUrl: {
         type: 'string',
         pattern: '^/',
-        default: '/',
         errors: {
           pattern: 'must start with a forward slash (/)'
         }
@@ -27,6 +26,14 @@ export const configSchema = {
           { type: 'array', items: { type: 'string' } }
         ],
         default: ''
+      },
+      cleanUrls: {
+        type: 'boolean',
+        default: false
+      },
+      rewrites: {
+        type: 'object',
+        additionalProperties: { type: 'string' }
       },
       overrides: {
         type: 'array',

--- a/packages/cli-snapshot/test/snapshot.test.js
+++ b/packages/cli-snapshot/test/snapshot.test.js
@@ -98,10 +98,11 @@ describe('percy snapshot', () => {
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual(jasmine.arrayContaining([
         '[percy] Percy has started!',
-        '[percy] Processing 3 snapshots...',
+        '[percy] Processing 4 snapshots...',
         '[percy] Snapshot taken: /test-1.html',
         '[percy] Snapshot taken: /test-2.html',
         '[percy] Snapshot taken: /test-3.html',
+        '[percy] Snapshot taken: /test-index/index.html',
         '[percy] Finalized build #1: https://percy.io/test/test/123'
       ]));
     });
@@ -112,10 +113,11 @@ describe('percy snapshot', () => {
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual(jasmine.arrayContaining([
         '[percy] Percy has started!',
-        '[percy] Processing 3 snapshots...',
+        '[percy] Processing 4 snapshots...',
         '[percy] Snapshot taken: /base/test-1.html',
         '[percy] Snapshot taken: /base/test-2.html',
         '[percy] Snapshot taken: /base/test-3.html',
+        '[percy] Snapshot taken: /base/test-index/index.html',
         '[percy] Finalized build #1: https://percy.io/test/test/123'
       ]));
     });
@@ -125,10 +127,11 @@ describe('percy snapshot', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
-        '[percy] Found 3 snapshots',
+        '[percy] Found 4 snapshots',
         '[percy] Snapshot found: /test-1.html',
         '[percy] Snapshot found: /test-2.html',
         '[percy] Snapshot found: /test-3.html',
+        '[percy] Snapshot found: /test-index/index.html'
       ]);
     });
 
@@ -147,13 +150,49 @@ describe('percy snapshot', () => {
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual([
-        '[percy] Found 3 snapshots',
+        '[percy] Found 4 snapshots',
         '[percy] Snapshot found: First',
         '[percy] Snapshot found: First (2)',
         '[percy] Snapshot found: /test-2.html',
         '[percy] Snapshot found: /test-2.html (2)',
         '[percy] Snapshot found: /test-3.html',
         '[percy] Snapshot found: /test-3.html (2)',
+        '[percy] Snapshot found: /test-index/index.html',
+        '[percy] Snapshot found: /test-index/index.html (2)'
+      ]);
+    });
+
+    it('rewrites file and index URLs with --clean-urls', async () => {
+      await Snapshot.run(['./public', '--dry-run', '--clean-urls']);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Found 4 snapshots',
+        '[percy] Snapshot found: /test-1',
+        '[percy] Snapshot found: /test-2',
+        '[percy] Snapshot found: /test-3',
+        '[percy] Snapshot found: /test-index'
+      ]);
+    });
+
+    it('rewrites URLs based on the provided rewrites config option', async () => {
+      fs.writeFileSync('.percy.yml', [
+        'version: 2',
+        'static:',
+        '  cleanUrls: true',
+        '  rewrites:',
+        '    /:path/:n: /:path-:n.html'
+      ].join('\n'));
+
+      await Snapshot.run(['./public', '--dry-run']);
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Found 4 snapshots',
+        '[percy] Snapshot found: /test/1',
+        '[percy] Snapshot found: /test/2',
+        '[percy] Snapshot found: /test/3',
+        '[percy] Snapshot found: /test-index'
       ]);
     });
   });

--- a/packages/cli-snapshot/test/snapshot.test.js
+++ b/packages/cli-snapshot/test/snapshot.test.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { inspect } from 'util';
 import rimraf from 'rimraf';
+import PercyConfig from '@percy/config';
 import mockAPI from '@percy/client/test/helpers';
 import logger from '@percy/logger/test/helpers';
 import { createTestServer } from '@percy/core/test/helpers';
@@ -12,19 +13,13 @@ const cwd = process.cwd();
 describe('percy snapshot', () => {
   beforeAll(() => {
     require('../src/hooks/init').default();
-
-    fs.mkdirSync(path.join(__dirname, 'tmp'));
-    process.chdir(path.join(__dirname, 'tmp'));
-
-    fs.mkdirSync('public');
-  });
-
-  afterAll(() => {
-    process.chdir(cwd);
-    rimraf.sync(path.join(__dirname, 'tmp'));
   });
 
   beforeEach(() => {
+    fs.mkdirSync(path.join(__dirname, 'tmp'));
+    process.chdir(path.join(__dirname, 'tmp'));
+    fs.mkdirSync('public');
+
     process.env.PERCY_TOKEN = '<<PERCY_TOKEN>>';
     mockAPI.start(50);
     logger.mock();
@@ -34,6 +29,9 @@ describe('percy snapshot', () => {
     delete process.env.PERCY_TOKEN;
     delete process.env.PERCY_ENABLE;
     process.removeAllListeners();
+
+    process.chdir(cwd);
+    rimraf.sync(path.join(__dirname, 'tmp'));
   });
 
   it('skips snapshotting when Percy is disabled', async () => {
@@ -67,17 +65,20 @@ describe('percy snapshot', () => {
   });
 
   describe('snapshotting static directories', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       fs.writeFileSync(path.join('public', 'test-1.html'), '<p>Test 1</p>');
       fs.writeFileSync(path.join('public', 'test-2.html'), '<p>Test 2</p>');
-      fs.writeFileSync(path.join('public', 'test-3.htm'), '<p>Test 3</p>');
+      fs.writeFileSync(path.join('public', 'test-3.html'), '<p>Test 3</p>');
       fs.writeFileSync(path.join('public', 'test-4.xml'), '<p>Test 4</p>');
+      fs.writeFileSync(path.join('public', 'test-5.xml'), '<p>Test 5</p>');
+
+      fs.mkdirSync(path.join('public', 'test-index'));
+      fs.writeFileSync(path.join('public', 'test-index', 'index.html'), '<p>Test Index</p>');
     });
 
     afterEach(() => {
-      if (fs.existsSync('.percy.yml')) {
-        fs.unlinkSync('.percy.yml');
-      }
+      try { fs.unlinkSync('.percy.yml'); } catch {}
+      PercyConfig.cache.clear();
     });
 
     it('errors when the base-url is invalid', async () => {
@@ -100,13 +101,13 @@ describe('percy snapshot', () => {
         '[percy] Processing 3 snapshots...',
         '[percy] Snapshot taken: /test-1.html',
         '[percy] Snapshot taken: /test-2.html',
-        '[percy] Snapshot taken: /test-3.htm',
+        '[percy] Snapshot taken: /test-3.html',
         '[percy] Finalized build #1: https://percy.io/test/test/123'
       ]));
     });
 
     it('snapshots matching files hosted with a base-url', async () => {
-      await Snapshot.run(['./public', '--base-url=/base/']);
+      await Snapshot.run(['./public', '--base-url=/base']);
 
       expect(logger.stderr).toEqual([]);
       expect(logger.stdout).toEqual(jasmine.arrayContaining([
@@ -114,7 +115,7 @@ describe('percy snapshot', () => {
         '[percy] Processing 3 snapshots...',
         '[percy] Snapshot taken: /base/test-1.html',
         '[percy] Snapshot taken: /base/test-2.html',
-        '[percy] Snapshot taken: /base/test-3.htm',
+        '[percy] Snapshot taken: /base/test-3.html',
         '[percy] Finalized build #1: https://percy.io/test/test/123'
       ]));
     });
@@ -127,7 +128,7 @@ describe('percy snapshot', () => {
         '[percy] Found 3 snapshots',
         '[percy] Snapshot found: /test-1.html',
         '[percy] Snapshot found: /test-2.html',
-        '[percy] Snapshot found: /test-3.htm'
+        '[percy] Snapshot found: /test-3.html',
       ]);
     });
 
@@ -151,8 +152,8 @@ describe('percy snapshot', () => {
         '[percy] Snapshot found: First (2)',
         '[percy] Snapshot found: /test-2.html',
         '[percy] Snapshot found: /test-2.html (2)',
-        '[percy] Snapshot found: /test-3.htm',
-        '[percy] Snapshot found: /test-3.htm (2)'
+        '[percy] Snapshot found: /test-3.html',
+        '[percy] Snapshot found: /test-3.html (2)',
       ]);
     });
   });
@@ -160,7 +161,7 @@ describe('percy snapshot', () => {
   describe('snapshotting a list of pages', () => {
     let server;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       server = await createTestServer({
         default: () => [200, 'text/html', '<p>Test</p>']
       });
@@ -189,7 +190,7 @@ describe('percy snapshot', () => {
       ].join('\n'));
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await server.close();
     });
 

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -10,7 +10,8 @@ const CAMELCASE_MAP = new Map([
 const SKIP_CASING_OPTIONS = [
   'request-headers',
   'requestHeaders',
-  'cookies'
+  'cookies',
+  'rewrites'
 ];
 
 // Converts kebab-cased and snake_cased strings to camelCase.

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -812,10 +812,26 @@ describe('PercyConfig', () => {
       expect(PercyConfig.normalize({
         'request-headers': {
           'X-Custom-Header': 'custom header'
+        },
+        requestHeaders: {
+          'X-Custom-Header-2': 'custom header 2'
+        },
+        cookies: {
+          cookie_flavor: 'chocolate'
+        },
+        rewrites: {
+          '/:foo-:bar': '/:foo/:bar/baz'
         }
       })).toEqual({
         requestHeaders: {
-          'X-Custom-Header': 'custom header'
+          'X-Custom-Header': 'custom header',
+          'X-Custom-Header-2': 'custom header 2'
+        },
+        cookies: {
+          cookie_flavor: 'chocolate'
+        },
+        rewrites: {
+          '/:foo-:bar': '/:foo/:bar/baz'
         }
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6802,6 +6802,11 @@ path-to-regexp@2.2.1:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
   integrity sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==
 
+path-to-regexp@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
+  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"


### PR DESCRIPTION
## What is this?

This adds two new options for static snapshots and refactors small parts of the snapshot command.

Logic that differed between static and non-static usages were moved into their respective implementation specific methods. This includes `base-url` error handling and default/normalized page options. Although the latter is shared, how the server address and non-static `base-url` is determined is specific to each implementation. Tests were also refactored a bit so suite hooks run for each test, and a couple other small test changes were made as well.

The `clean-urls` option is passed along to the static server handler directly, while the `rewrites` option is concatenated to any `base-url` rewrite. The `rewrites` are then also used in conjunction with `overrides` to generate a default page URL from the static file path. Another rewrite override is used to remove indexes and extensions from page URLs when `clean-urls` is true.

For config files, we don't want to normalize nested keys within `rewrites`, so it was added to the ignore-list in `@percy/config`'s normalize module (with tests).

[The snapshot command readme was also updated](https://github.com/percy/cli/blob/ww/static-rewrites/packages/cli-snapshot/README.md#static-options).

Resolves #420 <!-- #blazeit -->