### PR TITLE
🧹 Add stale issues/PRs action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,10 +13,10 @@ categories:
       - fix
       - bugfix
       - 🐛 bug
-  - title: '🏗  Maintenance'
+  - title: '🏗 Maintenance'
     labels:
       - 🧹 maintenance
-      - ⬆️ ⬇️ dependencies
+      - ⬆️⬇️ dependencies
 change-title-escapes: '\<*_&#@'
 version-resolver:
   major:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,28 +3,28 @@ tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '💥 Breaking Changes'
     labels:
-      - breaking
+      - 💥 breaking
   - title: '✨ Enhancements'
     labels:
       - feature
-      - enhancement
+      - ✨ enhancement
   - title: '🐛 Bug Fixes'
     labels:
       - fix
       - bugfix
-      - bug
+      - 🐛 bug
   - title: '🏗  Maintenance'
     labels:
-      - maintenance
-      - dependencies
+      - 🧹 maintenance
+      - ⬆️ ⬇️ dependencies
 change-title-escapes: '\<*_&#@'
 version-resolver:
   major:
     labels:
-      - breaking
+      - 💥 breaking
   minor:
     labels:
       - feature
-      - enhancement
+      - ✨ enhancement
   default: patch
 template: '$CHANGES'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 19 * * 2'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue is stale because it has been open for more than 14 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          stale-pr-message: 'This PR is stale because it has been open for more than 14 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 28 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 28 days with no activity.'
+          days-before-issue-stale: 14
+          days-before-pr-stale: 14
+          # close 14 days _after_ initial warning
+          days-before-issue-close: 14
+          days-before-pr-close: 14
+          exempt-pr-labels: '❄️on ice'
+          exempt-issue-labels: '🐛bug,❄️on ice,✨enhancement'
+          exempt-all-assignees: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,6 +24,6 @@ jobs:
           # close 14 days _after_ initial warning
           days-before-issue-close: 14
           days-before-pr-close: 14
-          exempt-pr-labels: '❄️on ice'
-          exempt-issue-labels: '🐛bug,❄️on ice,✨enhancement'
+          exempt-pr-labels: '❄️ on ice'
+          exempt-issue-labels: '🐛 bug,❄️ on ice,✨ enhancement'
           exempt-all-assignees: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,10 +9,16 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue is stale because it has been open for more than 14 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
-          stale-pr-message: 'This PR is stale because it has been open for more than 14 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 28 days with no activity.'
-          close-pr-message: 'This PR was closed because it has been stalled for 28 days with no activity.'
+          stale-issue-message: >-
+            This issue is stale because it has been open for more than 14 days with no activity. 
+            Remove stale label or comment or this will be closed in 14 days.
+          stale-pr-message: >-
+            This PR is stale because it has been open for more than 14 days with no activity.
+            Remove stale label or comment or this will be closed in 14 days.
+          close-issue-message: >-
+            This issue was closed because it has been stalled for 28 days with no activity.
+          close-pr-message: >- 
+            This PR was closed because it has been stalled for 28 days with no activity.
           days-before-issue-stale: 14
           days-before-pr-stale: 14
           # close 14 days _after_ initial warning


### PR DESCRIPTION
## What is this?

This action will help us keep on top of our issues and PRs. After 14 days of no activity there will be a warning comment made. If no activity is taken from there, the issue or PR will be closed 14 days later (28 total days of no activity). The action will run once a week on Tuesdays at 2pm CST. 