### PR TITLE
🐛 Wait for isolated networks to idle

### DIFF
--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -29,10 +29,7 @@ export default class Network {
     this.page.on('Network.loadingFinished', this._handleLoadingFinished);
     this.page.on('Network.loadingFailed', this._handleLoadingFailed);
     this.page.on('Page.frameDetached', this._handleFrameDetached);
-
-    /* istanbul ignore next: race condition */
-    this.page.send('Network.enable')
-      .catch(e => this.log.debug(e, this.page.meta));
+    this.page._handleCloseRace(this.page.send('Network.enable'));
   }
 
   // Enable request interception

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -38,7 +38,7 @@ export default class Page extends EventEmitter {
 
     if (this.parent) {
       this.parent.frames.add(this);
-      this.init(this.parent.options);
+      this._handleCloseRace(this.init(this.parent.options));
     }
   }
 
@@ -326,6 +326,15 @@ export default class Page extends EventEmitter {
     this.#callbacks.clear();
     this.parent?.frames.delete(this);
     this.browser = null;
+  }
+
+  _handleCloseRace(promise) {
+    /* istanbul ignore next: race conditions, amirite? */
+    return promise.catch(error => {
+      if (!error.message.endsWith(this.closedReason)) {
+        this.log.debug(error, this.meta);
+      }
+    });
   }
 
   _handleExecutionContextCreated = event => {

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -16,6 +16,7 @@ export default class Page extends EventEmitter {
   frameId = null;
   contextId = null;
   closedReason = null;
+  frames = new Set();
   log = logger('core:page');
 
   constructor(browser, { params, sessionId: parentId }) {
@@ -34,7 +35,11 @@ export default class Page extends EventEmitter {
 
     // if there is a parent session, automatically init this session
     this.parent = browser.pages.get(parentId);
-    if (this.parent) this.init(this.parent.options);
+
+    if (this.parent) {
+      this.parent.frames.add(this);
+      this.init(this.parent.options);
+    }
   }
 
   // initial page options asynchronously
@@ -95,6 +100,8 @@ export default class Page extends EventEmitter {
   // Close the target page if not already closed
   async close() {
     if (!this.browser) return;
+
+    this.log.debug('Page closing', this.meta);
 
     /* istanbul ignore next: errors race here when the browser closes */
     await this.browser.send('Target.closeTarget', { targetId: this.targetId })
@@ -307,7 +314,6 @@ export default class Page extends EventEmitter {
   }
 
   _handleClose() {
-    this.log.debug('Page closing', this.meta);
     this.closedReason ||= 'Page closed.';
 
     // reject any pending callbacks
@@ -318,6 +324,7 @@ export default class Page extends EventEmitter {
     }
 
     this.#callbacks.clear();
+    this.parent?.frames.delete(this);
     this.browser = null;
   }
 

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -1021,7 +1021,6 @@ describe('Discovery', () => {
         name: 'test cors',
         url: 'http://test.localhost:8001',
         discovery: {
-          networkIdleTimeout: 50,
           allowedHostnames: ['embed.localhost']
         }
       });

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -1001,6 +1001,41 @@ describe('Discovery', () => {
 
       await expectAsync(percy.idle()).toBeResolved();
     });
+
+    it('waits to capture resources from isolated pages', async () => {
+      server.reply('/', () => [200, {
+        'Content-Type': 'text/html',
+        'Origin-Agent-Cluster': '?1' // force page isolation
+      }, testDOM]);
+
+      server.reply('/img.gif', () => new Promise(resolve => {
+        // wait a tad longer than network idle would
+        setTimeout(resolve, 200, [200, 'image/gif', pixel]);
+      }));
+
+      server2.reply('/', () => [200, 'text/html', [
+        '<iframe src="http://embed.localhost:8000"></iframe>'
+      ].join('\n')]);
+
+      await percy.snapshot({
+        name: 'test cors',
+        url: 'http://test.localhost:8001',
+        discovery: {
+          networkIdleTimeout: 50,
+          allowedHostnames: ['embed.localhost']
+        }
+      });
+
+      await percy.idle();
+
+      expect(captured[0]).toContain(
+        jasmine.objectContaining({
+          attributes: jasmine.objectContaining({
+            'resource-url': 'http://embed.localhost:8000/img.gif'
+          })
+        })
+      );
+    });
   });
 
   describe('with launch options', () => {


### PR DESCRIPTION
## What is this?

Thanks to #490, it now makes it possible to properly capture resources from isolated pages. However, during the network idle check, only the top-level network method is used which only references its own requests. This PR adds tracking isolated pages to the parent page to create a inverse relationship. And also adds a new network method to retrieve all nested page requests during the idle check. These changes make it so network idle will check for nested requests in addition to its own requests.

While here, I also came across a familiar race condition in the page constructor as a result of the page closing during an async call within the constructor. This same race condition exists in the network constructor, however with a check to prevent intentional page closed errors from bubbling. Rather than repeat the pattern, it was improved slightly to make debug logs less confusing. Now, when one of these async constructor calls happen with the page closing, the error is disregarded. All other errors will be logged rather than let bubble since an error from these locations usually stems from an error elsewhere.