### PR TITLE
🐛 Set serialized iframe base URL for realtive URLs using `<base>`

### DIFF
--- a/packages/dom/src/serialize-frames.js
+++ b/packages/dom/src/serialize-frames.js
@@ -1,53 +1,14 @@
 import serializeDOM from './serialize-dom';
 
-// List of attributes that accept URIs that should be transformed
-const URI_ATTRS = ['href', 'src', 'srcset', 'poster', 'background'];
-const URI_SELECTOR = URI_ATTRS.map(a => `[${a}]`).join(',') + (
-  ',[style*="url("]'); // include elements with url style attributes
-
-// A loose srcset image candidate regex split into capture groups
-// https://html.spec.whatwg.org/multipage/images.html#srcset-attribute
-const SRCSET_REGEX = /(\s*)([^,]\S*[^,])((?:\s+[^,]+)*\s*(?:,|$))/g;
-
-// A loose CSS url() regex split into capture groups
-const CSS_URL_REGEX = /(url\((["']?))((?:\\.|(?!\2).|[^)])+)(\2\))/g;
-
-// Transforms URL attributes within a document to be fully qualified URLs. This is necessary when
+// Adds a `<base>` element to the serialized iframe's `<head>`. This is necessary when
 // embedded documents are serialized and their contents become root-relative.
-function transformRelativeUrls(dom) {
-  // transform style elements that might contain URLs
-  for (let style of dom.querySelectorAll('style')) {
-    style.innerHTML &&= style.innerHTML
-      .replace(CSS_URL_REGEX, (_, $1, $2, uri, $4) => (
-        `${$1}${new URL(uri, style.baseURI).href}${$4}`
-      ));
-  }
+function setBaseURL(dom) {
+  let baseURL = dom.querySelector('body').baseURI;
+  if (!new URL(baseURL).hostname) return;
 
-  // transform element attributes that might contain URLs
-  for (let el of dom.querySelectorAll(URI_SELECTOR)) {
-    for (let attr of URI_ATTRS.concat('style')) {
-      if (!(attr in el) || !el[attr] || !el.hasAttribute(attr)) continue;
-      let value = el[attr];
-
-      if (attr === 'style') {
-        // transform inline style url() usage
-        value = el.getAttribute('style')
-          .replace(CSS_URL_REGEX, (_, $1, $2, uri, $4) => (
-            `${$1}${new URL(uri, el.baseURI).href}${$4}`
-          ));
-      } else if (attr === 'srcset') {
-        // transform each srcset URL
-        value = value.replace(SRCSET_REGEX, (_, $1, uri, $3) => (
-          `${$1}${new URL(uri, el.baseURI).href}${$3}`
-        ));
-      } else {
-        // resolve the URL with the node's base URI
-        value = new URL(value, el.baseURI).href;
-      }
-
-      el.setAttribute(attr, value);
-    }
-  }
+  let $base = document.createElement('base');
+  $base.href = dom.querySelector('body').baseURI;
+  dom.querySelector('head').prepend($base);
 }
 
 // Recursively serializes iframe documents into srcdoc attributes.
@@ -72,7 +33,7 @@ export default function serializeFrames(dom, clone, { enableJavaScript }) {
 
       // recersively serialize contents
       let serialized = serializeDOM({
-        domTransformation: transformRelativeUrls,
+        domTransformation: setBaseURL,
         dom: frame.contentDocument,
         enableJavaScript
       });

--- a/packages/dom/test/serialize-frames.test.js
+++ b/packages/dom/test/serialize-frames.test.js
@@ -3,7 +3,7 @@ import { assert, withExample, parseDOM } from './helpers';
 import serializeDOM from '@percy/dom';
 
 describe('serializeFrames', () => {
-  let $;
+  let $, baseURI;
 
   const getFrame = id => when(() => {
     let $frame = document.getElementById(id);
@@ -14,6 +14,7 @@ describe('serializeFrames', () => {
   }, 5000);
 
   beforeEach(async function() {
+    baseURI = document.body.baseURI;
     withExample(`
       <iframe id="frame-external" src="https://example.com"></iframe>
       <iframe id="frame-external-fail" src="https://google.com"></iframe>
@@ -71,14 +72,14 @@ describe('serializeFrames', () => {
   it('serializes iframes created with JS', () => {
     expect($('#frame-js')[0].getAttribute('src')).toBeNull();
     expect($('#frame-js')[0].getAttribute('srcdoc')).toBe([
-      '<!DOCTYPE html><html><head></head><body>',
+      `<!DOCTYPE html><html><head><base href="${baseURI}"></head><body>`,
       '<p>made with js src</p>',
       '</body></html>'
     ].join(''));
 
     expect($('#frame-js-no-src')[0].getAttribute('src')).toBeNull();
     expect($('#frame-js-no-src')[0].getAttribute('srcdoc')).toBe([
-      '<!DOCTYPE html><html><head></head><body>',
+      `<!DOCTYPE html><html><head><base href="${baseURI}"></head><body>`,
       '<p>generated iframe</p>',
       '</body></html>'
     ].join(''));
@@ -90,21 +91,6 @@ describe('serializeFrames', () => {
       '<input data-percy-element-id=".+?" value="iframe with an input">',
       '</body></html>$'
     ].join('')));
-  });
-
-  it('serializes iframes internal URLs', () => {
-    let url = uri => new URL(uri, document.URL).href;
-
-    expect($('#frame-with-urls')[0].getAttribute('srcdoc')).toBe([
-      `<!DOCTYPE html><html><head></head><body background="${url('_/bg.png')}">`,
-      `<style>@font-face { src: url('${url('_/font.woff2')}') }</style>`,
-      `<h1 style="background-image:url(${url('_/head.png')})">Testing</h1>`,
-      `<link rel="stylesheet" href="${url('_/style.css')}">`,
-      `<img src="${url('_/img.gif')}" srcset="${url('/_/img.png')} 2x,`,
-      '  http://example.com/img.png 400w">',
-      `<video poster="${url('_/poster.png')}"></video>`
-      // account for indentation in the fixture
-    ].join(' '.repeat(12)) + '</body></html>');
   });
 
   it('does not serialize iframes with CORS', () => {


### PR DESCRIPTION
## What is this?

Discovered in #507, the regex that was used to parse and covert relative URLs was quite expensive. In that specific issue, it would hang the browser indefinitely. 

Instead of trying to use a regex to serialize the full URL into the document, we can skip all of that serialization work by [adding a `<base>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) to the iframes `<head>`. This will set the base URL for all relative paths within the iframe. 