### PR TITLE
✨ Install the correct Chromium binary for arm Macs

### DIFF
--- a/packages/core/src/install.js
+++ b/packages/core/src/install.js
@@ -47,7 +47,9 @@ function formatProgress(prefix, total, start, progress) {
 // Returns an item from the map keyed by the current platform
 function selectByPlatform(map) {
   let { platform, arch } = process;
-  return map[platform === 'win32' && arch === 'x64' ? 'win64' : platform];
+  if (platform === 'win32' && arch === 'x64') platform = 'win64';
+  if (platform === 'darwin' && arch === 'arm64') platform = 'darwinArm';
+  return map[platform];
 }
 
 // Installs a revision of Chromium to a local directory
@@ -63,6 +65,7 @@ function installChromium({
     selectByPlatform({
       linux: `Linux_x64/${revision}/chrome-linux.zip`,
       darwin: `Mac/${revision}/chrome-mac.zip`,
+      darwinArm: `Mac_Arm/${revision}/chrome-mac.zip`,
       win64: `Win_x64/${revision}/chrome-win.zip`,
       win32: `Win/${revision}/chrome-win.zip`
     });
@@ -71,7 +74,8 @@ function installChromium({
     linux: path.join('chrome-linux', 'chrome'),
     win64: path.join('chrome-win', 'chrome.exe'),
     win32: path.join('chrome-win', 'chrome.exe'),
-    darwin: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium')
+    darwin: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium'),
+    darwinArm: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium')
   });
 
   return install({
@@ -89,7 +93,8 @@ installChromium.revisions = {
   linux: '885264',
   win64: '885282',
   win32: '885263',
-  darwin: '885263'
+  darwin: '885263',
+  darwinArm: '885282'
 };
 
 // Installs an executable from a url to a local directory, returning the full path to the extracted

--- a/packages/core/test/unit/install.test.js
+++ b/packages/core/test/unit/install.test.js
@@ -179,6 +179,11 @@ describe('Unit / Install', () => {
         url: jasmine.stringMatching(`Mac/${install.chromium.revisions.darwin}/chrome-mac.zip`),
         return: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium')
       },
+      darwinArm: {
+        revision: install.chromium.revisions.darwinArm,
+        url: jasmine.stringMatching(`Mac/${install.chromium.revisions.darwinArm}/chrome-mac.zip`),
+        return: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium')
+      },
       win64: {
         revision: install.chromium.revisions.win64,
         url: jasmine.stringMatching(`Win_x64/${install.chromium.revisions.win64}/chrome-win.zip`),

--- a/packages/core/test/unit/install.test.js
+++ b/packages/core/test/unit/install.test.js
@@ -172,32 +172,37 @@ describe('Unit / Install', () => {
       linux: {
         revision: install.chromium.revisions.linux,
         url: jasmine.stringMatching(`Linux_x64/${install.chromium.revisions.linux}/chrome-linux.zip`),
-        return: path.join('chrome-linux', 'chrome')
+        return: path.join('chrome-linux', 'chrome'),
+        process: { platform: 'linux', arch: 'x64' }
       },
       darwin: {
         revision: install.chromium.revisions.darwin,
         url: jasmine.stringMatching(`Mac/${install.chromium.revisions.darwin}/chrome-mac.zip`),
-        return: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium')
+        return: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium'),
+        process: { platform: 'darwin', arch: 'x64' }
       },
       darwinArm: {
         revision: install.chromium.revisions.darwinArm,
         url: jasmine.stringMatching(`Mac/${install.chromium.revisions.darwinArm}/chrome-mac.zip`),
-        return: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium')
+        return: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium'),
+        process: { platform: 'darwin', arch: 'arm64' }
       },
       win64: {
         revision: install.chromium.revisions.win64,
         url: jasmine.stringMatching(`Win_x64/${install.chromium.revisions.win64}/chrome-win.zip`),
-        return: path.join('chrome-win', 'chrome.exe')
+        return: path.join('chrome-win', 'chrome.exe'),
+        process: { platform: 'win32', arch: 'x64' }
       },
       win32: {
         revision: install.chromium.revisions.win32,
         url: jasmine.stringMatching(`Win/${install.chromium.revisions.win32}/chrome-win.zip`),
-        return: path.join('chrome-win', 'chrome.exe')
+        return: path.join('chrome-win', 'chrome.exe'),
+        process: { platform: 'win32', arch: 'x32' }
       }
     })) {
       it(`downloads the correct files for ${platform}`, async () => {
-        spyOnProperty(process, 'platform').and.returnValue(platform === 'win64' ? 'win32' : platform);
-        spyOnProperty(process, 'arch').and.returnValue(platform === 'win32' ? 'x32' : 'x64');
+        spyOnProperty(process, 'platform').and.returnValue(expected.process.platform);
+        spyOnProperty(process, 'arch').and.returnValue(expected.process.arch);
 
         await expectAsync(install.chromium()).toBeResolvedTo(
           jasmine.stringMatching(expected.return.replace(/[.\\]/g, '\\$&'))

--- a/packages/core/test/unit/install.test.js
+++ b/packages/core/test/unit/install.test.js
@@ -183,7 +183,7 @@ describe('Unit / Install', () => {
       },
       darwinArm: {
         revision: install.chromium.revisions.darwinArm,
-        url: jasmine.stringMatching(`Mac/${install.chromium.revisions.darwinArm}/chrome-mac.zip`),
+        url: jasmine.stringMatching(`Mac_Arm/${install.chromium.revisions.darwinArm}/chrome-mac.zip`),
         return: path.join('chrome-mac', 'Chromium.app', 'Contents', 'MacOS', 'Chromium'),
         process: { platform: 'darwin', arch: 'arm64' }
       },

--- a/scripts/chromium-revision
+++ b/scripts/chromium-revision
@@ -34,6 +34,7 @@ const GH_HEADERS = {
 const G_STORAGE_API_URL = 'https://www.googleapis.com/storage/v1/b/chromium-browser-snapshots/o';
 const G_STORAGE_PREFIXES = {
   darwin: 'Mac',
+  darwinArm: 'Mac_Arm',
   linux: 'Linux_x64',
   win64: 'Win_x64',
   win32: 'Win'
@@ -95,7 +96,7 @@ async function printVersionRevisions(version) {
   // 50 revisions (not all platforms release at the same time)
   let revisions = await task({
     state: () => ({
-      platforms: ['linux', 'win64', 'win32', 'darwin'],
+      platforms: ['linux', 'win64', 'win32', 'darwin', 'darwinArm'],
       range: [revision - 50, revision],
       value: {}
     }),
@@ -105,8 +106,9 @@ async function printVersionRevisions(version) {
     async function(state) {
       let platform = state.platforms[state.i - 1];
       if (!platform) return state.value;
+      let rev = state.range[1];
 
-      for (let rev = state.range[1]; rev >= state.range[0]; rev--) {
+      for (; rev >= state.range[0]; rev--) {
         // query google's storage api for the platform revision
         let { items } = await request((
           `${G_STORAGE_API_URL}?fields=items(name,metadata)&` +


### PR DESCRIPTION
## What is this?

For a while, Chromium for Mac was only built on x64 architecture. With the advent of new M1 arm Macs, it wasn't clear if the Percy CLI even worked on these new macs since we rely on Chromium for asset discovery. I looked back into the Google storage APIs and found that there were recent additions that added Mac arm support. This PR adds the appropriate changes so our install script will download the correct version of Chromium when run on arm based Macs.