### PR TITLE
🐛 Ensure `networkIdleTimeout` is correctly passed and set

### DIFF
--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -47,6 +47,7 @@ export function getSnapshotConfig(percy, options) {
     // only specific discovery options are used per-snapshot
     discovery: {
       allowedHostnames: [uri.hostname, ...config.discovery.allowedHostnames],
+      networkIdleTimeout: config.discovery.networkIdleTimeout,
       requestHeaders: config.discovery.requestHeaders,
       authorization: config.discovery.authorization,
       disableCache: config.discovery.disableCache,


### PR DESCRIPTION
## What is this?

It appears `networkIdleTimeout` is currently not being set from config or the CLI. This PR ensures the network idle timeout gets correctly set. 

Will fix #643. 