### PR TITLE
🐛 Do not capture scripts or XHR requests when JS is not enabled

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -4,12 +4,12 @@ import { normalizeURL, hostnameMatches, createResource } from './utils';
 const MAX_RESOURCE_SIZE = 15 * (1024 ** 2); // 15MB
 const ALLOWED_STATUSES = [200, 201, 301, 302, 304, 307, 308];
 
-export function createRequestHandler({ disableCache, getResource }, m) {
+export function createRequestHandler(network, { disableCache, getResource }) {
   let log = logger('core:discovery');
 
   return async request => {
     let url = request.url;
-    let meta = { ...m, url };
+    let meta = { ...network.meta, url };
 
     try {
       log.debug(`Handling request: ${url}`, meta);
@@ -35,18 +35,18 @@ export function createRequestHandler({ disableCache, getResource }, m) {
   };
 }
 
-export function createRequestFinishedHandler({
+export function createRequestFinishedHandler(network, {
   allowedHostnames,
   disableCache,
   getResource,
   addResource
-}, m) {
+}) {
   let log = logger('core:discovery');
 
   return async request => {
     let origin = request.redirectChain[0] || request;
     let url = normalizeURL(origin.url);
-    let meta = { ...m, url };
+    let meta = { ...network.meta, url };
 
     try {
       let resource = getResource(url);
@@ -94,14 +94,14 @@ export function createRequestFinishedHandler({
   };
 }
 
-export function createRequestFailedHandler(options, meta) {
+export function createRequestFailedHandler(network) {
   let log = logger('core:discovery');
 
   return ({ url, error }) => {
     // do not log generic failures since the real error was most likely
     // already logged from elsewhere
     if (error !== 'net::ERR_FAILED') {
-      log.debug(`Request failed for ${url}: ${error}`, { ...meta, url });
+      log.debug(`Request failed for ${url}: ${error}`, { ...network.meta, url });
     }
   };
 }

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -3,6 +3,7 @@ import { normalizeURL, hostnameMatches, createResource } from './utils';
 
 const MAX_RESOURCE_SIZE = 15 * (1024 ** 2); // 15MB
 const ALLOWED_STATUSES = [200, 201, 301, 302, 304, 307, 308];
+const ALLOWED_RESOURCES = ['Document', 'Stylesheet', 'Image', 'Media', 'Font', 'Other'];
 
 export function createRequestHandler(network, { disableCache, getResource }) {
   let log = logger('core:discovery');
@@ -36,6 +37,7 @@ export function createRequestHandler(network, { disableCache, getResource }) {
 }
 
 export function createRequestFinishedHandler(network, {
+  enableJavaScript,
   allowedHostnames,
   disableCache,
   getResource,
@@ -70,6 +72,8 @@ export function createRequestFinishedHandler(network, {
           return log.debug('-> Skipping resource larger than 15MB', meta);
         } else if (!ALLOWED_STATUSES.includes(response.status)) {
           return log.debug(`-> Skipping disallowed status [${response.status}]`, meta);
+        } else if (!enableJavaScript && !ALLOWED_RESOURCES.includes(request.type)) {
+          return log.debug(`-> Skipping disallowed resource type [${request.type}]`, meta);
         }
 
         resource = createResource(url, body, response.mimeType, {

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -27,12 +27,12 @@ export default class Network {
       // by default, emulate a non-headless browser
       page.session.browser.version.userAgent.replace('Headless', '');
     this.interceptEnabled = !!options.intercept;
-    this.meta = page.meta;
+    this.meta = options.meta;
 
     if (this.interceptEnabled) {
-      this.onRequest = createRequestHandler(options.intercept, this.meta);
-      this.onRequestFinished = createRequestFinishedHandler(options.intercept, this.meta);
-      this.onRequestFailed = createRequestFailedHandler(options.intercept, this.meta);
+      this.onRequest = createRequestHandler(this, options.intercept);
+      this.onRequestFinished = createRequestFinishedHandler(this, options.intercept);
+      this.onRequestFailed = createRequestFailedHandler(this, options.intercept);
     }
   }
 

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -300,6 +300,7 @@ export default class Percy {
           // enable network inteception
           intercept: {
             disableCache: discovery.disableCache,
+            enableJavaScript: conf.enableJavaScript,
             allowedHostnames: discovery.allowedHostnames,
             getResource: url => url === root?.url ? root : (
               resources.get(url) || this.#cache.get(url)


### PR DESCRIPTION
## What is this?

Currently, when using the snapshot command (or any SDK that does not provide their own DOM snapshots), JavaScript is enabled for the local page context during capture to ensure the page is loaded properly, but it is still disabled by default when the snapshot is sent to Percy for screenshot stability.

Because it is enabled during asset discovery, we are capturing JavaScript assets and XHR requests that will never be used in Percy's infrastructure due to JS being disabled there. This PR adds tracking the paused request's resource type and a condition around that type during processing that will only allow specific resources to be captured when JS is disabled. When JS is enabled, all resources will be captured as before (provided none of the other non-capturing conditions are met).

While setting up the changes, the discovery handlers were altered slightly to be provided with the network instance rather than just the network meta info. This allows the discovery handlers to access network and page settings. However, because the page's default javascript setting is determined by the presence of an existing DOM snapshot, this value cannot be used in determining when to capture JS based assets. Instead, the `enableJavaScript` option is passed directly with other network intercept options.