### PR TITLE
✨ Accept additional snapshot execute options for various states 

### DIFF
--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -328,10 +328,15 @@ export default class Percy {
         // navigate to the url
         await page.goto(url);
 
+        // evaluate any necessary javascript
+        await page.evaluate(execute?.afterNavigation);
+
         // trigger resize events for other widths
         for (let width of widths) {
+          await page.evaluate(execute?.beforeResize);
           await discoveryIdle(); // ensure discovery idles before resizing
           await page.resize({ width, height: conf.minHeight });
+          await page.evaluate(execute?.afterResize);
         }
 
         // create and add a percy-css resource

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -592,7 +592,7 @@ describe('Discovery', () => {
             get() {
               let err = new Error('Timeout');
               if (!err.stack.includes('/network.js')) return;
-              if (Date.now() - (start ||= Date.now()) > 200) throw err;
+              if (Date.now() - (start ||= Date.now()) > 500) throw err;
             }
           });
 

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -499,6 +499,67 @@ describe('Snapshot', () => {
           '    at withPercyHelpers (<anonymous>:3:11)'
       ]));
     });
+
+    it('can execute multiple scripts', async () => {
+      let dot = () => (document.querySelector('p').innerHTML += '.');
+
+      await percy.snapshot({
+        name: 'test snapshot',
+        url: 'http://localhost:8000',
+        execute: [dot, dot, dot]
+      });
+
+      await percy.idle();
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Snapshot taken: test snapshot'
+      ]);
+
+      expect(Buffer.from((
+        mockAPI.requests['/builds/123/resources'][0]
+          .body.data.attributes['base64-content']
+      ), 'base64').toString()).toMatch('<p>Test...</p>');
+    });
+
+    it('can execute scripts at various states', async () => {
+      let domtest = (pre, fn) => `
+        let p = document.createElement('p');
+        p.innerHTML = ['${pre}', (${fn})()].join(' - ');
+        document.body.appendChild(p);
+      `;
+
+      await percy.snapshot({
+        name: 'test snapshot',
+        url: 'http://localhost:8000',
+        widths: [400, 800, 1200],
+        execute: {
+          afterNavigation: domtest('afterNavigation', () => window.location.href),
+          beforeResize: domtest('beforeResize', () => window.innerWidth),
+          afterResize: domtest('afterResize', () => window.innerWidth),
+          beforeSnapshot: domtest('beforeSnapshot', () => 'done!')
+        }
+      });
+
+      await percy.idle();
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual([
+        '[percy] Snapshot taken: test snapshot'
+      ]);
+
+      expect(Buffer.from((
+        mockAPI.requests['/builds/123/resources'][0]
+          .body.data.attributes['base64-content']
+      ), 'base64').toString()).toMatch([
+        '<p>afterNavigation - http://localhost:8000/</p>',
+        '<p>beforeResize - 400</p>',
+        '<p>afterResize - 800</p>',
+        '<p>beforeResize - 800</p>',
+        '<p>afterResize - 1200</p>',
+        '<p>beforeSnapshot - done!</p>'
+      ].join(''));
+    });
   });
 
   describe('with percy-css', () => {


### PR DESCRIPTION
## What is this?

This PR adds the ability to specify additional execute options to run scripts at specific states during the snapshot process. By default, the original `execute` function would only be evaluated right before a snapshot is taken. Now, there are additional options for `afterNavigation`, `beforeResize`, `afterResize`, and `beforeSnapshot`. If `execute` is provided as a function without these additional options, it is treated as a shorthand for `execute.beforeSnapshot`.

Thanks to @cancan101 for the idea! With these new options, it makes it easier for people to handle lazy-loaded images before the page gets resized. Closes #513 