### PR TITLE
🙈 Fix coverage ignore statement for racey errors

### DIFF
--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -85,13 +85,9 @@ export default class Page extends EventEmitter {
   // Close the target page if not already closed
   async close() {
     if (!this.#browser) return;
-
-    await this.#browser.send('Target.closeTarget', {
-      targetId: this.#targetId
-    }).catch(error => {
-      /* istanbul ignore next: race condition */
-      this.log.debug(error, this.meta);
-    });
+    await this.#browser.send('Target.closeTarget', { targetId: this.#targetId })
+      /* istanbul ignore next: errors race here when the browser closes */
+      .catch(error => this.log.debug(error, this.meta));
   }
 
   async resize({
@@ -334,7 +330,6 @@ export default class Page extends EventEmitter {
 
   _handleTargetCrashed = () => {
     this.closedReason = 'Page crashed!';
-    /* istanbul ignore next: racey with browser close */
-    this.close().catch(error => this.log.debug(error));
+    this.close();
   }
 }

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -85,8 +85,9 @@ export default class Page extends EventEmitter {
   // Close the target page if not already closed
   async close() {
     if (!this.#browser) return;
+
+    /* istanbul ignore next: errors race here when the browser closes */
     await this.#browser.send('Target.closeTarget', { targetId: this.#targetId })
-      /* istanbul ignore next: errors race here when the browser closes */
       .catch(error => this.log.debug(error, this.meta));
   }
 


### PR DESCRIPTION
## What is this?

Unfortunately, while #408 appeared to address a race between browser and page error handling, there existed other codepaths that could also race in the same way for the same reason.

For this codepath, the code was formatted in a way where we were only ignoring line coverage. The function though, is still created and in certain circumstances may not be called (which was the original goal of this ignore statement).

This PR updates the formatting and ignore statement so the entire handler is ignored. I found this "missing" coverage by studying the coverage output and figuring out which functions were being hit the least. The crash handler was only hit once, but we explicitly test for it. However, I noticed the ignore statement there and also in the `close` method in which it was ignoring. This tipped me off that the ignore statement in the `close` method was in the wrong place, and subsequently the error handler in the crash handler was unnecessary.

I don't know for sure if this will fix our flakey coverage, but I have a strong hunch it might.