### PR TITLE
✨ Allow registering multiple config migrations at a time

### DIFF
--- a/packages/cli-exec/src/hooks/init.js
+++ b/packages/cli-exec/src/hooks/init.js
@@ -4,5 +4,5 @@ import * as CoreConfig from '@percy/core/dist/config';
 // ensures the core schema and migration is loaded
 export default function() {
   PercyConfig.addSchema(CoreConfig.schemas);
-  PercyConfig.addMigration(CoreConfig.migration);
+  PercyConfig.addMigration(CoreConfig.migrations);
 }

--- a/packages/config/src/migrate.js
+++ b/packages/config/src/migrate.js
@@ -7,8 +7,15 @@ const migrations = new Map();
 
 // Register a migration function for the main config schema by default
 export function addMigration(migration, schema = '/config') {
+  if (Array.isArray(migration)) {
+    // accept schema as the first item in a tuple
+    if (typeof migration[0] === 'string') [schema, ...migration] = migration;
+    return migration.map(m => addMigration(m, schema));
+  }
+
   if (!migrations.has(schema)) migrations.set(schema, []);
   migrations.get(schema).push(migration);
+  return migration;
 }
 
 // Clear all migration functions
@@ -19,7 +26,7 @@ export function clearMigrations() {
 // Calls each registered migration function with a normalize provided config
 // and util functions for working with the config object
 export default function migrate(config, schema = '/config') {
-  config = normalize(config, { schema });
+  config = normalize(config, { schema }) ?? {};
 
   if (migrations.has(schema)) {
     let util = {

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -33,9 +33,9 @@ function kebabcase(str) {
     ));
 }
 
-// Recursively reduces config objects and arrays to remove undefined and empty values and rename
-// kebab-case properties to camelCase. Optionally allows deep merging of a second overrides
-// argument, and converting keys to kebab-case with a third options.kebab argument.
+// Removes undefined empty values and renames kebab-case properties to camelCase. Optionally
+// allows deep merging with options.overrides, converting keys to kebab-case with options.kebab,
+// and normalizing against a schema with options.schema.
 export default function normalize(object, options) {
   let keycase = options?.kebab ? kebabcase : camelcase;
 

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -449,9 +449,11 @@ describe('PercyConfig', () => {
       ]);
 
       expect(PercyConfig.migrate({}, '/a'))
-        .toEqual({ version: 2, foo: 1, bar: 2, baz: 3 });
+        .toEqual({ foo: 1, bar: 2, baz: 3 });
       expect(PercyConfig.migrate({}, '/b'))
-        .toEqual({ version: 2, xyzzy: -1 });
+        .toEqual({ xyzzy: -1 });
+      expect(PercyConfig.migrate({}, '/c'))
+        .toEqual({});
     });
   });
 

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -235,7 +235,7 @@ export function snapshotMigration(config, { map, log }) {
   // discovery options have moved
   for (let k of ['authorization', 'requestHeaders']) {
     if (config[k]) {
-      log.deprecated(`The snapshot option \`${k}\` ` + (
+      log.warn(`Warning: The snapshot option \`${k}\` ` + (
         `will be removed in 1.0.0. Use \`discovery.${k}\` instead.`));
       map(k, `discovery.${k}`);
     }

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -3,7 +3,7 @@ const { default: PercyConfig } = require('@percy/config');
 const CoreConfig = require('./config');
 
 PercyConfig.addSchema(CoreConfig.schemas);
-PercyConfig.addMigration(CoreConfig.migration);
+PercyConfig.addMigration(CoreConfig.migrations);
 
 // Export the Percy class with commonjs compatibility
 module.exports = require('./percy').default;

--- a/packages/core/test/unit/config.test.js
+++ b/packages/core/test/unit/config.test.js
@@ -1,7 +1,7 @@
 import logger from '@percy/logger/test/helpers';
-import { migration } from '../../src/config';
+import { configMigration } from '../../src/config';
 
-describe('Unit / Config', () => {
+describe('Unit / Config Migration', () => {
   let mocked = {
     map: (...a) => mocked.migrate.map.push(a),
     del: (...a) => mocked.migrate.del.push(a),
@@ -14,7 +14,7 @@ describe('Unit / Config', () => {
   });
 
   it('migrates v1 config', () => {
-    migration({
+    configMigration({
       version: 1,
       snapshot: {
         widths: [1000]
@@ -49,7 +49,7 @@ describe('Unit / Config', () => {
   });
 
   it('logs for currently deprecated options', () => {
-    migration({
+    configMigration({
       version: 2,
       snapshot: {
         authorization: {},
@@ -71,7 +71,7 @@ describe('Unit / Config', () => {
   });
 
   it('does not migrate when not needed', () => {
-    migration({
+    configMigration({
       version: 2,
       discovery: {
         allowedHostnames: ['allowed']


### PR DESCRIPTION
## What is this?

With #450, the migrate function was updated to be able to migrate specific schemas. We can now utilize that new feature to register a snapshot config migration for deprecated options. These deprecations previously lived within a merge callback.

The migrate function was updated again in this PR to accept multiple migration at once similar to how we can register multiple schemas at once. The forced version was also moved into a default migration; and to ensure it always runs last, migrations are now registered in reverse order, so they run last-in-first-out.