### PR TITLE
✨ Add --debug discovery flag

### DIFF
--- a/packages/cli-command/src/command.js
+++ b/packages/cli-command/src/command.js
@@ -66,6 +66,7 @@ export default class PercyCommand extends Command {
 
     // set config: false to prevent core from reloading config
     return Object.assign(config, {
+      skipUploads: this.flags.debug,
       config: false
     });
   }

--- a/packages/cli-command/src/flags.js
+++ b/packages/cli-command/src/flags.js
@@ -18,22 +18,25 @@ const logging = {
   })
 };
 
-// Common asset discovery flags mapped to config options.
+// Common asset discovery flags.
 const discovery = {
   'allowed-hostname': flags.string({
     char: 'h',
-    description: 'allowed hostnames',
+    description: 'allowed hostnames to capture in asset discovery',
     multiple: true,
     percyrc: 'discovery.allowedHostnames'
   }),
   'network-idle-timeout': flags.integer({
     char: 't',
-    description: 'asset discovery idle timeout',
+    description: 'asset discovery network idle timeout',
     percyrc: 'discovery.networkIdleTimeout'
   }),
   'disable-cache': flags.boolean({
     description: 'disable asset discovery caches',
     percyrc: 'discovery.disableCache'
+  }),
+  debug: flags.boolean({
+    description: 'debug asset discovery and do not upload snapshots'
   })
 };
 

--- a/packages/cli-command/test/command.test.js
+++ b/packages/cli-command/test/command.test.js
@@ -66,6 +66,8 @@ describe('PercyCommand', () => {
     expect(logger.loglevel()).toBe('warn');
     await TestPercyCommand.run(['--silent']);
     expect(logger.loglevel()).toBe('silent');
+    await TestPercyCommand.run(['--debug']);
+    expect(logger.loglevel()).toBe('debug');
   });
 
   it('logs errors to the logger and exits', async () => {
@@ -127,12 +129,14 @@ describe('PercyCommand', () => {
         '--allowed-hostname', '*.percy.io',
         '--network-idle-timeout', '150',
         '--disable-cache',
+        '--debug',
         'foo', 'bar'
       ])).toBeResolved();
 
       expect(results[0].percyrc()).toEqual({
         version: 2,
         config: false,
+        skipUploads: true,
         snapshot: {
           widths: [375, 1280],
           minHeight: 1024,

--- a/packages/cli-exec/README.md
+++ b/packages/cli-exec/README.md
@@ -20,10 +20,11 @@ USAGE
 OPTIONS
   -P, --port=port                                  [default: 5338] server port
   -c, --config=config                              configuration file path
-  -h, --allowed-hostname=allowed-hostname          allowed hostnames
+  -h, --allowed-hostname=allowed-hostname          allowed hostnames to capture in asset discovery
   -q, --quiet                                      log errors only
-  -t, --network-idle-timeout=network-idle-timeout  asset discovery idle timeout
+  -t, --network-idle-timeout=network-idle-timeout  asset discovery network idle timeout
   -v, --verbose                                    log everything
+  --debug                                          debug asset discovery and do not upload snapshots
   --disable-cache                                  disable asset discovery caches
   --parallel                                       marks the build as one of many parallel builds
   --partial                                        marks the build as a partial build
@@ -60,10 +61,11 @@ USAGE
 OPTIONS
   -P, --port=port                                  [default: 5338] server port
   -c, --config=config                              configuration file path
-  -h, --allowed-hostname=allowed-hostname          allowed hostnames
+  -h, --allowed-hostname=allowed-hostname          allowed hostnames to capture in asset discovery
   -q, --quiet                                      log errors only
-  -t, --network-idle-timeout=network-idle-timeout  asset discovery idle timeout
+  -t, --network-idle-timeout=network-idle-timeout  asset discovery network idle timeout
   -v, --verbose                                    log everything
+  --debug                                          debug asset discovery and do not upload snapshots
   --disable-cache                                  disable asset discovery caches
   --silent                                         log nothing
 

--- a/packages/cli-snapshot/README.md
+++ b/packages/cli-snapshot/README.md
@@ -21,11 +21,12 @@ OPTIONS
   -b, --base-url=base-url                          the base url pages are hosted at when snapshotting
   -c, --config=config                              configuration file path
   -d, --dry-run                                    prints a list of pages to snapshot without snapshotting
-  -h, --allowed-hostname=allowed-hostname          allowed hostnames
+  -h, --allowed-hostname=allowed-hostname          allowed hostnames to capture in asset discovery
   -q, --quiet                                      log errors only
-  -t, --network-idle-timeout=network-idle-timeout  asset discovery idle timeout
+  -t, --network-idle-timeout=network-idle-timeout  asset discovery network idle timeout
   -v, --verbose                                    log everything
   --clean-urls                                     rewrite static index and filepath URLs to be clean
+  --debug                                          debug asset discovery and do not upload snapshots
   --disable-cache                                  disable asset discovery caches
 
   --files=files                                    [default: **/*.{html,htm}] one or more globs matching static file

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -38,6 +38,7 @@ const percy = await Percy.start(percyOptions)
 - `clientInfo` — Client info sent to Percy via a user-agent string
 - `environmentInfo` — Environment info also sent with the user-agent string
 - `deferUploads` — Defer creating a build and uploading snapshots until later
+- `skipUploads` — Skip creating a build and uploading snapshots altogether
 
 The following options can also be defined within a Percy config file
 

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -207,6 +207,26 @@ describe('Percy', () => {
       expect(mockAPI.requests['/builds']).toBeDefined();
     });
 
+    it('does not create a build when uploads are skipped', async () => {
+      percy = new Percy({ token: 'PERCY_TOKEN', skipUploads: true });
+      await expectAsync(percy.start()).toBeResolved();
+      expect(mockAPI.requests['/builds']).toBeUndefined();
+
+      // attempt to dispatch differed uploads
+      await percy.dispatch();
+
+      expect(mockAPI.requests['/builds']).toBeUndefined();
+
+      // stopping should also skip uploads
+      await percy.stop();
+
+      expect(mockAPI.requests['/builds']).toBeUndefined();
+
+      expect(logger.stderr).toEqual([
+        '[percy] Build not created'
+      ]);
+    });
+
     it('stops accepting snapshots when a queued build fails to be created', async () => {
       server = await createTestServer({
         default: () => [200, 'text/html', '<p>Snapshot</p>']

--- a/packages/logger/src/index.js
+++ b/packages/logger/src/index.js
@@ -14,7 +14,8 @@ Object.assign(logger, {
   connect: (...args) => new Logger().connect(...args),
   remote: (...args) => new Logger().remote(...args),
   loglevel(level, flags = {}) {
-    if (flags.verbose) level = 'debug';
+    if (flags.debug) level = 'debug';
+    else if (flags.verbose) level = 'debug';
     else if (flags.quiet) level = 'warn';
     else if (flags.silent) level = 'silent';
     return new Logger().loglevel(level);

--- a/packages/logger/test/logger.test.js
+++ b/packages/logger/test/logger.test.js
@@ -171,6 +171,8 @@ describe('logger', () => {
     });
 
     it('can be controlled by a secondary flags argument', () => {
+      logger.loglevel('info', { debug: true });
+      expect(logger.loglevel()).toEqual('debug');
       logger.loglevel('info', { verbose: true });
       expect(logger.loglevel()).toEqual('debug');
       logger.loglevel('info', { quiet: true });
@@ -267,7 +269,7 @@ describe('logger', () => {
       expect(helpers.stderr).toEqual([
         jasmine.stringMatching('Warn log \\(\\dms\\)'),
         jasmine.stringMatching('Error log \\(\\dms\\)'),
-        jasmine.stringMatching('Debug log \\((9[0-9]|1[01][0-9])ms\\)'),
+        jasmine.stringMatching('Debug log \\(\\d{2,3}ms\\)'),
         jasmine.stringMatching('Final log \\(\\dms\\)')
       ]);
     });


### PR DESCRIPTION
## What is this?

Asset discovery issues are typically debugged with the `--verbose` flag, or by setting the environment variable `PERCY_LOGLEVEL=debug`. While this option prints detailed logs throughout the toolchain, including asset discovery, it only does just that — prints detailed logs. However, when debugging asset discovery issues, the constant uploading of any snapshots results in a hit to screenshot usage. It would be beneficial while debugging asset discovery issues to simply not send any snapshots at all, or not even create a build to begin with.

This PR introduces a `--debug` flag, which not only enables debug logs just like the `--verbose` flag, but additionally disables snapshot uploads via a new core `skipUploads` option. This option mirrors the existing (but unused) `deferUploads` option. The two options do the same thing, with the addition of the `skipUploads` option skipping the deferred uploads altogether. The `--debug` flag could also be an entrypoint for future asset discovery debugging features.

The `start()` method was adjusted slightly to remove the Percy token check. This token doesn't need to be set when not uploading snapshots or creating builds. The token is also checked before any API call by client, such as the first task of the `start()` method, creating a build; this check is also already deferred when uploads are deferred. The creation of the deferred task was also moved outside of the try-catch block since there is nothing to catch until the task is run and awaited on.