### PR TITLE
🐛 Fix bug when sessions may be detached before being fully attached

### DIFF
--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -276,7 +276,7 @@ export default class Browser extends EventEmitter {
     } else if (data.method === 'Target.detachedFromTarget') {
       // remove the old session reference when detached from a target
       let session = this.sessions.get(data.params.sessionId);
-      this.sessions.delete(session.sessionId);
+      this.sessions.delete(data.params.sessionId);
       session?._handleClose();
     }
 


### PR DESCRIPTION
## What is this?

It has been very rarely observed that this line of code causes an error when the session being detached does not have an associated session class. The line right below this code has a safeguard (`?.`) but this line did not. Rather than adding the safeguard, the provided session ID is used when removing sessions.

No test was written for this since it is unknown exactly how the situation arrises, but the error itself was an undefined error that this fix should take care of.