### PR TITLE
♻️ Refactor page, network, and session handling

### DIFF
--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -1,124 +1,40 @@
 import { promises as fs } from 'fs';
-import EventEmitter from 'events';
 import logger from '@percy/logger';
 import Network from './network';
 import { hostname, waitFor } from './utils';
 
-// Used by some methods to impose a strict maximum timeout, such as .goto and .snapshot
-const PAGE_TIMEOUT = 30000;
+export default class Page {
+  static TIMEOUT = 30000;
 
-export default class Page extends EventEmitter {
-  #callbacks = new Map();
-
-  browser = null;
-  sessionId = null;
-  targetId = null;
-  frameId = null;
-  contextId = null;
-  closedReason = null;
-  frames = new Set();
   log = logger('core:page');
 
-  constructor(browser, { params, sessionId: parentId }) {
-    super();
+  constructor(session, options) {
+    this.session = session;
+    this.enableJavaScript = options.enableJavaScript ?? true;
+    this.network = new Network(this, options);
+    this.meta = options.meta;
 
-    this.browser = browser;
-    this.sessionId = params.sessionId;
-    this.targetId = params.targetInfo.targetId;
+    session.on('Runtime.executionContextCreated', this._handleExecutionContextCreated);
+    session.on('Runtime.executionContextDestroyed', this._handleExecutionContextDestroyed);
+    session.on('Runtime.executionContextsCleared', this._handleExecutionContextsCleared);
+    session.send('Runtime.enable').catch(session._handleClosedError);
 
-    this.network = new Network(this);
-
-    this.on('Runtime.executionContextCreated', this._handleExecutionContextCreated);
-    this.on('Runtime.executionContextDestroyed', this._handleExecutionContextDestroyed);
-    this.on('Runtime.executionContextsCleared', this._handleExecutionContextsCleared);
-    this.on('Inspector.targetCrashed', this._handleTargetCrashed);
-
-    // if there is a parent session, automatically init this session
-    this.parent = browser.pages.get(parentId);
-
-    if (this.parent) {
-      this.parent.frames.add(this);
-      this._handleCloseRace(this.init(this.parent.options));
-    }
+    this.log.debug('Page created');
   }
 
-  // initial page options asynchronously
-  async init(options = {}) {
-    this.options = options;
-
-    let {
-      cacheDisabled = true,
-      enableJavaScript = true,
-      requestHeaders = {},
-      networkIdleTimeout,
-      authorization,
-      userAgent,
-      intercept,
-      meta
-    } = options;
-
-    this.log.debug('Initialize page', meta);
-    this.network.timeout = networkIdleTimeout;
-    this.network.authorization = authorization;
-    this.meta = meta;
-
-    let [, { frameTree }, version] = await Promise.all([
-      this.send('Page.enable'),
-      this.send('Page.getFrameTree'),
-      this.send('Browser.getVersion')
-    ]);
-
-    this.frameId = frameTree.frame.id;
-    // by default, emulate a non-headless browser
-    userAgent ||= version.userAgent.replace('Headless', '');
-
-    // auto-attach related targets
-    let autoAttachTarget = {
-      waitForDebuggerOnStart: false,
-      autoAttach: true,
-      flatten: true
-    };
-
-    await Promise.all([
-      this.send('Runtime.enable'),
-      this.send('Target.setAutoAttach', autoAttachTarget),
-      this.send('Page.setLifecycleEventsEnabled', { enabled: true }),
-      this.send('Network.setCacheDisabled', { cacheDisabled }),
-      this.send('Network.setExtraHTTPHeaders', { headers: requestHeaders }),
-      this.send('Network.setUserAgentOverride', { userAgent }),
-      this.send('Security.setIgnoreCertificateErrors', { ignore: true }),
-      this.send('Emulation.setScriptExecutionDisabled', { value: !enableJavaScript })
-    ]);
-
-    if (intercept) {
-      await this.network.intercept(intercept);
-    }
-
-    return this;
-  }
-
-  // Close the target page if not already closed
+  // Close the page
   async close() {
-    if (!this.browser) return;
-
-    this.log.debug('Page closing', this.meta);
-
-    /* istanbul ignore next: errors race here when the browser closes */
-    await this.browser.send('Target.closeTarget', { targetId: this.targetId })
-      .catch(error => this.log.debug(error, this.meta));
+    await this.session.close();
+    this.log.debug('Page closed', this.meta);
   }
 
-  async resize({
-    deviceScaleFactor = 1,
-    mobile = false,
-    height,
-    width
-  }) {
+  // Resize the page to the specified width and height
+  async resize({ width, height }) {
     this.log.debug(`Resize page to ${width}x${height}`);
 
-    await this.send('Emulation.setDeviceMetricsOverride', {
-      deviceScaleFactor,
-      mobile,
+    await this.session.send('Emulation.setDeviceMetricsOverride', {
+      deviceScaleFactor: 1,
+      mobile: false,
       height,
       width
     });
@@ -130,12 +46,12 @@ export default class Page extends EventEmitter {
 
     let navigate = async () => {
       // set cookies before navigation so we can default the domain to this hostname
-      if (this.browser.cookies.length) {
+      if (this.session.browser.cookies.length) {
         let defaultDomain = hostname(url);
 
-        await this.send('Network.setCookies', {
+        await this.session.send('Network.setCookies', {
           // spread is used to make a shallow copy of the cookie
-          cookies: this.browser.cookies.map(({ ...cookie }) => {
+          cookies: this.session.browser.cookies.map(({ ...cookie }) => {
             if (!cookie.url) cookie.domain ||= defaultDomain;
             return cookie;
           })
@@ -143,27 +59,30 @@ export default class Page extends EventEmitter {
       }
 
       // handle navigation errors
-      let res = await this.send('Page.navigate', { url });
+      let res = await this.session.send('Page.navigate', { url });
       if (res.errorText) throw new Error(res.errorText);
     };
 
     let handlers = [
       // wait until navigation and the correct lifecycle
-      ['Page.frameNavigated', e => this.frameId === e.frame.id],
-      ['Page.lifecycleEvent', e => this.frameId === e.frameId && e.name === waitUntil]
+      ['Page.frameNavigated', e => this.session.targetId === e.frame.id],
+      ['Page.lifecycleEvent', e => this.session.targetId === e.frameId && e.name === waitUntil]
     ].map(([name, cond]) => {
       let handler = e => cond(e) && (handler.finished = true) && handler.off();
-      handler.off = () => this.off(name, handler);
-      this.on(name, handler);
+      handler.off = () => this.session.off(name, handler);
+      this.session.on(name, handler);
       return handler;
     });
 
     try {
       // trigger navigation and poll for handlers to have finished
       await Promise.all([navigate(), waitFor(() => {
-        if (this.closedReason) throw new Error(this.closedReason);
+        if (this.session.closedReason) {
+          throw new Error(this.session.closedReason);
+        }
+
         return handlers.every(handler => handler.finished);
-      }, PAGE_TIMEOUT)]);
+      }, Page.TIMEOUT)]);
     } catch (error) {
       // remove handlers and modify the error message
       for (let handler of handlers) handler.off();
@@ -201,14 +120,15 @@ export default class Page extends EventEmitter {
     ) + '}';
 
     // send the call function command
-    let { result, exceptionDetails } = await this.send('Runtime.callFunctionOn', {
-      functionDeclaration: fnbody,
-      arguments: args.map(value => ({ value })),
-      executionContextId: this.contextId,
-      returnByValue: true,
-      awaitPromise: true,
-      userGesture: true
-    });
+    let { result, exceptionDetails } =
+      await this.session.send('Runtime.callFunctionOn', {
+        functionDeclaration: fnbody,
+        arguments: args.map(value => ({ value })),
+        executionContextId: this.contextId,
+        returnByValue: true,
+        awaitPromise: true,
+        userGesture: true
+      });
 
     if (exceptionDetails) {
       throw exceptionDetails.exception.description;
@@ -256,7 +176,7 @@ export default class Page extends EventEmitter {
       await this.eval(function waitForSelector({ waitFor }, selector, timeout) {
         return waitFor(() => !!document.querySelector(selector), timeout)
           .catch(() => Promise.reject(new Error(`Failed to find "${selector}"`)));
-      }, waitForSelector, PAGE_TIMEOUT);
+      }, waitForSelector, Page.TIMEOUT);
     }
 
     // execute any javascript
@@ -286,72 +206,37 @@ export default class Page extends EventEmitter {
     }), options);
   }
 
-  async send(method, params) {
-    let error = new Error();
+  // Initialize newly attached pages and iframes with page options
+  _handleAttachedToTarget = event => {
+    let session = !event ? this.session
+      : this.session.children.get(event.sessionId);
+    /* istanbul ignore if: sanity check */
+    if (!session) return;
 
-    /* istanbul ignore next: race condition paranoia */
-    if (this.closedReason) {
-      return Promise.reject(Object.assign(error, {
-        message: `Protocol error (${method}): ${this.closedReason}`
-      }));
-    }
+    let commands = [this.network.watch(session)];
 
-    // send a raw message to the browser so we can provide a sessionId
-    let id = await this.browser.send({ sessionId: this.sessionId, method, params });
+    if (session.isDocument) {
+      session.on('Target.attachedToTarget', this._handleAttachedToTarget);
 
-    // return a promise that will resolve or reject when a response is received
-    return new Promise((resolve, reject) => {
-      this.#callbacks.set(id, { error, resolve, reject, method });
-    });
-  }
-
-  _handleMessage(data) {
-    if (data.id && this.#callbacks.has(data.id)) {
-      // resolve or reject a pending promise created with #send()
-      let callback = this.#callbacks.get(data.id);
-      this.#callbacks.delete(data.id);
-
-      /* istanbul ignore next: races with browser._handleMessage() */
-      if (data.error) {
-        callback.reject(Object.assign(callback.error, {
-          message: `Protocol error (${callback.method}): ${data.error.message}` +
-            ('data' in data.error ? `: ${data.error.data}` : '')
+      commands.push(
+        session.send('Page.enable'),
+        session.send('Page.setLifecycleEventsEnabled', { enabled: true }),
+        session.send('Security.setIgnoreCertificateErrors', { ignore: true }),
+        session.send('Emulation.setScriptExecutionDisabled', { value: !this.enableJavaScript }),
+        session.send('Target.setAutoAttach', {
+          waitForDebuggerOnStart: false,
+          autoAttach: true,
+          flatten: true
         }));
-      } else {
-        callback.resolve(data.result);
-      }
-    } else {
-      // emit the message as an event
-      this.emit(data.method, data.params);
-    }
-  }
-
-  _handleClose() {
-    this.closedReason ||= 'Page closed.';
-
-    // reject any pending callbacks
-    for (let callback of this.#callbacks.values()) {
-      callback.reject(Object.assign(callback.error, {
-        message: `Protocol error (${callback.method}): ${this.closedReason}`
-      }));
     }
 
-    this.#callbacks.clear();
-    this.parent?.frames.delete(this);
-    this.browser = null;
+    return Promise.all(commands)
+      .catch(session._handleClosedError);
   }
 
-  _handleCloseRace(promise) {
-    /* istanbul ignore next: race conditions, amirite? */
-    return promise.catch(error => {
-      if (!error.message.endsWith(this.closedReason)) {
-        this.log.debug(error, this.meta);
-      }
-    });
-  }
-
+  // Keep track of the page's execution context id
   _handleExecutionContextCreated = event => {
-    if (this.frameId === event.context.auxData.frameId) {
+    if (this.session.targetId === event.context.auxData.frameId) {
       this.contextId = event.context.id;
     }
   }
@@ -365,10 +250,5 @@ export default class Page extends EventEmitter {
 
   _handleExecutionContextsCleared = () => {
     this.contextId = null;
-  }
-
-  _handleTargetCrashed = () => {
-    this.closedReason = 'Page crashed!';
-    this.close();
   }
 }

--- a/packages/core/src/session.js
+++ b/packages/core/src/session.js
@@ -85,6 +85,7 @@ export default class Session extends EventEmitter {
     this.close();
   }
 
+  /* istanbul ignore next: encountered during closing races */
   _handleClosedError = error => {
     if (!error.message.endsWith(this.closedReason)) {
       this.log.debug(error, this.meta);

--- a/packages/core/src/session.js
+++ b/packages/core/src/session.js
@@ -1,0 +1,93 @@
+import EventEmitter from 'events';
+import logger from '@percy/logger';
+
+export default class Session extends EventEmitter {
+  #callbacks = new Map();
+
+  log = logger('core:session');
+  children = new Map();
+
+  constructor(browser, { params, sessionId: parentId }) {
+    super();
+
+    this.browser = browser;
+    this.sessionId = params.sessionId;
+    this.targetId = params.targetInfo.targetId;
+    this.type = params.targetInfo.type;
+    this.isDocument = this.type === 'page' || this.type === 'iframe';
+    this.parent = browser.sessions.get(parentId);
+    this.parent?.children.set(this.sessionId, this);
+
+    this.on('Inspector.targetCrashed', this._handleTargetCrashed);
+  }
+
+  async close() {
+    if (!this.browser) return;
+
+    await this.browser.send('Target.closeTarget', {
+      targetId: this.targetId
+    }).catch(this._handleClosedError);
+  }
+
+  async send(method, params) {
+    /* istanbul ignore next: race condition paranoia */
+    if (this.closedReason) {
+      throw new Error(`Protocol error (${method}): ${this.closedReason}`);
+    }
+
+    // send a raw message to the browser so we can provide a sessionId
+    let id = await this.browser.send({ sessionId: this.sessionId, method, params });
+
+    // will resolve or reject when a matching response is received
+    return new Promise((resolve, reject) => {
+      this.#callbacks.set(id, { error: new Error(), resolve, reject, method });
+    });
+  }
+
+  _handleMessage(data) {
+    if (data.id && this.#callbacks.has(data.id)) {
+      // resolve or reject a pending promise created with #send()
+      let callback = this.#callbacks.get(data.id);
+      this.#callbacks.delete(data.id);
+
+      /* istanbul ignore next: races with browser._handleMessage() */
+      if (data.error) {
+        callback.reject(Object.assign(callback.error, {
+          message: `Protocol error (${callback.method}): ${data.error.message}` +
+            ('data' in data.error ? `: ${data.error.data}` : '')
+        }));
+      } else {
+        callback.resolve(data.result);
+      }
+    } else {
+      // emit the message as an event
+      this.emit(data.method, data.params);
+    }
+  }
+
+  _handleClose() {
+    this.closedReason ||= 'Session closed.';
+
+    // reject any pending callbacks
+    for (let callback of this.#callbacks.values()) {
+      callback.reject(Object.assign(callback.error, {
+        message: `Protocol error (${callback.method}): ${this.closedReason}`
+      }));
+    }
+
+    this.#callbacks.clear();
+    this.parent?.children.delete(this.sessionId);
+    this.browser = null;
+  }
+
+  _handleTargetCrashed = () => {
+    this.closedReason = 'Session crashed!';
+    this.close();
+  }
+
+  _handleClosedError = error => {
+    if (!error.message.endsWith(this.closedReason)) {
+      this.log.debug(error, this.meta);
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

With #530, it was found that worker requests cause the network to hang. The approach in that PR was to ignore requests from workers. After new tests failed on Windows enough times, it was discovered that the test itself was a bit faulty. Once it was made deterministic via the worker updating DOM state, it consistently failed no matter the platform.

After a day of debugging, I discovered that workers inherit the `Fetch` domain of their parent session, but not the `Network` domain. Since both domains need to be enabled in order for request interception to work, requests within workers were being paused but never continued. In order to attempt to disable the inherited `Fetch` domain, we would have to alter how pages are initialized since workers do not have many of the domains that the page class references. Also, if we have to explicitly disable the `Fetch` domain, we could alternatively enable the `Network` domain properly. This alternative fix to the network hanging would also enable capturing requests sent by service workers.

## Approach

All browser targets (pages, frames, workers) are associated with a debugging session when auto-attached. However, the page class only works with page and frame targets due to certain domains used during set up. All page methods that work for any session were moved into a dedicated session class. How the browser handles auto-attached targets now creates session instances rather than page instances. Page instances are now an abstraction on top of specific session instances that also get a dedicated network instance. These single page and network instances are responsible for setting up domains and handlers for all related auto-attached sessions.

These changes resulted in the ability to capture requests from any auto-attached target, including workers and frames. Because of this, the `Page.frameDetached` network handler workaround was no longer needed since the network was now aware of all child session network events as soon as they are available. **However**, this resulted in a regression with capturing isolated frame's root resource. The request for isolated frames starts in the parent session, but once resolved, a new session is attached and all future events come from the new session. Because the parent session never receives a finished event it does not have access to the resource contents, but since the request does not originate from the frame session it complains that the resource's requestId does not exist.

I couldn't find any workaround this time to capture the frame's root resource. It seems like the previous workaround worked because the network events were enabled after fetching the frame resource contents. With these changes however, all events are enabled and attached as soon as possible. The only solution I could find, was to disable site-isolation with a flag, `--disable-site-isolation-trials`. This flag is intended for diagnosing issues with out-of-process iframes by disabling site-per-process isolations. Once disabled, our isolated frame tests passed without workarounds. I suspect this might also help with the flakiness this test sees in CI.

### Unrelated

While researching flags, I documented all of our existing flag args.

While refactoring how the browser handles sessions and pages, I also refactored how args are handled once I realized that `defaultArgs` was per-instance and not a static that needed to avoid being mutated. How browser closing is handled was also refactored once I realized that the CDP method of closing was never actually encountered.

While testing #530 on Windows locally, I found that the browser would frequently close unexpectedly while headed. Turns out, this is because when headed, closing the automatically opened blank page causes the whole browser to close (Windows only). This auto-closing was removed to make debugging on Windows easier.