### PR TITLE
🐛 Fix the eta shown when installing the browser

### DIFF
--- a/packages/core/src/install.js
+++ b/packages/core/src/install.js
@@ -17,8 +17,8 @@ function formatBytes(int) {
 
 // Formats milleseconds as "MM:SS"
 function formatTime(ms) {
-  let minutes = (ms / 1000 / 60).toFixed().padStart(2, '0');
-  let seconds = (ms / 1000).toFixed().padStart(2, '0');
+  let minutes = (ms / 1000 / 60).toString().split('.')[0].padStart(2, '0');
+  let seconds = (ms / 1000 % 60).toFixed().padStart(2, '0');
   return `${minutes}:${seconds}`;
 }
 
@@ -33,8 +33,7 @@ function formatProgress(prefix, total, start, progress) {
   let barContent = Array(Math.max(0, barLen + 1)).join('=') + (
     Array(Math.max(0, width - barLen + 1)).join(' '));
 
-  let elapsed = new Date() - start;
-  /* istanbul ignore next: eta in testing is always 0 */
+  let elapsed = Date.now() - start;
   let eta = (ratio >= 1) ? 0 : elapsed * (total / progress - 1);
 
   return (
@@ -137,7 +136,7 @@ async function install({
           let start, progress;
 
           response.on('data', chunk => {
-            start ??= new Date();
+            start ??= Date.now();
             progress = (progress ?? 0) + chunk.length;
             log.progress(formatProgress(premsg, total, start, progress));
           });

--- a/packages/core/test/unit/install.test.js
+++ b/packages/core/test/unit/install.test.js
@@ -17,6 +17,8 @@ describe('Unit / Install', () => {
   let dlnock, dlcallback, options;
 
   beforeEach(() => {
+    logger.mock();
+
     // emulate tty properties for testing
     Object.assign(logger.constructor.stdout, {
       isTTY: true,
@@ -78,12 +80,17 @@ describe('Unit / Install', () => {
   });
 
   it('logs progress during the archive download', async () => {
+    let now = Date.now();
+    // eta is calculated by the elapsed time and remaining progress
+    spyOn(Date, 'now').and.callFake(() => (now += 65002));
+    dlcallback.and.callFake(s => [200, s, { 'content-length': s.length * 5 }]);
+
     await install(options);
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
       '[percy] Downloading Archive v0...',
-      '[percy] Downloading Archive v0 [====================] 16B/16B 100% 00:00',
+      '[percy] Downloading Archive v0 [====                ] 16B/80B 20% 04:20',
       '[percy] Successfully downloaded Archive v0'
     ]);
   });


### PR DESCRIPTION
## What is this?

Two small logging-related bug fixes when the browser is installed:

1. The calculated seconds shown was for the entire eta estimate, including minutes. This meant that if the eta was 4 minutes, the eta shown would be `04:240`. 

    This was fixed by adding the modulus operator (`%`) to get the remaining seconds.

2. The calculated minutes shown was accidentally rounded when using `.toFixed()`. This is the expected behavior of this method, but not what we want when formatting minutes. 

    This was fixed by using `.toString().split('.')[0]` in its place, which does not round.

I modified an existing test to verify the formatting, which helped to remove a previously ignored line of coverage.