### PR TITLE
🐛 Fix situations where asset discovery might hang

### DIFF
--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -19,6 +19,7 @@ export default class Browser extends EventEmitter {
 
   defaultArgs = [
     '--enable-features=NetworkService,NetworkServiceInProcess',
+    '--disable-features=Translate',
     '--disable-background-networking',
     '--disable-background-timer-throttling',
     '--disable-backgrounding-occluded-windows',
@@ -28,7 +29,6 @@ export default class Browser extends EventEmitter {
     '--disable-default-apps',
     '--disable-dev-shm-usage',
     '--disable-extensions',
-    '--disable-features=TranslateUI',
     '--disable-hang-monitor',
     '--disable-ipc-flooding-protection',
     '--disable-popup-blocking',

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -120,15 +120,12 @@ export default class Network {
   _handleRequestPaused = event => {
     let { networkId: requestId } = event;
     let pending = this.#pending.get(requestId);
+    this.#pending.delete(requestId);
 
     // guard against redirects with the same requestId
     if (pending?.request.url === event.request.url &&
         pending.request.method === event.request.method) {
       this._handleRequest(pending, event.requestId);
-    }
-
-    if (pending) {
-      this.#pending.delete(requestId);
     } else {
       this.#intercepts.set(requestId, event);
     }
@@ -165,7 +162,6 @@ export default class Network {
     // if handling a redirected request, associate the response and add to its redirect chain
     if (event.redirectResponse && this.#requests.has(requestId)) {
       let req = this.#requests.get(requestId);
-      req.response = event.redirectResponse;
       redirectChain = [...req.redirectChain, req];
       // clean up interim requests
       this._forgetRequest(req, true);

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -235,7 +235,7 @@ export default class Network {
   // callback. The request should have an associated response and be finished with any redirects.
   _handleLoadingFinished = async event => {
     let request = this.#requests.get(event.requestId);
-    /* istanbul ignore next: race condition paranioa */
+    /* istanbul ignore if: race condition paranioa */
     if (!request) return;
 
     if (this._intercept) {
@@ -263,9 +263,10 @@ export default class Network {
   // process before the request finish event had a chance to be triggered.
   _handleFrameDetached = async event => {
     let request = this.#frames.get(event.frameId);
-    /* istanbul ignore next: race condition paranioa */
+    /* istanbul ignore if: race condition paranioa */
     if (!request) return;
 
+    /* istanbul ignore else: could be false when a page is used without asset discovery */
     if (this._intercept) {
       await this.onrequestfinished(request);
     }

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -15,6 +15,7 @@ export default class Network {
   #requests = new Map();
   #intercepts = new Map();
   #authentications = new Set();
+  #frames = new Map();
 
   log = logger('core:network');
 
@@ -27,6 +28,7 @@ export default class Network {
     this.page.on('Network.eventSourceMessageReceived', this._handleEventSourceMessageReceived);
     this.page.on('Network.loadingFinished', this._handleLoadingFinished);
     this.page.on('Network.loadingFailed', this._handleLoadingFailed);
+    this.page.on('Page.frameDetached', this._handleFrameDetached);
 
     /* istanbul ignore next: race condition */
     this.page.send('Network.enable')
@@ -82,9 +84,10 @@ export default class Network {
   }
 
   // Called when a request should be removed from various trackers
-  _forgetRequest({ requestId, interceptId }, keepPending) {
+  _forgetRequest({ requestId, interceptId, frameId }, keepPending) {
     this.#requests.delete(requestId);
     this.#authentications.delete(interceptId);
+    this.#frames.delete(frameId);
 
     if (!keepPending) {
       this.#pending.delete(requestId);
@@ -156,7 +159,7 @@ export default class Network {
   // responses and calls this.onrequest with request info and callbacks to continue, respond,
   // or abort a request. One of the callbacks is required to be called and only one.
   _handleRequest = async (event, interceptId) => {
-    let { requestId, request } = event;
+    let { frameId, requestId, request } = event;
     let redirectChain = [];
 
     // if handling a redirected request, associate the response and add to its redirect chain
@@ -168,6 +171,7 @@ export default class Network {
       this._forgetRequest(req, true);
     }
 
+    request.frameId = frameId;
     request.requestId = requestId;
     request.interceptId = interceptId;
     request.redirectChain = redirectChain;
@@ -213,6 +217,10 @@ export default class Network {
       let { body, base64Encoded } = await this.page.send('Network.getResponseBody', { requestId });
       return Buffer.from(body, base64Encoded ? 'base64' : 'utf8');
     };
+
+    if (request.frameId !== this.page.frameId) {
+      this.#frames.set(request.frameId, request);
+    }
   }
 
   // Called when a request streams events. These types of requests break asset discovery because
@@ -226,8 +234,7 @@ export default class Network {
   // Called when a request has finished loading which triggers the this.onrequestfinished
   // callback. The request should have an associated response and be finished with any redirects.
   _handleLoadingFinished = async event => {
-    let { requestId } = event;
-    let request = this.#requests.get(requestId);
+    let request = this.#requests.get(event.requestId);
     /* istanbul ignore next: race condition paranioa */
     if (!request) return;
 
@@ -240,14 +247,27 @@ export default class Network {
 
   // Called when a request has failed loading and triggers the this.onrequestfailed callback.
   _handleLoadingFailed = async event => {
-    let { requestId, errorText } = event;
-    let request = this.#requests.get(requestId);
+    let request = this.#requests.get(event.requestId);
     /* istanbul ignore if: race condition paranioa */
     if (!request) return;
 
     if (this._intercept) {
-      request.error = errorText;
+      request.error = event.errorText;
       await this.onrequestfailed(request);
+    }
+
+    this._forgetRequest(request);
+  }
+
+  // Called after a frame detaches from the main frame. It's likely that the frame created its own
+  // process before the request finish event had a chance to be triggered.
+  _handleFrameDetached = async event => {
+    let request = this.#frames.get(event.frameId);
+    /* istanbul ignore next: race condition paranioa */
+    if (!request) return;
+
+    if (this._intercept) {
+      await this.onrequestfinished(request);
     }
 
     this._forgetRequest(request);

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -107,8 +107,8 @@ export default class Page extends EventEmitter {
   async resize({
     deviceScaleFactor = 1,
     mobile = false,
-    height = 1024,
-    width = 1280
+    height,
+    width
   }) {
     this.log.debug(`Resize page to ${width}x${height}`);
 

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -45,8 +45,6 @@ export default class Page extends EventEmitter {
     authorization,
     userAgent,
     intercept,
-    height,
-    width,
     meta
   } = {}) {
     this.log.debug('Initialize page', meta);
@@ -71,8 +69,7 @@ export default class Page extends EventEmitter {
       this.send('Network.setExtraHTTPHeaders', { headers: requestHeaders }),
       this.send('Network.setUserAgentOverride', { userAgent }),
       this.send('Security.setIgnoreCertificateErrors', { ignore: true }),
-      this.send('Emulation.setScriptExecutionDisabled', { value: !enableJavaScript }),
-      this.resize({ width, height })
+      this.send('Emulation.setScriptExecutionDisabled', { value: !enableJavaScript })
     ]);
 
     if (intercept) {

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -301,9 +301,6 @@ export default class Percy {
           userAgent: discovery.userAgent,
           meta,
 
-          // initial width
-          width: widths.shift(),
-
           // enable network inteception
           intercept: {
             disableCache: discovery.disableCache,
@@ -319,9 +316,19 @@ export default class Percy {
           }
         });
 
-        // navigate to the url and trigger resize events
+        // set the initial page size
+        await page.resize({
+          width: widths.shift(),
+          height: conf.minHeight
+        });
+
+        // navigate to the url
         await page.goto(url);
-        for (let width of widths) await page.resize({ width });
+
+        // trigger resize events for other widths
+        for (let width of widths) {
+          await page.resize({ width, height: conf.minHeight });
+        }
 
         // create and add a percy-css resource
         let percyCSS = createPercyCSSResource(url, conf.percyCSS);

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -965,6 +965,24 @@ describe('Discovery', () => {
         })
       );
     });
+
+    it('does not hang waiting for embedded isolated pages', async () => {
+      server.reply('/', () => [200, {
+        'Content-Type': 'text/html',
+        'Origin-Agent-Cluster': '?1' // force page isolation
+      }, testDOM]);
+
+      server2.reply('/', () => [200, 'text/html', [
+        '<iframe src="http://embed.localhost:8000"></iframe>'
+      ].join('\n')]);
+
+      await percy.snapshot({
+        name: 'test cors',
+        url: 'http://test.localhost:8001'
+      });
+
+      await expectAsync(percy.idle()).toBeResolved();
+    });
   });
 
   describe('with launch options', () => {

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -867,7 +867,7 @@ describe('Discovery', () => {
   });
 
   describe('with remote resources', () => {
-    let testExternalDOM = testDOM.replace('img.gif', 'http://test.localtest.me:8001/img.gif');
+    let testExternalDOM = testDOM.replace('img.gif', 'http://ex.localhost:8001/img.gif');
     let server2;
 
     beforeEach(async () => {
@@ -944,7 +944,7 @@ describe('Discovery', () => {
       percy = await Percy.start({
         token: 'PERCY_TOKEN',
         discovery: {
-          allowedHostnames: ['*.localtest.me']
+          allowedHostnames: ['ex.localhost']
         }
       });
 
@@ -957,10 +957,10 @@ describe('Discovery', () => {
 
       await percy.idle();
 
-      expect(captured[0][3]).toEqual(
+      expect(captured[0]).toContain(
         jasmine.objectContaining({
           attributes: jasmine.objectContaining({
-            'resource-url': 'http://test.localtest.me:8001/img.gif'
+            'resource-url': 'http://ex.localhost:8001/img.gif'
           })
         })
       );


### PR DESCRIPTION
## What is this?

This PR addresses a couple of networking issues in asset discovery.

### Improved timeout logs

Foremost, while debugging a very minimal reproduction of asset discovery hanging, it was very helpful to know which requests were causing the issue. This resulted in an improved network timeout log, which includes a list of the offending request URLs in debug logs.

With the improved logs, it was easy to see that there was an issue with requests for some frame documents. With some additional, very noisy, event logs (not included), it revealed that once the document's response was received, the subsequent request finished events were never observed.

### Site isolation handling

This prompted an investigation into how events are handled with embedded documents, and it was then discovered that Chromium's [site-isolation](https://www.chromium.org/Home/chromium-security/site-isolation) was somehow responsible for the lack of events once the frame was created. Disabling this feature indeed fixed the issue with frame requests hanging, however it felt wrong disabling a security feature like this.

Unrelated, I also found that the `TranslateUI` feature flag changed to just `Translate`. Unfortunately, Chromium will change flags/features between versions like this, and in this particular instance we don't happen to have an explicit test for the translate popup that this was initially meant to suppress. I still didn't add a test in this PR since it mostly focuses on network issues and I just happened to mess with this flag during the above investigation.

To avoid disabling site-isolation, we need to be able to observe subframe requests. This is possible with a couple of very small changes. While pages are already automatically created for newly attached targets, those pages were not automatically initialized. If we want to automatically attach and initialize a subframe for request interception, we do not want to resize the subframe when initialized, so page resizing was moved out of page initialization. To automatically attach and initialize subframes: the `Target.setAutoAttach` command is sent and when a page is created with a parent, it is initialized with inherited options (including network interception options).

### Hanging frame requests

This still leaves the issue of the initial frame request not properly getting cleaned up due to never receiving request finished events. The subframe network also does not see this request since the request is already complete at the time of target creation. To clean up such frame requests, they are registered during the response phase if the resulting response has a different frame. The `Page.frameDetached` event is also watched, and if a frame request has not been handled at the time the event is received, it is assumed to be finished and the appropriate handlers are called.

### Hanging redirects

This concludes the bulk of the changes this PR focuses on, however while testing I also noticed a flakey test related to redirects. This flake also resulted in asset discovery hanging, so it felt appropriate to include a fix with other changes related to the same undesired outcome. 

While debugging this issue, I found that page navigation was sometimes flaking, and that was fixed by a slight refactor to how lifecycle events are handled during page navigation. Once that was fixed, the real issue revealed itself to be related to recent network additions (#469). With some of the logic that was added, there was a gap in which an intercepted redirect might not be properly registered as being intercepted. This is fixed by simply removing the gap in the if-else conditionals. The redirect test was made more robust as a result, although it always seems related to race-y events rather than complex redirect rules.