### PR TITLE
🐛 Fix bug when providing execute without before snapshot

### DIFF
--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -260,7 +260,8 @@ export default class Page extends EventEmitter {
     }
 
     // execute any javascript
-    await this.evaluate(execute?.beforeSnapshot ?? execute);
+    await this.evaluate(typeof execute === 'function'
+      ? execute : execute?.beforeSnapshot);
 
     // wait for any final network activity before capturing the dom snapshot
     await this.network.idle();


### PR DESCRIPTION
## What is this?

Thanks to @cancan101 for testing out the new `execute` features from #514 and finding a bug. When `execute` is provided without a `beforeSnapshot` option, the entire `execute` object is passed on to the evaluate function, which creates an unserializable function as a result.

Rather than coalesce the `execute` option, we can typecheck if it is a function and fallback to `execute?.beforeSnapshot`.