### PR TITLE
🐛 Fix `CSS_URL_REGEX` for serializing relative URLs in iframes

### DIFF
--- a/packages/dom/src/serialize-frames.js
+++ b/packages/dom/src/serialize-frames.js
@@ -10,7 +10,7 @@ const URI_SELECTOR = URI_ATTRS.map(a => `[${a}]`).join(',') + (
 const SRCSET_REGEX = /(\s*)([^,]\S*[^,])((?:\s+[^,]+)*\s*(?:,|$))/g;
 
 // A loose CSS url() regex split into capture groups
-const CSS_URL_REGEX = /(url\((["']?))((?:\\.|(?!\2).|[^)])+)(\2\))/g;
+const CSS_URL_REGEX = /(url\(['"]?)([^'")]*)(['"]?\))/g;
 
 // Transforms URL attributes within a document to be fully qualified URLs. This is necessary when
 // embedded documents are serialized and their contents become root-relative.


### PR DESCRIPTION
## What is this?

Turns out when serializing relative URLs in iframes, the regex we're using _could_ cause the browser to crash/hang. 
For example, the following inline styles from a google maps iframe:

```
position: absolute; z-index: 0; left: 0px; top: 0px; height: 100%; width: 100%; padding: 0px; border-width: 0px; margin: 0px; cursor: url("https://maps.gstatic.com/mapfiles/openhand_8_8.cur"), default; touch-action: pan-x pan-y;
```

Would crash the browser. When plugging this into a regex tester, we saw this error:

![image](https://user-images.githubusercontent.com/2072894/129947813-7bff9180-6b7f-4695-9d73-828a2a3b8d9d.png)
