### PR TITLE
🐛 Fix reference error when static config options are not defined

### DIFF
--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -109,7 +109,7 @@ export function migration(config, util) {
     util.deprecate('static.files', { map: 'static.include', ...notice });
     util.deprecate('static.ignore', { map: 'static.exclude', ...notice });
 
-    for (let i in (config.static.overrides || [])) {
+    for (let i in (config.static?.overrides || [])) {
       let k = `static.overrides[${i}]`;
       util.deprecate(`${k}.files`, { map: `${k}.include`, ...notice });
       util.deprecate(`${k}.ignore`, { map: `${k}.exclude`, ...notice });


### PR DESCRIPTION
## What is this?

This PR adds a safety check to the migrate function to avoid errors when there are no `static` config options (which usually happens when using any other command).

More evidence that a root-level integration test suite is needed. This error only happens with other commands but each command is tested in isolation (mostly).