### PR TITLE
✨ Add ability to set percy config after core initialization

### DIFF
--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -108,6 +108,12 @@ export default function createPercyServer(percy) {
       build: percy.build
     }],
 
+    // remotely get and set percy config options
+    '/percy/config': ({ body }) => [200, 'application/json', {
+      config: body ? percy.setConfig(body) : percy.config,
+      success: true
+    }],
+
     // responds when idle
     '/percy/idle': () => percy.idle()
       .then(() => [200, 'application/json', { success: true }]),

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -136,6 +136,43 @@ describe('Percy', () => {
     });
   });
 
+  describe('#setConfig(config)', () => {
+    it('adds client and environment information', () => {
+      expect(percy.setConfig({
+        clientInfo: 'client/info',
+        environmentInfo: 'env/info'
+      })).toEqual(percy.config);
+
+      expect(percy.client.clientInfo).toContain('client/info');
+      expect(percy.client.environmentInfo).toContain('env/info');
+    });
+
+    it('merges existing and provided config options', () => {
+      expect(percy.setConfig({
+        snapshot: { widths: [1000] }
+      })).toEqual({
+        ...percy.config,
+        snapshot: {
+          ...percy.config.snapshot,
+          widths: [1000]
+        }
+      });
+    });
+
+    it('warns and ignores invalid config options', () => {
+      expect(percy.setConfig({
+        snapshot: { widths: 1000 },
+        foo: 'bar'
+      })).toEqual(percy.config);
+
+      expect(logger.stderr).toEqual([
+        '[percy] Invalid config:',
+        '[percy] - foo: unknown property',
+        '[percy] - snapshot.widths: must be an array, received a number'
+      ]);
+    });
+  });
+
   describe('#start()', () => {
     it('creates a new build', async () => {
       await expectAsync(percy.start()).toBeResolved();

--- a/packages/core/test/server.test.js
+++ b/packages/core/test/server.test.js
@@ -49,6 +49,40 @@ describe('Server', () => {
     });
   });
 
+  it('has a /config endpoint that returns loaded config options', async () => {
+    await percy.start();
+
+    let response = await fetch('http://localhost:1337/percy/config');
+    await expectAsync(response.json()).toBeResolvedTo({
+      success: true,
+      config: PercyConfig.getDefaults()
+    });
+  });
+
+  it('can set config options via the /config endpoint', async () => {
+    await percy.start();
+
+    let response = await fetch('http://localhost:1337/percy/config', {
+      method: 'POST',
+      body: JSON.stringify({
+        snapshot: { widths: [1000] }
+      })
+    });
+
+    await expectAsync(response.json()).toBeResolvedTo({
+      success: true,
+      config: PercyConfig.getDefaults({
+        snapshot: { widths: [1000] }
+      })
+    });
+
+    expect(percy.config).toEqual(
+      PercyConfig.getDefaults({
+        snapshot: { widths: [1000] }
+      })
+    );
+  });
+
   it('has an /idle endpoint that calls #idle()', async () => {
     spyOn(percy, 'idle').and.resolveTo();
     await percy.start();


### PR DESCRIPTION
## What is this?

Currently, you can only set config options during core initialization. This makes sense for some config used during start up relating to build creation or the asset discovery browser. However other config options can still be set after start up, such as global snapshot options, certain discovery options, and config options registered by other plugins.

This PR adds a `setConfig` method which enables merging provided config options with the loaded config options. A local API endpoint is also added which calls `setConfig` for post requests but otherwise will return the current config object. The `setConfig` method will also normalize and validate config options.