### PR TITLE
♻ Small revision to the deprecate migrate util api

### DIFF
--- a/packages/config/src/migrate.js
+++ b/packages/config/src/migrate.js
@@ -36,7 +36,7 @@ function defaultMigration(config, { set }) {
 // Migrate util for deprecated options
 function deprecate(config, log, path, options) {
   if (get(config, path) == null) return;
-  let { type, in: ver, map: to, alt, warn } = options;
+  let { type, until: ver, map: to, alt, warn } = options;
   let name = joinPropertyPath(path);
 
   let message = 'The ' + [

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -432,7 +432,7 @@ describe('PercyConfig', () => {
 
       // test various other options
       expect(test({ type: 'test' }, 4)).toEqual({ ...v, value: 4 });
-      expect(test({ in: '1.0.0' }, 5)).toEqual({ ...v, value: 5 });
+      expect(test({ until: '1.0.0' }, 5)).toEqual({ ...v, value: 5 });
       expect(test({ map: 'test' }, 6)).toEqual({ ...v, test: 6 });
       expect(test({ alt: 'See docs.' }, 7)).toEqual({ ...v, value: 7 });
 
@@ -445,7 +445,7 @@ describe('PercyConfig', () => {
       expect(test({ type: 'annoying', warn: true }, 10)).toEqual({ ...v, value: 10 });
 
       // combination of options
-      expect(test({ type: 'test', in: '1.0.0', map: 'test.value' }, 11))
+      expect(test({ type: 'test', until: '1.0.0', map: 'test.value' }, 11))
         .toEqual({ ...v, test: { value: 11 } });
 
       expect(logger.stderr).toEqual([

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -219,7 +219,7 @@ export function configMigration(config, util) {
     util.map('agent.assetDiscovery.pagePoolSizeMax', 'discovery.concurrency');
     util.del('agent');
   } else {
-    let notice = { type: 'config', in: '1.0.0' };
+    let notice = { type: 'config', until: '1.0.0' };
     // snapshot discovery options have moved
     util.deprecate('snapshot.authorization', { map: 'discovery.authorization', ...notice });
     util.deprecate('snapshot.requestHeaders', { map: 'discovery.requestHeaders', ...notice });
@@ -228,7 +228,7 @@ export function configMigration(config, util) {
 
 // Snapshot option migrate function
 export function snapshotMigration(config, util) {
-  let notice = { type: 'snapshot', in: '1.0.0', warn: true };
+  let notice = { type: 'snapshot', until: '1.0.0', warn: true };
   // discovery options have moved
   util.deprecate('authorization', { map: 'discovery.authorization', ...notice });
   util.deprecate('requestHeaders', { map: 'discovery.requestHeaders', ...notice });

--- a/packages/core/test/unit/config.test.js
+++ b/packages/core/test/unit/config.test.js
@@ -58,8 +58,8 @@ describe('Unit / Config Migration', () => {
     }, mocked);
 
     expect(mocked.migrate.deprecate).toEqual([
-      ['snapshot.authorization', { map: 'discovery.authorization', type: 'config', in: '1.0.0' }],
-      ['snapshot.requestHeaders', { map: 'discovery.requestHeaders', type: 'config', in: '1.0.0' }]
+      ['snapshot.authorization', { map: 'discovery.authorization', type: 'config', until: '1.0.0' }],
+      ['snapshot.requestHeaders', { map: 'discovery.requestHeaders', type: 'config', until: '1.0.0' }]
     ]);
   });
 


### PR DESCRIPTION
## What is this?

The option to deprecate `until: version` reads more accurately than `in: version` and reflects that the user has _until_ that version to move away from the deprecation.