### PR TITLE
✨ Add deprecate config migrate util

### DIFF
--- a/packages/config/src/utils.js
+++ b/packages/config/src/utils.js
@@ -31,6 +31,7 @@ export function parsePropertyPath(path) {
 
 // Join an array of path parts into a single path string
 export function joinPropertyPath(path) {
+  if (typeof path === 'string') return path;
   let joined = path.map(k => isArrayKey(k) ? `[${k}]` : `.${k}`).join('');
   if (joined.startsWith('.')) return joined.substr(1);
   return joined;

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -208,45 +208,32 @@ export const snapshotDOMSchema = {
 };
 
 // Config migrate function
-export function configMigration(config, { map, del, log }) {
+export function configMigration(config, util) {
   /* eslint-disable curly */
   if (config.version < 2) {
     // discovery options have moved
-    map('agent.assetDiscovery.allowedHostnames', 'discovery.allowedHostnames');
-    map('agent.assetDiscovery.networkIdleTimeout', 'discovery.networkIdleTimeout');
-    map('agent.assetDiscovery.cacheResponses', 'discovery.disableCache', v => !v);
-    map('agent.assetDiscovery.requestHeaders', 'discovery.requestHeaders');
-    map('agent.assetDiscovery.pagePoolSizeMax', 'discovery.concurrency');
-    del('agent');
+    util.map('agent.assetDiscovery.allowedHostnames', 'discovery.allowedHostnames');
+    util.map('agent.assetDiscovery.networkIdleTimeout', 'discovery.networkIdleTimeout');
+    util.map('agent.assetDiscovery.cacheResponses', 'discovery.disableCache', v => !v);
+    util.map('agent.assetDiscovery.requestHeaders', 'discovery.requestHeaders');
+    util.map('agent.assetDiscovery.pagePoolSizeMax', 'discovery.concurrency');
+    util.del('agent');
   } else {
+    let notice = { type: 'config', in: '1.0.0' };
     // snapshot discovery options have moved
-    for (let k of ['authorization', 'requestHeaders']) {
-      if (config.snapshot?.[k]) {
-        log.deprecated(`The config option \`snapshot.${k}\` ` + (
-          `will be removed in 1.0.0. Use \`discovery.${k}\` instead.`));
-        map(`snapshot.${k}`, `discovery.${k}`);
-      }
-    }
+    util.deprecate('snapshot.authorization', { map: 'discovery.authorization', ...notice });
+    util.deprecate('snapshot.requestHeaders', { map: 'discovery.requestHeaders', ...notice });
   }
 }
 
 // Snapshot option migrate function
-export function snapshotMigration(config, { map, log }) {
+export function snapshotMigration(config, util) {
+  let notice = { type: 'snapshot', in: '1.0.0', warn: true };
   // discovery options have moved
-  for (let k of ['authorization', 'requestHeaders']) {
-    if (config[k]) {
-      log.warn(`Warning: The snapshot option \`${k}\` ` + (
-        `will be removed in 1.0.0. Use \`discovery.${k}\` instead.`));
-      map(k, `discovery.${k}`);
-    }
-  }
-
-  // snapshots was renamed
-  if (config.snapshots) {
-    log.warn('Warning: The `snapshots` option will be ' + (
-      'removed in 1.0.0. Use `additionalSnapshots` instead.'));
-    map('snapshots', 'additionalSnapshots');
-  }
+  util.deprecate('authorization', { map: 'discovery.authorization', ...notice });
+  util.deprecate('requestHeaders', { map: 'discovery.requestHeaders', ...notice });
+  // snapshots option was renamed
+  util.deprecate('snapshots', { map: 'additionalSnapshots', ...notice });
 }
 
 // Convinient references for schema registrations

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -124,7 +124,7 @@ describe('Snapshot', () => {
         'will be removed in 1.0.0. Use `discovery.requestHeaders` instead.',
       '[percy] Warning: The snapshot option `authorization` ' +
         'will be removed in 1.0.0. Use `discovery.authorization` instead.',
-      '[percy] Warning: The `snapshots` option ' +
+      '[percy] Warning: The snapshot option `snapshots` ' +
         'will be removed in 1.0.0. Use `additionalSnapshots` instead.'
     ]);
   });


### PR DESCRIPTION
## What is this?

We currently only have a single place where config migrations log a few deprecation warnings, and that is in `@percy/core`. We also had/have deprecations in the Storybook SDK, although that SDK recently left beta and so the deprecations are/will be removed. In the future, other config deprecations might come up, and so it would be helpful to consolidate how deprecations are handled into a single migrate util passed along just like the other current migrate utils.

This PR also updates `@percy/core` migration deprecations to use the new util.

Depends on #493 as these changes are how I discovered those bugs.