### PR TITLE
🐛 Fix enableJavaScript default for snapshot discovery

### DIFF
--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -295,7 +295,7 @@ export default class Percy {
         // open a new browser page
         page = await this.browser.page({
           networkIdleTimeout: this.config.discovery.networkIdleTimeout,
-          enableJavaScript: domSnapshot ? conf.enableJavaScript : true,
+          enableJavaScript: conf.enableJavaScript ?? !domSnapshot,
           requestHeaders: discovery.requestHeaders,
           authorization: discovery.authorization,
           userAgent: discovery.userAgent,

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -353,6 +353,41 @@ describe('Discovery', () => {
     ]);
   });
 
+  it('does not capture javascript files when not enabled', async () => {
+    server.reply('/javascript.js', () => [200, 'text/javascript', 'window.location = "/"']);
+
+    let jsDOM = dedent`
+      <html><head></head><body>
+      <script src="/javascript.js"></script>
+      </body></html>
+    `;
+
+    await percy.snapshot({
+      name: 'test snapshot',
+      url: 'http://localhost:8000',
+      domSnapshot: jsDOM
+    });
+
+    await percy.idle();
+
+    let paths = server.requests.map(r => r[0]);
+    expect(paths.sort()).not.toContain('/javascript.js');
+
+    expect(captured[0]).toEqual([
+      jasmine.objectContaining({
+        attributes: jasmine.objectContaining({
+          'resource-url': jasmine.stringMatching(/^\/percy\.\d+\.log$/)
+        })
+      }),
+      jasmine.objectContaining({
+        attributes: jasmine.objectContaining({
+          'resource-url': 'http://localhost:8000/',
+          'is-root': true
+        })
+      })
+    ]);
+  });
+
   it('logs detailed debug logs', async () => {
     percy.loglevel('debug');
 

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -838,7 +838,10 @@ describe('Discovery', () => {
       await percy.snapshot({
         name: 'test snapshot',
         url: 'http://localhost:8000',
-        domSnapshot: testExternalAsyncDOM
+        domSnapshot: testExternalAsyncDOM,
+        // img loading is eager when not enabled which causes the page load event
+        // to wait for the eager img request to finish
+        enableJavaScript: true
       });
 
       await percy.idle();


### PR DESCRIPTION
## What is this?

During the recent discovery/snapshot refactors, the `Page` class was updated to default `enableJavaScript` to `true` for other packages to borrow a page without explicitly enabling it. However, since `enableJavaScript` did not have a default configuration value for dom snapshots in the `Percy` class, that resulted in all snapshots defaulting to have javascript enabled during asset discovery (this does not affect the API default).

I also noticed that for snapshot captures, JavaScript is always enabled, even if the config option is `false`.

I updated this line to always prefer the `enableJavaScript` option and default based on the presence of `domSnapshot`. When there is no dom provided, the default should be `true`, otherwise it should be `false`. I also added a test so this can be caught in the future if it regresses again.