### PR TITLE
✨ Accept sitemaps with the snapshot command!

### DIFF
--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -57,6 +57,22 @@ export const configSchema = {
         }
       }
     }
+  },
+
+  sitemap: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      include: {
+        $ref: '/snapshot/cli#/$refs/predicate'
+      },
+      exclude: {
+        $ref: '/snapshot/cli#/$refs/predicate'
+      },
+      overrides: {
+        $ref: '/config/static#/properties/overrides'
+      }
+    }
   }
 };
 

--- a/packages/cli-snapshot/src/utils.js
+++ b/packages/cli-snapshot/src/utils.js
@@ -119,9 +119,10 @@ export function mapStaticSnapshots(snapshots, {
   cleanUrls,
   rewrites = [],
   overrides = []
-}) {
+} = {}) {
   // reduce rewrites into a single function
   let applyRewrites = [{
+    test: url => !/^(https?:\/)?\//.test(url) && url,
     rewrite: url => path.posix.normalize(path.posix.join('/', url))
   }, ...rewrites.map(({ source, destination }) => ({
     test: pathToRegexp.match(destination),
@@ -130,8 +131,8 @@ export function mapStaticSnapshots(snapshots, {
     test: url => cleanUrls && url,
     rewrite: url => url.replace(/(\/index)?\.html$/, '')
   }].reduceRight((apply, { test, rewrite }) => snap => {
-    let res = !test || test(snap.url ?? snap);
-    if (res) snap = rewrite(test ? (res.params ?? res) : (snap.url ?? snap));
+    let res = test(snap.url ?? snap);
+    if (res) snap = rewrite(res.params ?? res);
     return apply(snap);
   }, s => s);
 

--- a/packages/cli-snapshot/test/sitemap.test.js
+++ b/packages/cli-snapshot/test/sitemap.test.js
@@ -1,0 +1,64 @@
+import mockAPI from '@percy/client/test/helpers';
+import logger from '@percy/logger/test/helpers';
+import { createTestServer } from '@percy/core/test/helpers';
+import { Snapshot } from '../src/commands/snapshot';
+
+describe('percy snapshot <sitemap>', () => {
+  let server;
+
+  beforeEach(async () => {
+    server = await createTestServer({
+      default: () => [200, 'text/html', '<p>Test</p>'],
+      '/sitemap.xml': () => [200, 'text/xml', [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+        '  <url>',
+        '    <loc>http://localhost:8000</loc>',
+        '  </url>',
+        '  <url>',
+        '    <loc>http://localhost:8000/</loc>',
+        '  </url>',
+        '  <url>',
+        '    <loc>http://localhost:8000/test-1</loc>',
+        '  </url>',
+        '  <url>',
+        '    <loc>http://localhost:8000/test-2</loc>',
+        '  </url>',
+        '</urlset>'
+      ].join('\n')]
+    });
+
+    process.env.PERCY_TOKEN = '<<PERCY_TOKEN>>';
+    mockAPI.start(50);
+    logger.mock();
+  });
+
+  afterEach(async () => {
+    delete process.env.PERCY_TOKEN;
+    process.removeAllListeners();
+    await server.close();
+  });
+
+  it('snapshots URLs listed by a sitemap', async () => {
+    await Snapshot.run(['http://localhost:8000/sitemap.xml', '--dry-run']);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      '[percy] Found 3 snapshots',
+      '[percy] Snapshot found: /',
+      '[percy] Snapshot found: /test-1',
+      '[percy] Snapshot found: /test-2'
+    ]);
+  });
+
+  it('throws an error when the sitemap is not an xml file', async () => {
+    await expectAsync(Snapshot.run(['http://localhost:8000/not-a-sitemap']))
+      .toBeRejectedWithError('EEXIT: 1');
+
+    expect(logger.stdout).toEqual([]);
+    expect(logger.stderr).toEqual([
+      '[percy] Error: The sitemap must be an XML document, ' +
+        'but the content-type was "text/html"'
+    ]);
+  });
+});


### PR DESCRIPTION
## What is this?

This makes it possible to use `percy snapshot <sitemap-url>` to take snapshots of all of the URLs listed by a sitemap.

The changes in the PR leverage the existing `mapStaticSnapshots` util, thus allowing `include`, `exclude`, and `overrides`. Technically, this util also allows a couple of other static options, however those options (such as rewrites and base-url) are not necessary as URLs within a sitemap are typically canonical URLs.

If a fetched sitemap is not an XML document, an error will be thrown. In the future, it's possible this can be relaxed a little since our regexp parser doesn't necessarily need valid XML to work (it simply matches URLs between XML `<loc>` tags).

I also discovered that some sitemaps list a URL twice, with and without a trailing forward slash (`/`). This prompted a filter to remove such duplicate URLs.

Not many tests were necessary for this since it leverages existing utils.