### PR TITLE
🐛 Do not track or capture requests from service workers

### DIFF
--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -256,7 +256,8 @@ export default class Browser extends EventEmitter {
   _handleMessage(data) {
     data = JSON.parse(data);
 
-    if (data.method === 'Target.attachedToTarget') {
+    if (data.method === 'Target.attachedToTarget' &&
+        ['page', 'iframe'].includes(data.params.targetInfo.type)) {
       // create a new page reference when attached to a target
       this.pages.set(data.params.sessionId, new Page(this, data));
     } else if (data.method === 'Target.detachedFromTarget') {

--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -18,7 +18,6 @@ export default class Browser extends EventEmitter {
   #lastid = 0;
 
   defaultArgs = [
-    '--enable-features=NetworkService,NetworkServiceInProcess',
     '--disable-features=Translate',
     '--disable-background-networking',
     '--disable-background-timer-throttling',

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -40,10 +40,15 @@ export default class Network {
     this.onrequestfinished = createRequestFinishedHandler(options, this.page.meta);
     this.onrequestfailed = createRequestFailedHandler(options, this.page.meta);
 
-    await this.page.send('Fetch.enable', {
-      handleAuthRequests: true,
-      patterns: [{ urlPattern: '*' }]
-    });
+    await Promise.all([
+      this.page.send('Fetch.enable', {
+        handleAuthRequests: true,
+        patterns: [{ urlPattern: '*' }]
+      }),
+      this.page.send('Network.setBypassServiceWorker', {
+        bypass: true
+      })
+    ]);
   }
 
   // Resolves after the timeout when there are no more in-flight requests.


### PR DESCRIPTION
## What is this?

Our network interception techniques are designed for web pages, but not workers, who do not share the same devtools protocol namespaces. When auto-attaching targets, we do so indiscriminately for all targets. This causes page-network instances to be associated with workers which then causes asset discovery to hang since said instances are not designed for workers.

When creating page instances from auto-attached targets, we can first check against the target type to ensure it is a page target. This has the effect of causing requests from within service workers to never be tracked or captured. This is actually the desirable behavior since JavaScript is normally disabled by default in our infrastructure. If we decide to support capturing service worker requests in the future, we will likely need to approach it differently to how network requests within pages are currently handled.

I also added Network.setBypassServiceWorker which will bypass workers for network requests to avoid custom resource caching implementations since we have our own asset discovery caching.