### PR TITLE
🔊 Add log to warn when SDK user agent is missing

### DIFF
--- a/packages/cli-build/src/commands/build/finalize.js
+++ b/packages/cli-build/src/commands/build/finalize.js
@@ -1,6 +1,7 @@
 import Command, { flags } from '@percy/cli-command';
 import PercyClient from '@percy/client';
 import logger from '@percy/logger';
+import pkg from '../../../package.json';
 
 export class Finalize extends Command {
   static description = 'Finalize parallel Percy builds where PERCY_PARALLEL_TOTAL=-1';
@@ -26,7 +27,10 @@ export class Finalize extends Command {
       process.env.PERCY_PARALLEL_TOTAL = '-1';
     }
 
-    let client = new PercyClient();
+    let client = new PercyClient({
+      clientInfo: `${pkg.name}/${pkg.version}`,
+      environmentInfo: ''
+    });
 
     // ensure that this command is not used for other parallel totals
     if (client.env.parallel.total !== -1) {

--- a/packages/cli-build/src/commands/build/finalize.js
+++ b/packages/cli-build/src/commands/build/finalize.js
@@ -29,7 +29,7 @@ export class Finalize extends Command {
 
     let client = new PercyClient({
       clientInfo: `${pkg.name}/${pkg.version}`,
-      environmentInfo: ''
+      environmentInfo: `node/${process.version}`
     });
 
     // ensure that this command is not used for other parallel totals

--- a/packages/cli-build/src/commands/build/wait.js
+++ b/packages/cli-build/src/commands/build/wait.js
@@ -59,7 +59,7 @@ export class Wait extends Command {
 
     await new PercyClient({
       clientInfo: `${pkg.name}/${pkg.version}`,
-      environmentInfo: ''
+      environmentInfo: `node/${process.version}`
     }).waitForBuild(this.flags, data => {
       this.status(data);
     });

--- a/packages/cli-build/src/commands/build/wait.js
+++ b/packages/cli-build/src/commands/build/wait.js
@@ -1,6 +1,7 @@
 import Command, { flags } from '@percy/cli-command';
 import PercyClient from '@percy/client';
 import logger from '@percy/logger';
+import pkg from '../../../package.json';
 
 export class Wait extends Command {
   static description = 'Wait for a build to be finished. Requires a full access PERCY_TOKEN';
@@ -56,10 +57,12 @@ export class Wait extends Command {
       return this.log.info('Percy is disabled');
     }
 
-    await new PercyClient()
-      .waitForBuild(this.flags, data => {
-        this.status(data);
-      });
+    await new PercyClient({
+      clientInfo: `${pkg.name}/${pkg.version}`,
+      environmentInfo: ''
+    }).waitForBuild(this.flags, data => {
+      this.status(data);
+    });
   }
 
   // Log build status and maybe exit when failed

--- a/packages/cli-snapshot/src/commands/snapshot.js
+++ b/packages/cli-snapshot/src/commands/snapshot.js
@@ -95,6 +95,7 @@ export class Snapshot extends Command {
       }),
 
       clientInfo: `${pkg.name}/${pkg.version}`,
+      environmentInfo: `node/${process.version}`,
       server: false
     });
 
@@ -123,11 +124,7 @@ export class Snapshot extends Command {
           this.log.debug(`-> url: ${snap.url}`);
         }
       } else {
-        this.percy.snapshot({
-          ...snap,
-          clientInfo: `${pkg.name}/${pkg.version}`,
-          environmentInfo: `node/${process.version}`
-        });
+        this.percy.snapshot({ ...snap });
       }
     }
   }

--- a/packages/cli-snapshot/src/commands/snapshot.js
+++ b/packages/cli-snapshot/src/commands/snapshot.js
@@ -123,7 +123,11 @@ export class Snapshot extends Command {
           this.log.debug(`-> url: ${snap.url}`);
         }
       } else {
-        this.percy.snapshot(snap);
+        this.percy.snapshot({
+          ...snap,
+          clientInfo: `${pkg.name}/${pkg.version}`,
+          environmentInfo: `node/${process.version}`
+        });
       }
     }
   }

--- a/packages/cli-snapshot/src/commands/snapshot.js
+++ b/packages/cli-snapshot/src/commands/snapshot.js
@@ -124,7 +124,7 @@ export class Snapshot extends Command {
           this.log.debug(`-> url: ${snap.url}`);
         }
       } else {
-        this.percy.snapshot({ ...snap });
+        this.percy.snapshot(snap);
       }
     }
   }

--- a/packages/cli-upload/src/commands/upload.js
+++ b/packages/cli-upload/src/commands/upload.js
@@ -82,7 +82,8 @@ export class Upload extends Command {
     paths.sort();
 
     this.client = new PercyClient({
-      clientInfo: `${pkg.name}/${pkg.version}`
+      clientInfo: `${pkg.name}/${pkg.version}`,
+      environmentInfo: ''
     });
 
     if (dry) {

--- a/packages/cli-upload/src/commands/upload.js
+++ b/packages/cli-upload/src/commands/upload.js
@@ -83,7 +83,7 @@ export class Upload extends Command {
 
     this.client = new PercyClient({
       clientInfo: `${pkg.name}/${pkg.version}`,
-      environmentInfo: ''
+      environmentInfo: `node/${process.version}`
     });
 
     if (dry) {

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -31,7 +31,6 @@ function validateProjectPath(path) {
 export default class PercyClient {
   log = logger('client');
   env = new PercyEnvironment(process.env);
-  envWarning = false;
   clientInfo = new Set();
   environmentInfo = new Set();
 
@@ -71,11 +70,6 @@ export default class PercyClient {
 
   // Stringifies client and environment info.
   userAgent() {
-    if (!this.envWarning && (!(this.clientInfo.size > 2) || !(this.environmentInfo.size > 1))) {
-      this.envWarning = true;
-      this.log.warn('Warning: Missing `clientInfo` and/or `environmentInfo` properties');
-    }
-
     let client = [...this.clientInfo].join(' ');
     let environment = [...this.environmentInfo].join('; ');
 

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -31,13 +31,14 @@ function validateProjectPath(path) {
 export default class PercyClient {
   log = logger('client');
   env = new PercyEnvironment(process.env);
+  envWarning = false;
 
   constructor({
     // read or write token, defaults to PERCY_TOKEN environment variable
     token,
     // initial user agent info
-    clientInfo = '',
-    environmentInfo = '',
+    clientInfo = [],
+    environmentInfo = [],
     // versioned api url
     apiUrl = PERCY_CLIENT_API_URL
   } = {}) {
@@ -62,6 +63,11 @@ export default class PercyClient {
 
   // Stringifies client and environment info.
   userAgent() {
+    if (!this.envWarning && (this.clientInfo.size === 0 || this.environmentInfo.size === 0)) {
+      this.envWarning = true;
+      this.log.warn('Warning: Missing `clientInfo` and/or `environmentInfo` properties');
+    }
+
     let client = [`Percy/${/\w+$/.exec(this.apiUrl)}`]
       .concat(`${pkg.name}/${pkg.version}`, ...this.clientInfo)
       .filter(Boolean).join(' ');

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -33,7 +33,6 @@ export default class PercyClient {
   env = new PercyEnvironment(process.env);
   clientInfo = new Set();
   environmentInfo = new Set();
-  envWarning = false;
 
   constructor({
     // read or write token, defaults to PERCY_TOKEN environment variable
@@ -296,8 +295,7 @@ export default class PercyClient {
     this.addClientInfo(clientInfo);
     this.addEnvironmentInfo(environmentInfo);
 
-    if (!this.envWarning && (this.clientInfo.size === 0 || this.environmentInfo.size === 0)) {
-      this.envWarning = true;
+    if (!this.clientInfo.size || !this.environmentInfo.size) {
       this.log.warn('Warning: Missing `clientInfo` and/or `environmentInfo` properties');
     }
 

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -26,8 +26,6 @@ describe('PercyClient', () => {
       expect(client.userAgent()).toMatch(
         /^Percy\/v1 @percy\/client\/\S+ \(node\/v[\d.]+.*\)$/
       );
-      expect(logger.stderr)
-        .toEqual(['[percy] Warning: Missing `clientInfo` and/or `environmentInfo` properties']);
     });
 
     it('contains any additional client and environment information', () => {

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -3,12 +3,15 @@ import { mockgit } from '@percy/env/test/helpers';
 import PercyClient from '../src';
 import { sha256hash, base64encode } from '../src/utils';
 import mockAPI from './helpers';
+import logger from '@percy/logger/test/helpers';
 
 describe('PercyClient', () => {
   let client;
 
   beforeEach(() => {
     mockAPI.start();
+    logger.mock();
+
     client = new PercyClient({
       token: 'PERCY_TOKEN'
     });
@@ -23,6 +26,8 @@ describe('PercyClient', () => {
       expect(client.userAgent()).toMatch(
         /^Percy\/v1 @percy\/client\/\S+ \(node\/v[\d.]+.*\)$/
       );
+      expect(logger.stderr)
+        .toEqual(['[percy] Warning: Missing `clientInfo` and/or `environmentInfo` properties']);
     });
 
     it('contains any additional client and environment information', () => {
@@ -35,6 +40,7 @@ describe('PercyClient', () => {
       expect(client.userAgent()).toMatch(
         /^Percy\/v1 @percy\/client\/\S+ client-info \(env-info; node\/v[\d.]+.*\)$/
       );
+      expect(logger.stderr).toEqual([]);
     });
 
     it('does not duplicate or include empty client and environment information', () => {

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -38,7 +38,7 @@ describe('PercyClient', () => {
       });
 
       expect(client.userAgent()).toMatch(
-        /^Percy\/v1 @percy\/client\/\S+ client-info \(env-info; node\/v[\d.]+.*\)$/
+        /^Percy\/v1 @percy\/client\/\S+ client-info \(node\/v[\d.]+.*; env-info\)$/
       );
       expect(logger.stderr).toEqual([]);
     });
@@ -58,7 +58,7 @@ describe('PercyClient', () => {
       client.addEnvironmentInfo(['env-info', 'env-info']);
 
       expect(client.userAgent()).toMatch(
-        /^Percy\/v1 @percy\/client\/\S+ client-info \(env-info; node\/v[\d.]+.*\)$/
+        /^Percy\/v1 @percy\/client\/\S+ client-info \(node\/v[\d.]+.*; env-info\)$/
       );
     });
   });
@@ -460,7 +460,7 @@ describe('PercyClient', () => {
       expect(mockAPI.requests['/builds/123/snapshots'][0].headers).toEqual(
         jasmine.objectContaining({
           'user-agent': jasmine.stringMatching(
-            /^Percy\/v1 @percy\/client\/\S+ sdk\/info \(sdk\/env; node\/v[\d.]+.*\)$/
+            /^Percy\/v1 @percy\/client\/\S+ sdk\/info \(node\/v[\d.]+.*; sdk\/env\)$/
           )
         })
       );

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -83,41 +83,6 @@ describe('PercyClient', () => {
       expect(logger.stderr).toEqual(['[percy] Warning: Missing `clientInfo` and/or `environmentInfo` properties']);
     });
 
-    it('it only logs the missing UA warning once', async () => {
-      client = new PercyClient({
-        token: 'PERCY_TOKEN',
-        environmentInfo: 'env-info'
-      });
-
-      await expectAsync(client.createSnapshot(123, {
-        name: 'snapfoo',
-        widths: [1000],
-        minHeight: 1000,
-        enableJavaScript: true,
-        resources: [{
-          url: '/foobar',
-          content: 'foo',
-          mimetype: 'text/html',
-          root: true
-        }]
-      })).toBeResolved();
-
-      await expectAsync(client.createSnapshot(123, {
-        name: 'snapfoo',
-        widths: [1000],
-        minHeight: 1000,
-        enableJavaScript: true,
-        resources: [{
-          url: '/foobar',
-          content: 'foo',
-          mimetype: 'text/html',
-          root: true
-        }]
-      })).toBeResolved();
-
-      expect(logger.stderr).toEqual(['[percy] Warning: Missing `clientInfo` and/or `environmentInfo` properties']);
-    });
-
     it('does not duplicate or include empty client and environment information', () => {
       client.addClientInfo(null);
       client.addClientInfo(undefined);

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -11,7 +11,6 @@ describe('PercyClient', () => {
   beforeEach(() => {
     mockAPI.start();
     logger.mock();
-
     client = new PercyClient({
       token: 'PERCY_TOKEN'
     });

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -21,6 +21,7 @@ import {
 export default class Percy {
   log = logger('core');
   readyState = null;
+  envWarning = false;
 
   #cache = new Map();
   #uploads = new Queue();
@@ -233,6 +234,11 @@ export default class Percy {
   snapshot(options) {
     if (this.readyState !== 1) {
       throw new Error('Not running');
+    }
+
+    if (!this.envWarning && (!options.clientInfo || !options.environmentInfo)) {
+      this.envWarning = true;
+      this.log.warn('Warning: Missing `clientInfo` and/or `environmentInfo` properties');
     }
 
     let {

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -21,7 +21,6 @@ import {
 export default class Percy {
   log = logger('core');
   readyState = null;
-  envWarning = false;
 
   #cache = new Map();
   #uploads = new Queue();
@@ -234,11 +233,6 @@ export default class Percy {
   snapshot(options) {
     if (this.readyState !== 1) {
       throw new Error('Not running');
-    }
-
-    if (!this.envWarning && (!options.clientInfo || !options.environmentInfo)) {
-      this.envWarning = true;
-      this.log.warn('Warning: Missing `clientInfo` and/or `environmentInfo` properties');
     }
 
     let {

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -241,7 +241,9 @@ describe('Percy', () => {
 
       await expectAsync(percy.snapshot({
         name: 'Snapshot 1',
-        url: 'http://localhost:8000'
+        url: 'http://localhost:8000',
+        clientInfo: 'client-info',
+        environmentInfo: 'env-info'
       })).toBeResolved();
 
       expect(mockAPI.requests['/builds']).toBeUndefined();
@@ -256,7 +258,9 @@ describe('Percy', () => {
       // throws synchronously
       expect(() => percy.snapshot({
         name: 'Snapshot 2',
-        url: 'http://localhost:8000'
+        url: 'http://localhost:8000',
+        clientInfo: 'client-info',
+        environmentInfo: 'env-info'
       })).toThrowError('Closed');
 
       expect(logger.stdout).toEqual([
@@ -321,7 +325,9 @@ describe('Percy', () => {
       percy.snapshot({
         name: 'test snapshot',
         url: 'http://localhost:8000',
-        domSnapshot: '<html></html>'
+        domSnapshot: '<html></html>',
+        clientInfo: 'client-info',
+        environmentInfo: 'env-info'
       });
 
       await expectAsync(percy.stop()).toBeResolved();
@@ -356,7 +362,9 @@ describe('Percy', () => {
       await percy.snapshot({
         name: 'test snapshot',
         url: 'http://localhost:8000',
-        domSnapshot: '<html></html>'
+        domSnapshot: '<html></html>',
+        clientInfo: 'client-info',
+        environmentInfo: 'env-info'
       });
 
       await expectAsync(percy.stop()).toBeResolved();

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -9,13 +9,37 @@ describe('Percy', () => {
     percy = new Percy({
       token: 'PERCY_TOKEN',
       snapshot: { widths: [1000] },
-      discovery: { concurrency: 1 }
+      discovery: { concurrency: 1 },
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info'
     });
   });
 
   afterEach(async () => {
     await percy.stop();
     await server?.close();
+  });
+
+  it('logs when a snapshot is missing env info', async () => {
+    percy = new Percy({
+      token: 'PERCY_TOKEN',
+      snapshot: { widths: [1000] },
+      discovery: { concurrency: 1 }
+    });
+
+    await percy.start();
+    await percy.snapshot({
+      name: 'test snapshot',
+      url: 'http://localhost:8000',
+      domSnapshot: '<html></html>'
+    });
+
+    await expectAsync(percy.stop()).toBeResolved();
+    expect(logger.stderr).toEqual(['[percy] Warning: Missing `clientInfo` and/or `environmentInfo` properties']);
+    expect(logger.stdout).toEqual(jasmine.arrayContaining([
+      '[percy] Percy has started!',
+      '[percy] Snapshot taken: test snapshot'
+    ]));
   });
 
   it('scrubs invalid config options and loads defaults', () => {
@@ -241,9 +265,7 @@ describe('Percy', () => {
 
       await expectAsync(percy.snapshot({
         name: 'Snapshot 1',
-        url: 'http://localhost:8000',
-        clientInfo: 'client-info',
-        environmentInfo: 'env-info'
+        url: 'http://localhost:8000'
       })).toBeResolved();
 
       expect(mockAPI.requests['/builds']).toBeUndefined();
@@ -258,9 +280,7 @@ describe('Percy', () => {
       // throws synchronously
       expect(() => percy.snapshot({
         name: 'Snapshot 2',
-        url: 'http://localhost:8000',
-        clientInfo: 'client-info',
-        environmentInfo: 'env-info'
+        url: 'http://localhost:8000'
       })).toThrowError('Closed');
 
       expect(logger.stdout).toEqual([
@@ -325,9 +345,7 @@ describe('Percy', () => {
       percy.snapshot({
         name: 'test snapshot',
         url: 'http://localhost:8000',
-        domSnapshot: '<html></html>',
-        clientInfo: 'client-info',
-        environmentInfo: 'env-info'
+        domSnapshot: '<html></html>'
       });
 
       await expectAsync(percy.stop()).toBeResolved();
@@ -362,9 +380,7 @@ describe('Percy', () => {
       await percy.snapshot({
         name: 'test snapshot',
         url: 'http://localhost:8000',
-        domSnapshot: '<html></html>',
-        clientInfo: 'client-info',
-        environmentInfo: 'env-info'
+        domSnapshot: '<html></html>'
       });
 
       await expectAsync(percy.stop()).toBeResolved();

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -53,7 +53,9 @@ describe('Snapshot', () => {
         name: 'nombre',
         suffix: ' - 1',
         waitForTimeout: 1000
-      }]
+      }],
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info'
     })).toThrow();
 
     expect(logger.stderr).toEqual([
@@ -74,7 +76,9 @@ describe('Snapshot', () => {
       execute: 'e',
       additionalSnapshots: [
         { prefix: 'f' }
-      ]
+      ],
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info'
     })).toThrow();
 
     expect(logger.stderr).toEqual([
@@ -100,7 +104,9 @@ describe('Snapshot', () => {
           'still-not-a-hostname.io/with-a-path',
           'finally.a-real.hostname.org'
         ]
-      }
+      },
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info'
     })).toThrow();
 
     expect(logger.stderr).toEqual([
@@ -113,11 +119,12 @@ describe('Snapshot', () => {
   });
 
   it('warns on deprecated options', () => {
+    let envInfo = { clientInfo: 'client-info', environmentInfo: 'env-info' };
     percy.close(); // close queues so snapshots fail
 
-    expect(() => percy.snapshot({ url: 'http://a', requestHeaders: { foo: 'bar' } })).toThrow();
-    expect(() => percy.snapshot({ url: 'http://b', authorization: { username: 'foo' } })).toThrow();
-    expect(() => percy.snapshot({ url: 'http://c', snapshots: [{ name: 'foobar' }] })).toThrow();
+    expect(() => percy.snapshot({ url: 'http://a', requestHeaders: { foo: 'bar' }, ...envInfo })).toThrow();
+    expect(() => percy.snapshot({ url: 'http://b', authorization: { username: 'foo' }, ...envInfo })).toThrow();
+    expect(() => percy.snapshot({ url: 'http://c', snapshots: [{ name: 'foobar' }], ...envInfo })).toThrow();
 
     expect(logger.stderr).toEqual([
       '[percy] Warning: The snapshot option `requestHeaders` ' +
@@ -145,7 +152,9 @@ describe('Snapshot', () => {
     await percy.snapshot({
       name: 'test snapshot',
       url: 'http://localhost:8000',
-      domSnapshot: testDOM
+      domSnapshot: testDOM,
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info'
     });
 
     expect(logger.stderr).toEqual([]);
@@ -162,7 +171,9 @@ describe('Snapshot', () => {
     await percy.snapshot({
       name: 'test snapshot',
       url: 'http://localhost:8000',
-      domSnapshot: testDOM
+      domSnapshot: testDOM,
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info'
     });
 
     expect(logger.stdout).toEqual([]);
@@ -180,7 +191,9 @@ describe('Snapshot', () => {
     await percy.snapshot({
       name: 'test snapshot',
       url: 'http://localhost:8000',
-      domSnapshot: testDOM
+      domSnapshot: testDOM,
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info'
     });
 
     await percy.idle();
@@ -200,7 +213,9 @@ describe('Snapshot', () => {
 
     let snap = percy.snapshot({
       name: 'test snapshot',
-      url: 'http://localhost:8000'
+      url: 'http://localhost:8000',
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info'
     });
 
     // wait until a page is requested
@@ -225,7 +240,9 @@ describe('Snapshot', () => {
 
     let snap = percy.snapshot({
       name: 'test snapshot',
-      url: 'http://localhost:8000'
+      url: 'http://localhost:8000',
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info'
     });
 
     // wait until an asset has at least been requested
@@ -252,7 +269,9 @@ describe('Snapshot', () => {
       url: 'http://localhost:8000',
       execute: () => {
         document.body.innerHTML += '<img src="/img.png"/>';
-      }
+      },
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info'
     });
 
     // wait until the asset is requested before exiting
@@ -270,7 +289,9 @@ describe('Snapshot', () => {
     let snap = percy.snapshot({
       name: 'crash snapshot',
       url: 'http://localhost:8000',
-      execute: () => new Promise(r => setTimeout(r, 1000))
+      execute: () => new Promise(r => setTimeout(r, 1000)),
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info'
     });
 
     // wait for page creation
@@ -361,7 +382,9 @@ describe('Snapshot', () => {
           { suffix: ' two' },
           { prefix: 'third ' },
           { name: 'test snapshot 4' }
-        ]
+        ],
+        clientInfo: 'client-info',
+        environmentInfo: 'env-info'
       });
 
       expect(logger.stderr).toEqual([]);
@@ -382,7 +405,9 @@ describe('Snapshot', () => {
           { suffix: ' 2', execute: () => document.querySelector('p').classList.add('eval-2') },
           { suffix: ' 3', execute: () => document.querySelector('p').classList.add('eval-3') },
           { suffix: ' 4' }
-        ]
+        ],
+        clientInfo: 'client-info',
+        environmentInfo: 'env-info'
       });
 
       await percy.idle();
@@ -404,7 +429,9 @@ describe('Snapshot', () => {
       await percy.snapshot({
         name: 'foo snapshot',
         url: 'http://localhost:8000',
-        execute: () => document.querySelector('a').click()
+        execute: () => document.querySelector('a').click(),
+        clientInfo: 'client-info',
+        environmentInfo: 'env-info'
       });
 
       expect(logger.stderr).toEqual([]);
@@ -428,7 +455,9 @@ describe('Snapshot', () => {
           let $p = document.querySelector('p');
           setTimeout(() => ($p.id = 'timed'), 100);
           await waitFor(() => $p.id === 'timed', 200);
-        `
+        `,
+        clientInfo: 'client-info',
+        environmentInfo: 'env-info'
       });
 
       expect(logger.stderr).toEqual([]);
@@ -454,7 +483,9 @@ describe('Snapshot', () => {
 
           let $f = document.querySelector('iframe');
           if ($f) $f.src = '/foo';
-        }
+        },
+        clientInfo: 'client-info',
+        environmentInfo: 'env-info'
       });
 
       expect(logger.stderr).toEqual([]);
@@ -506,7 +537,9 @@ describe('Snapshot', () => {
       await percy.snapshot({
         name: 'test snapshot',
         url: 'http://localhost:8000',
-        execute: [dot, dot, dot]
+        execute: [dot, dot, dot],
+        clientInfo: 'client-info',
+        environmentInfo: 'env-info'
       });
 
       await percy.idle();
@@ -536,7 +569,9 @@ describe('Snapshot', () => {
         execute: {
           afterNavigation: domtest('afterNavigation', () => window.location.href),
           beforeSnapshot: domtest('beforeSnapshot', () => 'done!')
-        }
+        },
+        clientInfo: 'client-info',
+        environmentInfo: 'env-info'
       });
 
       await percy.snapshot({
@@ -546,7 +581,9 @@ describe('Snapshot', () => {
         execute: {
           beforeResize: domtest('beforeResize', () => window.innerWidth),
           afterResize: domtest('afterResize', () => window.innerWidth)
-        }
+        },
+        clientInfo: 'client-info',
+        environmentInfo: 'env-info'
       });
 
       await percy.idle();

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -21,7 +21,9 @@ describe('Snapshot', () => {
       token: 'PERCY_TOKEN',
       snapshot: { widths: [1000] },
       discovery: { concurrency: 1 },
-      server: false
+      server: false,
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info'
     });
 
     logger.reset();
@@ -53,9 +55,7 @@ describe('Snapshot', () => {
         name: 'nombre',
         suffix: ' - 1',
         waitForTimeout: 1000
-      }],
-      clientInfo: 'client-info',
-      environmentInfo: 'env-info'
+      }]
     })).toThrow();
 
     expect(logger.stderr).toEqual([
@@ -76,9 +76,7 @@ describe('Snapshot', () => {
       execute: 'e',
       additionalSnapshots: [
         { prefix: 'f' }
-      ],
-      clientInfo: 'client-info',
-      environmentInfo: 'env-info'
+      ]
     })).toThrow();
 
     expect(logger.stderr).toEqual([
@@ -104,9 +102,7 @@ describe('Snapshot', () => {
           'still-not-a-hostname.io/with-a-path',
           'finally.a-real.hostname.org'
         ]
-      },
-      clientInfo: 'client-info',
-      environmentInfo: 'env-info'
+      }
     })).toThrow();
 
     expect(logger.stderr).toEqual([
@@ -119,12 +115,11 @@ describe('Snapshot', () => {
   });
 
   it('warns on deprecated options', () => {
-    let envInfo = { clientInfo: 'client-info', environmentInfo: 'env-info' };
     percy.close(); // close queues so snapshots fail
 
-    expect(() => percy.snapshot({ url: 'http://a', requestHeaders: { foo: 'bar' }, ...envInfo })).toThrow();
-    expect(() => percy.snapshot({ url: 'http://b', authorization: { username: 'foo' }, ...envInfo })).toThrow();
-    expect(() => percy.snapshot({ url: 'http://c', snapshots: [{ name: 'foobar' }], ...envInfo })).toThrow();
+    expect(() => percy.snapshot({ url: 'http://a', requestHeaders: { foo: 'bar' } })).toThrow();
+    expect(() => percy.snapshot({ url: 'http://b', authorization: { username: 'foo' } })).toThrow();
+    expect(() => percy.snapshot({ url: 'http://c', snapshots: [{ name: 'foobar' }] })).toThrow();
 
     expect(logger.stderr).toEqual([
       '[percy] Warning: The snapshot option `requestHeaders` ' +
@@ -152,9 +147,7 @@ describe('Snapshot', () => {
     await percy.snapshot({
       name: 'test snapshot',
       url: 'http://localhost:8000',
-      domSnapshot: testDOM,
-      clientInfo: 'client-info',
-      environmentInfo: 'env-info'
+      domSnapshot: testDOM
     });
 
     expect(logger.stderr).toEqual([]);
@@ -171,9 +164,7 @@ describe('Snapshot', () => {
     await percy.snapshot({
       name: 'test snapshot',
       url: 'http://localhost:8000',
-      domSnapshot: testDOM,
-      clientInfo: 'client-info',
-      environmentInfo: 'env-info'
+      domSnapshot: testDOM
     });
 
     expect(logger.stdout).toEqual([]);
@@ -191,9 +182,7 @@ describe('Snapshot', () => {
     await percy.snapshot({
       name: 'test snapshot',
       url: 'http://localhost:8000',
-      domSnapshot: testDOM,
-      clientInfo: 'client-info',
-      environmentInfo: 'env-info'
+      domSnapshot: testDOM
     });
 
     await percy.idle();
@@ -213,9 +202,7 @@ describe('Snapshot', () => {
 
     let snap = percy.snapshot({
       name: 'test snapshot',
-      url: 'http://localhost:8000',
-      clientInfo: 'client-info',
-      environmentInfo: 'env-info'
+      url: 'http://localhost:8000'
     });
 
     // wait until a page is requested
@@ -240,9 +227,7 @@ describe('Snapshot', () => {
 
     let snap = percy.snapshot({
       name: 'test snapshot',
-      url: 'http://localhost:8000',
-      clientInfo: 'client-info',
-      environmentInfo: 'env-info'
+      url: 'http://localhost:8000'
     });
 
     // wait until an asset has at least been requested
@@ -269,9 +254,7 @@ describe('Snapshot', () => {
       url: 'http://localhost:8000',
       execute: () => {
         document.body.innerHTML += '<img src="/img.png"/>';
-      },
-      clientInfo: 'client-info',
-      environmentInfo: 'env-info'
+      }
     });
 
     // wait until the asset is requested before exiting
@@ -289,9 +272,7 @@ describe('Snapshot', () => {
     let snap = percy.snapshot({
       name: 'crash snapshot',
       url: 'http://localhost:8000',
-      execute: () => new Promise(r => setTimeout(r, 1000)),
-      clientInfo: 'client-info',
-      environmentInfo: 'env-info'
+      execute: () => new Promise(r => setTimeout(r, 1000))
     });
 
     // wait for page creation
@@ -382,9 +363,7 @@ describe('Snapshot', () => {
           { suffix: ' two' },
           { prefix: 'third ' },
           { name: 'test snapshot 4' }
-        ],
-        clientInfo: 'client-info',
-        environmentInfo: 'env-info'
+        ]
       });
 
       expect(logger.stderr).toEqual([]);
@@ -405,9 +384,7 @@ describe('Snapshot', () => {
           { suffix: ' 2', execute: () => document.querySelector('p').classList.add('eval-2') },
           { suffix: ' 3', execute: () => document.querySelector('p').classList.add('eval-3') },
           { suffix: ' 4' }
-        ],
-        clientInfo: 'client-info',
-        environmentInfo: 'env-info'
+        ]
       });
 
       await percy.idle();
@@ -429,9 +406,7 @@ describe('Snapshot', () => {
       await percy.snapshot({
         name: 'foo snapshot',
         url: 'http://localhost:8000',
-        execute: () => document.querySelector('a').click(),
-        clientInfo: 'client-info',
-        environmentInfo: 'env-info'
+        execute: () => document.querySelector('a').click()
       });
 
       expect(logger.stderr).toEqual([]);
@@ -455,9 +430,7 @@ describe('Snapshot', () => {
           let $p = document.querySelector('p');
           setTimeout(() => ($p.id = 'timed'), 100);
           await waitFor(() => $p.id === 'timed', 200);
-        `,
-        clientInfo: 'client-info',
-        environmentInfo: 'env-info'
+        `
       });
 
       expect(logger.stderr).toEqual([]);
@@ -483,9 +456,7 @@ describe('Snapshot', () => {
 
           let $f = document.querySelector('iframe');
           if ($f) $f.src = '/foo';
-        },
-        clientInfo: 'client-info',
-        environmentInfo: 'env-info'
+        }
       });
 
       expect(logger.stderr).toEqual([]);
@@ -537,9 +508,7 @@ describe('Snapshot', () => {
       await percy.snapshot({
         name: 'test snapshot',
         url: 'http://localhost:8000',
-        execute: [dot, dot, dot],
-        clientInfo: 'client-info',
-        environmentInfo: 'env-info'
+        execute: [dot, dot, dot]
       });
 
       await percy.idle();
@@ -569,9 +538,7 @@ describe('Snapshot', () => {
         execute: {
           afterNavigation: domtest('afterNavigation', () => window.location.href),
           beforeSnapshot: domtest('beforeSnapshot', () => 'done!')
-        },
-        clientInfo: 'client-info',
-        environmentInfo: 'env-info'
+        }
       });
 
       await percy.snapshot({
@@ -581,9 +548,7 @@ describe('Snapshot', () => {
         execute: {
           beforeResize: domtest('beforeResize', () => window.innerWidth),
           afterResize: domtest('afterResize', () => window.innerWidth)
-        },
-        clientInfo: 'client-info',
-        environmentInfo: 'env-info'
+        }
       });
 
       await percy.idle();


### PR DESCRIPTION
## What is this?

This implements a warning log if the SDK sends a snapshot without any user agent info (`environmentInfo` & `clientInfo`). Closes #455 

Before releasing this, we will need to update the Storybook SDK