### PR TITLE
✨ Normalize config with schemas

### DIFF
--- a/packages/cli-config/src/commands/config/migrate.js
+++ b/packages/cli-config/src/commands/config/migrate.js
@@ -67,7 +67,10 @@ export class Migrate extends Command {
 
     // prefer kebab-case for yaml
     if (/^ya?ml$/.test(format)) {
-      migrated = PercyConfig.normalize(migrated, { kebab: true });
+      migrated = PercyConfig.normalize(migrated, {
+        schema: '/config',
+        kebab: true
+      });
     }
 
     // stringify to the desired format

--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -33,6 +33,7 @@ export const configSchema = {
       },
       rewrites: {
         type: 'object',
+        normalize: false,
         additionalProperties: { type: 'string' }
       },
       overrides: {

--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -93,7 +93,7 @@ export default function load({
     if (bail) return;
   }
 
-  if (config) {
+  if (path !== false && config) {
     log[infoDebug](`Using config:\n${inspect(config)}`);
   }
 

--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -93,9 +93,9 @@ export default function load({
     if (bail) return;
   }
 
-  // normalize again to remove empty values for logging
-  config = normalize(config);
-  if (config) log[infoDebug](`Using config:\n${inspect(config)}`);
+  if (config) {
+    log[infoDebug](`Using config:\n${inspect(config)}`);
+  }
 
   // merge with defaults
   return getDefaults(config);

--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -83,8 +83,8 @@ export default function load({
     }
   }
 
-  // merge found config with overrides and validate
-  config = normalize(config, { overrides });
+  // normalize and merge with overrides then validate
+  config = normalize(config, { overrides, schema: '/config' });
   let errors = config && validate(config);
 
   if (errors) {

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -1,3 +1,4 @@
+import { getSchema } from './validate';
 import { merge } from './utils';
 
 // Edge case camelizations
@@ -5,14 +6,6 @@ const CAMELCASE_MAP = new Map([
   ['css', 'CSS'],
   ['javascript', 'JavaScript']
 ]);
-
-// Do not change casing of nested options
-const SKIP_CASING_OPTIONS = [
-  'request-headers',
-  'requestHeaders',
-  'cookies',
-  'rewrites'
-];
 
 // Converts kebab-cased and snake_cased strings to camelCase.
 const KEBAB_SNAKE_REG = /[-_]([^-_]+)/g;
@@ -42,13 +35,14 @@ function kebabcase(str) {
 export default function normalize(object, options) {
   let keycase = options?.kebab ? kebabcase : camelcase;
 
-  return merge([object, options?.overrides], (path, prev, next) => {
-    let skip = false;
+  return merge([object, options?.overrides], path => {
+    let schemas = getSchema(options?.schema, path.map(camelcase));
+    let skip = schemas.shift()?.normalize === false;
 
-    path = path.map(k => {
-      if (!skip && typeof k === 'string') k = keycase(k);
-      skip = SKIP_CASING_OPTIONS.includes(k);
-      return k;
+    path = path.map((k, i) => {
+      if (skip) return k;
+      skip ||= schemas[i]?.normalize === false;
+      return keycase(k);
     });
 
     return [path];

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -11,6 +11,8 @@ const CAMELCASE_MAP = new Map([
 const KEBAB_SNAKE_REG = /[-_]([^-_]+)/g;
 
 function camelcase(str) {
+  if (typeof str !== 'string') return str;
+
   return str.replace(KEBAB_SNAKE_REG, (match, word) => (
     CAMELCASE_MAP.get(word) || (word[0].toUpperCase() + word.slice(1))
   ));
@@ -20,6 +22,8 @@ function camelcase(str) {
 const CAMEL_SNAKE_REG = /([a-z])([A-Z]+)|_([^_]+)/g;
 
 function kebabcase(str) {
+  if (typeof str !== 'string') return str;
+
   return Array.from(CAMELCASE_MAP)
     .reduce((str, [word, camel]) => (
       str.replace(camel, `-${word}`)

--- a/packages/config/src/utils.js
+++ b/packages/config/src/utils.js
@@ -110,8 +110,13 @@ export function merge(sources, map) {
       let prev = ctx?.[key];
 
       // maybe map the property path and/or value
-      let [p, next] = map?.(path, prev, value) || [];
-      if (p) path = [...p];
+      let [mapped, next] = map?.(path, prev, value) || [];
+
+      // update the context and path if changed
+      if (mapped?.some((m, i) => m !== path[i])) {
+        ctx = get(target, mapped.slice(0, -1));
+        path = [...mapped];
+      }
 
       // adjust path to concat array values when necessary
       if (next !== null && (isArray(ctx) || isInteger(key))) {

--- a/packages/config/src/utils.js
+++ b/packages/config/src/utils.js
@@ -10,12 +10,12 @@ function create(array) {
 // Returns true if the provided key looks like an array key
 const ARRAY_PATH_KEY_REG = /^(\[\d+]|0|[1-9]\d*)$/;
 
-function isArrayKey(key) {
+export function isArrayKey(key) {
   return isInteger(key) || ARRAY_PATH_KEY_REG.test(key);
 }
 
 // Split a property path string by dot or array notation
-function parsePropertyPath(path) {
+export function parsePropertyPath(path) {
   return isArray(path) ? path : path.split('.').reduce((full, part) => {
     return full.concat(part.split('[').reduce((f, p) => {
       if (p.endsWith(']')) p = p.slice(0, -1);

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -796,13 +796,13 @@ describe('PercyConfig', () => {
       expect(PercyConfig.normalize({
         'foo-bar': 'baz',
         foo: { bar_baz: 'qux' },
-        fooBar_baz: 'qux',
+        fooBar_baz: ['qux'],
         percyCSS: '',
         enableJavaScript: false
       }, { kebab: true })).toEqual({
         'foo-bar': 'baz',
         foo: { 'bar-baz': 'qux' },
-        'foo-bar-baz': 'qux',
+        'foo-bar-baz': ['qux'],
         'percy-css': '',
         'enable-javascript': false
       });

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -239,6 +239,8 @@ export function migration(config, { map, del, log }) {
 
 // Validate and merge per-snapshot configuration options with global configuration options.
 export function getSnapshotConfig(options, { snapshot, discovery }, log) {
+  options = PercyConfig.normalize(options, { schema: '/snapshot/dom' });
+
   // throw an error when missing required options
   assert(options.url, 'Missing required URL for snapshot');
   assert((options.widths ?? snapshot.widths)?.length, 'Missing required widths for snapshot');

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -61,6 +61,7 @@ export const configSchema = {
       },
       requestHeaders: {
         type: 'object',
+        normalize: false,
         additionalProperties: { type: 'string' }
       },
       authorization: {
@@ -74,9 +75,11 @@ export const configSchema = {
       cookies: {
         anyOf: [{
           type: 'object',
+          normalize: false,
           additionalProperties: { type: 'string' }
         }, {
           type: 'array',
+          normalize: false,
           items: {
             type: 'object',
             required: ['name', 'value'],
@@ -121,7 +124,6 @@ export const snapshotSchema = {
     minHeight: { $ref: '/config/snapshot#/properties/minHeight' },
     percyCSS: { $ref: '/config/snapshot#/properties/percyCSS' },
     enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },
-
     discovery: {
       type: 'object',
       additionalProperties: false,
@@ -133,24 +135,20 @@ export const snapshotSchema = {
         userAgent: { $ref: '/config/discovery#/properties/userAgent' }
       }
     },
-
     waitForSelector: {
       type: 'string'
     },
-
     waitForTimeout: {
       type: 'integer',
       minimum: 1,
       maximum: 30000
     },
-
     execute: {
       oneOf: [
         { type: 'string' },
         { instanceof: 'Function' }
       ]
     },
-
     additionalSnapshots: {
       type: 'array',
       items: {

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -54,9 +54,10 @@ export default class Percy {
     if (loglevel) this.loglevel(loglevel);
     this.deferUploads = deferUploads;
 
-    this.config = config === false
-      ? PercyConfig.getDefaults(options)
-      : PercyConfig.load({ path: config, overrides: options });
+    this.config = PercyConfig.load({
+      overrides: options,
+      path: config
+    });
 
     let { concurrency } = this.config.discovery;
     if (concurrency) this.#snapshots.concurrency = concurrency;

--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import http from 'http';
 import { Server as WSS } from 'ws';
-import PercyConfig from '@percy/config';
 import logger from '@percy/logger';
 import pkg from '../package.json';
 
@@ -127,10 +126,8 @@ export default function createPercyServer(percy) {
       }),
 
     // forward snapshot requests
-    '/percy/snapshot': ({ body }) => (
-      percy.snapshot(PercyConfig.normalize(body))
-        .then(() => [200, 'application/json', { success: true }])
-    ),
+    '/percy/snapshot': ({ body }) => percy.snapshot(body)
+      .then(() => [200, 'application/json', { success: true }]),
 
     // stops the instance async at the end of the event loop
     '/percy/stop': () => setImmediate(() => percy.stop()) && (

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -28,20 +28,6 @@ describe('Percy', () => {
     });
   });
 
-  it('does not scrub invalid config options when the config option is false', () => {
-    percy = new Percy({
-      config: false,
-      snapshot: { foo: 'bar' }
-    });
-
-    expect(percy.config.snapshot).toEqual({
-      widths: [375, 1280],
-      minHeight: 1024,
-      percyCSS: '',
-      foo: 'bar'
-    });
-  });
-
   it('allows access to create browser pages for other SDKs', async () => {
     let img = '<img src="http://localhost:9000/404.png">';
 

--- a/packages/core/test/server.test.js
+++ b/packages/core/test/server.test.js
@@ -93,7 +93,7 @@ describe('Server', () => {
     expect(percy.stop).toHaveBeenCalled();
   });
 
-  it('has a /snapshot endpoint that calls #snapshot() with normalized options', async () => {
+  it('has a /snapshot endpoint that calls #snapshot() with provided options', async () => {
     spyOn(percy, 'snapshot').and.resolveTo();
     await percy.start();
 
@@ -104,7 +104,7 @@ describe('Server', () => {
 
     expect(response.headers.get('x-percy-core-version')).toMatch(pkg.version);
     await expectAsync(response.json()).toBeResolvedTo({ success: true });
-    expect(percy.snapshot).toHaveBeenCalledOnceWith({ testMe: true, meToo: true });
+    expect(percy.snapshot).toHaveBeenCalledOnceWith({ 'test-me': true, me_too: true });
   });
 
   it('returns a 500 error when an endpoint throws', async () => {

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -115,9 +115,9 @@ describe('Snapshot', () => {
   it('warns on deprecated options', () => {
     percy.close(); // close queues so snapshots fail
 
-    expect(() => percy.snapshot({ url: 'http://a', requestHeaders: {} })).toThrow();
-    expect(() => percy.snapshot({ url: 'http://b', authorization: {} })).toThrow();
-    expect(() => percy.snapshot({ url: 'http://c', snapshots: [] })).toThrow();
+    expect(() => percy.snapshot({ url: 'http://a', requestHeaders: { foo: 'bar' } })).toThrow();
+    expect(() => percy.snapshot({ url: 'http://b', authorization: { username: 'foo' } })).toThrow();
+    expect(() => percy.snapshot({ url: 'http://c', snapshots: [{ name: 'foobar' }] })).toThrow();
 
     expect(logger.stderr).toEqual([
       '[percy] Warning: The snapshot option `requestHeaders` ' +


### PR DESCRIPTION
## What is this?

With #447, the new `static.rewrites` config file option was added to a config module constant that determines which object properties are normalized and which aren't. Before that PR, the constant was initially created to prevent normalizing `discovery.request-headers` options, and subsequently later `discovery.cookies` options.

This was all easy to do as the changes came up since the aforementioned options were defined by other packages within this repo. However, outside of this repo where config schemas can still be defined, there is no such mechanism for disabling normalization of a property. In order to do so, a dedicated PR must be opened on this repo to add the desired properties to the constant.

Instead, with this PR, normalization can be disabled for a property by its own schema. The `PercyConfig.normalize` method now accepts another option which can define a schema to normalize against. In order to get a property's associated schema, the `getSchema` validation helper was updated to accept a path. Upon providing a path, the function will now return an array of schema's indexed by each part of the path, with the zero indexed item being the root schema.

If a path is provided, subsequent nested schemas will be accumulated with the original root schema by recursively fetching the next path's schema. To facilitate schema references, the base functionality of this method will now resolve any `$ref` in a provided schema by once again recursively fetching the desired schema and plucking out the referenced meta path. For schemas that actually contain more than a single possible schema, such as tuples or meta schemas like `oneOf`, the best matching schema is determined by how deep the paths match; with a bias towards loosely matched schemas that can contain properties not defined by said schema.

After the extensive `getSchema` and minor `normalize` changes, the `migrate` helper was also updated to accept a schema to migrate against (defaulting to the default config schema). Since normalization can be dependent on a schema, and because migrations normalize their data, the migrate helpers were updated to allow defining migrations for specific schemas. While this won't be utilized immediately for migrating other options, it can definitely come in handy for future deprecations or breaking changes.

In addition to the changes described above, the test that was added also uncovered a merge bug that was fixed by re-contextualizing the merge if the merge path is mapped to another path. Before, when mapping parent keys of arrays, the context was lost which could trick the following logic into thinking it was creating a new array rather than concatenating arrays. An extra normalization usage in the `load` method was also removed because empty values as a result of pruning invalid options are already removed by validation changes in #406.

Because of the changes in this PR, and in addition to those validation changes, other small codepaths were (re)moved. There was an old codepath for duplicate "using config" logs that was handled in the core constructor. With the new changes, we can move this to within the load method itself. If a file is not loaded, the log will not happen; but validation will still be performed in addition to merging with defaults as the old code path did. This actually improves core config options by always validating, even when not loaded by a file. Another code path, which normalized snapshot options, was moved into the snapshot options config helper introduced in #416.

---

Me adding new config options to the Storybook SDK: https://www.youtube.com/watch?v=AbSehcT19u0