### PR TITLE
🐛 Fix sitemap unique URL filtering bug

### DIFF
--- a/packages/cli-snapshot/src/commands/snapshot.js
+++ b/packages/cli-snapshot/src/commands/snapshot.js
@@ -148,9 +148,14 @@ export class Snapshot extends Command {
           `but the content-type was "${contentType}"`));
       }
 
-      // parse and filter out duplicate URLs that differ by a trailing slash
+      // parse XML content into a list of URLs
       let urls = body.match(/(?<=<loc>)(.*)(?=<\/loc>)/ig);
-      return urls.filter((u, i, a) => i === a.indexOf(u.replace(/\/$/, '')));
+
+      // filter out duplicate URLs that differ by a trailing slash
+      return urls.filter((url, i) => {
+        let match = urls.indexOf(url.replace(/\/$/, ''));
+        return match === -1 || match === i;
+      });
     });
 
     // map with inherited static options

--- a/packages/cli-snapshot/test/sitemap.test.js
+++ b/packages/cli-snapshot/test/sitemap.test.js
@@ -19,10 +19,10 @@ describe('percy snapshot <sitemap>', () => {
         '    <loc>http://localhost:8000/</loc>',
         '  </url>',
         '  <url>',
-        '    <loc>http://localhost:8000/test-1</loc>',
+        '    <loc>http://localhost:8000/test-1/</loc>',
         '  </url>',
         '  <url>',
-        '    <loc>http://localhost:8000/test-2</loc>',
+        '    <loc>http://localhost:8000/test-2/</loc>',
         '  </url>',
         '</urlset>'
       ].join('\n')]
@@ -46,8 +46,8 @@ describe('percy snapshot <sitemap>', () => {
     expect(logger.stdout).toEqual([
       '[percy] Found 3 snapshots',
       '[percy] Snapshot found: /',
-      '[percy] Snapshot found: /test-1',
-      '[percy] Snapshot found: /test-2'
+      '[percy] Snapshot found: /test-1/',
+      '[percy] Snapshot found: /test-2/'
     ]);
   });
 


### PR DESCRIPTION
## What is this?

This fixes a bug in the sitemap URL filtering logic where if a URL ends in a forward slash and does not exist in the sitemap without one, it will be removed from the sitemap.