### PR TITLE
🐛 Fix client and env info normalization

### DIFF
--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -20,8 +20,8 @@ export function getSnapshotConfig(percy, options) {
   let log = logger('core:snapshot');
 
   // migrate deprecated snapshot config options
-  let { clientInfo, environmentInfo, ...opts } = options;
-  let snapshot = PercyConfig.migrate(opts, '/snapshot');
+  let { clientInfo, environmentInfo, ...snapshot } = (
+    PercyConfig.migrate(options, '/snapshot'));
 
   // throw an error when missing required widths
   if (!(snapshot.widths ?? percy.config.snapshot.widths)?.length) {

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -209,13 +209,13 @@ describe('Snapshot', () => {
     await percy.snapshot({
       name: 'test snapshot',
       url: 'http://localhost:8000',
-      clientInfo: 'test client info',
-      environmentInfo: 'test env info',
+      client_info: 'test client info',
+      environment_info: 'test env info',
       widths: [400, 1200],
       discovery: {
-        allowedHostnames: ['example.com'],
-        requestHeaders: { 'X-Foo': 'Bar' },
-        disableCache: true
+        'allowed-hostnames': ['example.com'],
+        'request-headers': { 'X-Foo': 'Bar' },
+        'disable-cache': true
       },
       additionalSnapshots: [
         { prefix: 'foo ', waitForTimeout: 100 },


### PR DESCRIPTION
## What is this?

SDKs send client and environment information for debugging purposes. Since our SDKs span across languages and frameworks, config and snapshot options are accepted in many formats (camelCase, kebab-case, or snake_case). With recent changes however, client and environment information were extracted from snapshot options before normalization can occur. This results in snapshot validation claiming invalid options and pruning them, which then also results in a warning about missing client/env info (see linked issue). This PR amends the offending lines and extracts client/env info after normalization.

Fixes #581