### PR TITLE
🐛 Do not replace initial overrides with empty flags

### DIFF
--- a/packages/cli-command/test/command.test.js
+++ b/packages/cli-command/test/command.test.js
@@ -148,12 +148,16 @@ describe('PercyCommand', () => {
       });
     });
 
+    it('does not replace initial overrides with empty flags', async () => {
+      await expectAsync(TestPercyCommand.run([])).toBeResolved();
+
+      expect(results[0].percyrc({
+        discovery: { disableCache: true }
+      })).toHaveProperty('discovery.disableCache', true);
+    });
+
     it('logs warnings for deprecated flags', async () => {
-      let captured = {};
-
       class TestPercyCommandDeprecated extends TestPercyCommand {
-        test = () => (captured = this.flags)
-
         static flags = {
           generic: flags.boolean({
             deprecated: true
@@ -188,7 +192,7 @@ describe('PercyCommand', () => {
         '[percy] Warning: The --deprecated flag will be removed in 1.0.0. Use --bar instead.'
       ]);
 
-      expect(captured).toEqual({
+      expect(results[0].flags).toEqual({
         generic: true,
         version: true,
         mapped: true,


### PR DESCRIPTION
## What is this?

The `initialOverrides` value of the shared CLI `#percyrc()` method does not work as intended. Flags always override the initial overrides, even when the flag is undefined, resulting in desired values being removed from the resulting config object.

This PR fixes the issue by aborting the override if the flag is null or undefined. I also borrowed the `set` util from `@percy/config` to set the overridden flag using a much more tested method. An existing test was also updated to remove unnecessary set up.