### PR TITLE
🐛 Fix small config util bugs

### DIFF
--- a/packages/config/src/utils.js
+++ b/packages/config/src/utils.js
@@ -7,6 +7,11 @@ function create(array) {
   return array ? [] : {};
 }
 
+// Returns true or false if a subject has iterable keys or not
+function hasKeys(subj) {
+  return isArray(subj) || Object.getPrototypeOf(subj) === Object.prototype;
+}
+
 // Returns true if the provided key looks like an array key
 const ARRAY_PATH_KEY_REG = /^(\[\d+]|0|[1-9]\d*)$/;
 
@@ -26,9 +31,9 @@ export function parsePropertyPath(path) {
 
 // Join an array of path parts into a single path string
 export function joinPropertyPath(path) {
-  return path.map(part => (
-    isArrayKey(part) ? `[${part}]` : `.${part}`
-  )).join('').substr(1);
+  let joined = path.map(k => isArrayKey(k) ? `[${k}]` : `.${k}`).join('');
+  if (joined.startsWith('.')) return joined.substr(1);
+  return joined;
 }
 
 // Gets a value in the object at the path
@@ -129,7 +134,7 @@ export function merge(sources, map) {
       }
 
       // set the next or default value if there is one
-      if (next != null || (next !== null && value != null && typeof value !== 'object')) {
+      if (next != null || (next !== null && value != null && !hasKeys(value))) {
         set(target ??= create(isSourceArray), path, next ?? value);
       }
 

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -801,6 +801,24 @@ describe('PercyConfig', () => {
       });
     });
 
+    it('does not remove all empty "objects"', () => {
+      let config = {
+        regex: /foobar/,
+        date: new Date(),
+        foo: new (class {})(),
+        object: {},
+        array: []
+      };
+
+      expect(PercyConfig.normalize(config))
+        .toEqual({
+          // referential equality
+          regex: config.regex,
+          date: config.date,
+          foo: config.foo
+        });
+    });
+
     it('converts keys to camelCase', () => {
       expect(PercyConfig.normalize({
         'foo-bar': 'baz',


### PR DESCRIPTION
## What is this?

This PR fixes a couple small bugs I found in `@percy/config`:

- When validating arrays as the root subject, the resulting message would contain a path like `0].example`. This was fixed by only stripping leading periods from joined paths rather that stripping the first character blindly.

- When normalizing objects that are not plain objects or arrays (Date, RegExp, etc), the object was inadvertently removed from the result. This was fixed by explicitly testing for the correct type of objects we're looking for. The util was named `hasKeys` in case we ever need to account for other types of iterable objects (but not all of them).