### PR TITLE
✨Cancelable @percy/core methods

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@ rules:
   prefer-const: off
   no-unused-expressions: off
   babel/no-unused-expressions: warn
+  node/no-callback-literal: off
   promise/param-names: off
   semi: [error, always]
   multiline-ternary: off

--- a/packages/cli-exec/src/commands/exec/start.js
+++ b/packages/cli-exec/src/commands/exec/start.js
@@ -32,7 +32,10 @@ export class Start extends Command {
     });
 
     // only stop when terminated
-    let stop = () => percy.stop(true);
+    let stop = async () => {
+      await percy.stop(true);
+    };
+
     process.on('SIGHUP', stop);
     process.on('SIGINT', stop);
     process.on('SIGTERM', stop);

--- a/packages/cli-exec/test/start.test.js
+++ b/packages/cli-exec/test/start.test.js
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+import request from '@percy/client/dist/request';
 import { logger } from './helpers';
 import { Start } from '../src/commands/exec/start';
 import { Stop } from '../src/commands/exec/stop';
@@ -13,21 +13,20 @@ describe('percy exec:start', () => {
   });
 
   it('starts a long-running percy process', async () => {
-    let response = await fetch('http://localhost:5338/percy/healthcheck');
-    await expectAsync(response.json()).toBeResolvedTo(
-      jasmine.objectContaining({ success: true }));
+    let response = await request('http://localhost:5338/percy/healthcheck');
+    expect(response).toHaveProperty('success', true);
   });
 
   it('stops the process when terminated', async () => {
     await expectAsync(
-      fetch('http://localhost:5338/percy/healthcheck')
+      request('http://localhost:5338/percy/healthcheck')
     ).toBeResolved();
 
     process.emit('SIGTERM');
 
     // check a few times rather than wait on a timeout to be deterministic
     await expectAsync(function check(i = 0) {
-      return fetch('http://localhost:5338/percy/healthcheck', { timeout: 10 })
+      return request('http://localhost:5338/percy/healthcheck', { timeout: 10 })
         .then(r => i >= 10 ? r : new Promise((res, rej) => {
           setTimeout(() => check(i++).then(res, rej), 100);
         }));

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -11,6 +11,10 @@ import {
   discoverSnapshotResources
 } from './snapshot';
 
+import {
+  generatePromise
+} from './utils';
+
 // A Percy instance will create a new build when started, handle snapshot
 // creation, asset discovery, and resource uploads, and will finalize the build
 // when stopped. Snapshots are processed concurrently and the build is not
@@ -130,16 +134,10 @@ export default class Percy {
   }
 
   // Resolves once snapshot and upload queues are idle
-  async idle() {
-    await this.#snapshots.idle();
-    await this.#uploads.idle();
-  }
-
-  // Waits for snapshot idle and flushes the upload queue
-  async dispatch() {
-    await this.#snapshots.idle();
-    if (!this.skipUploads) await this.#uploads.flush();
-  }
+  idle = () => generatePromise(async function*() {
+    yield* this.#snapshots.idle();
+    yield* this.#uploads.idle();
+  }.bind(this))
 
   // Immediately stops all queues, preventing any more tasks from running
   close() {
@@ -149,7 +147,7 @@ export default class Percy {
 
   // Starts a local API server, a browser process, and queues creating a new Percy build which will run
   // at a later time when uploads are deferred, or run immediately when not deferred.
-  async start() {
+  start = options => generatePromise(async function*() {
     // already starting or started
     if (this.readyState != null) return;
     this.readyState = 0;
@@ -180,19 +178,31 @@ export default class Percy {
     try {
       // when not deferred, wait until the build is created first
       if (!this.deferUploads) await buildTask;
-      // launch the discovery browser
-      if (!this.dryRun) await this.browser.launch();
-      // if there is a server, start listening
-      await this.server?.listen(this.port);
 
-      // mark this process as running
+      // maybe launch the discovery browser
+      if (!this.dryRun && options?.browser !== false) {
+        yield this.browser.launch();
+      }
+
+      // start the server after everything else is ready
+      yield this.server?.listen(this.port);
+
+      // mark instance as started
       this.log.info('Percy has started!');
       this.readyState = 1;
     } catch (error) {
       // on error, close any running server and browser
       await this.server?.close();
       await this.browser.close();
+
+      // mark instance as closed
       this.readyState = 3;
+
+      // when uploads are deferred, cancel build creation
+      if (error.canceled && this.deferUploads) {
+        this.#uploads.cancel('build/create');
+        this.readyState = null;
+      }
 
       // throw an easier-to-understand error when the port is taken
       if (error.code === 'EADDRINUSE') {
@@ -201,11 +211,45 @@ export default class Percy {
         throw error;
       }
     }
-  }
+  }.bind(this))
+
+  // Wait for currently queued snapshots then run and wait for resulting uploads
+  flush = close => generatePromise(async function*() {
+    // close the snapshot queue and wait for it to empty
+    if (this.#snapshots.size) {
+      if (close) this.#snapshots.close();
+
+      yield* this.#snapshots.flush(s => {
+        // do not log a count when not closing or while dry-running
+        if (!close || this.dryRun) return;
+        this.log.progress(`Processing ${s} snapshot${s !== 1 ? 's' : ''}...`, !!s);
+      });
+    }
+
+    // run, close, and wait for the upload queue to empty
+    if (!this.skipUploads && this.#uploads.size) {
+      if (close) this.#uploads.close();
+
+      yield* this.#uploads.flush(s => {
+        // do not log a count when not closing or while creating a build
+        if (!close || this.#uploads.has('build/create')) return;
+        this.log.progress(`Uploading ${s} snapshot${s !== 1 ? 's' : ''}...`, !!s);
+      });
+    }
+  }.bind(this)).canceled(() => {
+    // reopen closed queues when canceled
+    this.#snapshots.open();
+    this.#uploads.open();
+  })
 
   // Stops the local API server and browser once snapshots have completed and finalizes the Percy
   // build. Does nothing if not running. When `force` is true, any queued tasks are cleared.
-  async stop(force) {
+  stop = force => generatePromise(async function*() {
+    // not started, but the browser was launched
+    if (!this.readyState && this.browser.isConnected()) {
+      await this.browser.close();
+    }
+
     // not started or already stopped
     if (!this.readyState || this.readyState > 2) return;
 
@@ -217,32 +261,23 @@ export default class Percy {
     this.readyState = 2;
 
     // log when force stopping
-    let meta = { build: this.build };
-    if (force) this.log.info('Stopping percy...', meta);
+    if (force) this.log.info('Stopping percy...');
 
-    // close the snapshot queue and wait for it to empty
-    if (this.#snapshots.close().size) {
-      await this.#snapshots.empty(s => !this.dryRun && (
-        this.log.progress(`Processing ${s} snapshot${s !== 1 ? 's' : ''}...`, !!s)
-      ));
-    }
+    // process uploads and close queues
+    yield* this.flush(true);
 
-    // run, close, and wait for the upload queue to empty
-    if (!this.skipUploads && this.#uploads.run().close().size) {
-      await this.#uploads.empty(s => {
-        this.log.progress(`Uploading ${s} snapshot${s !== 1 ? 's' : ''}...`, !!s);
-      });
-    }
-
-    // if dry-running, print the total number of snapshots that would be uploaded
+    // if dry-running, log the total number of snapshots
     if (this.dryRun && this.#uploads.size) {
       let total = this.#uploads.size - 1; // subtract the build task
       this.log.info(`Found ${total} snapshot${total !== 1 ? 's' : ''}`);
     }
 
-    // close the any running server and browser
+    // close any running server and browser
     await this.server?.close();
     await this.browser.close();
+
+    // finalize and log build info
+    let meta = { build: this.build };
 
     if (this.build?.failed) {
       // do not finalize failed builds
@@ -256,8 +291,12 @@ export default class Percy {
       this.log.warn('Build not created', meta);
     }
 
+    // mark instance as stopped
     this.readyState = 3;
-  }
+  }.bind(this)).canceled(() => {
+    // reset ready state when canceled
+    this.readyState = 1;
+  })
 
   // Deprecated capture method
   capture(options) {
@@ -296,7 +335,7 @@ export default class Percy {
           this._scheduleUpload(snap.name, { ...snap, resources });
         });
       } catch (error) {
-        if (error.message === 'Canceled') {
+        if (error.canceled) {
           this.log.error('Received a duplicate snapshot name, ' + (
             `the previous snapshot was canceled: ${snapshot.name}`));
         } else {

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -56,15 +56,18 @@ export default class Percy {
     this.dryRun = !!dryRun;
     this.skipUploads = this.dryRun || !!skipUploads;
     this.deferUploads = this.skipUploads || !!deferUploads;
+    if (this.deferUploads) this.#uploads.stop();
 
     this.config = PercyConfig.load({
       overrides: options,
       path: config
     });
 
-    let { concurrency } = this.config.discovery;
-    if (concurrency) this.#snapshots.concurrency = concurrency;
-    if (this.deferUploads) this.#uploads.stop();
+    if (this.config.discovery.concurrency) {
+      let { concurrency } = this.config.discovery;
+      this.#uploads.concurrency = concurrency;
+      this.#snapshots.concurrency = concurrency;
+    }
 
     this.client = new PercyClient({
       token,
@@ -115,6 +118,13 @@ export default class Percy {
       // replace arrays instead of merging
       return Array.isArray(next) && [path, next];
     });
+
+    // adjust concurrency if necessary
+    if (this.config.discovery.concurrency) {
+      let { concurrency } = this.config.discovery;
+      this.#uploads.concurrency = concurrency;
+      this.#snapshots.concurrency = concurrency;
+    }
 
     return this.config;
   }

--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -141,9 +141,10 @@ export default function createPercyServer(percy) {
     },
 
     // stops the instance async at the end of the event loop
-    '/percy/stop': () => setImmediate(() => percy.stop()) && (
-      [200, 'application/json', { success: true }]
-    ),
+    '/percy/stop': () => {
+      setImmediate(async () => await percy.stop());
+      return [200, 'application/json', { success: true }];
+    },
 
     // other routes 404
     default: () => [404, 'application/json', {

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -609,8 +609,8 @@ describe('Snapshot', () => {
       expect(logger.stderr).toEqual(jasmine.arrayContaining([
         '[percy] Encountered an error taking snapshot: test snapshot',
         '[percy] Error: test error\n' +
-          '    at execute (<anonymous>:2:17)\n' +
-          '    at withPercyHelpers (<anonymous>:3:11)'
+          '    at execute (<anonymous>:3:17)\n' +
+          '    at withPercyHelpers (<anonymous>:4:11)'
       ]));
     });
 

--- a/packages/core/test/unit/queue.test.js
+++ b/packages/core/test/unit/queue.test.js
@@ -85,7 +85,7 @@ describe('Unit / Tasks Queue', () => {
   });
 
   describe('#idle()', () => {
-    it('resolves when all tasks settle', async () => {
+    it('resolves when running tasks settle', async () => {
       let tasks = Array(5).fill().map(() => task(100));
       tasks.forEach((t, i) => q.push(i, t));
 
@@ -94,8 +94,46 @@ describe('Unit / Tasks Queue', () => {
         throw new Error('technically settled');
       })).catch(() => {}); // we're catching the promise, not the task
 
+      q.push('stop', () => q.stop());
+      let more = Array(3).fill().map(() => task(50));
+      more.forEach((t, i) => q.push(`more/${i}`, t));
+
       await expectAsync(q.idle()).toBeResolved();
       tasks.forEach(t => expect(t).toHaveProperty('running', false));
+      more.forEach(t => expect(t).not.toHaveProperty('running'));
+
+      await expectAsync(q.run().idle()).toBeResolved();
+      more.forEach(t => expect(t).toHaveProperty('running', false));
+    });
+  });
+
+  describe('#empty()', () => {
+    it('resolves when all tasks are settled', async () => {
+      let tasks = Array(5).fill().map(() => task(50));
+      tasks.forEach((t, i) => q.push(i, t));
+
+      q.push('stop', () => q.stop());
+      let more = Array(3).fill().map(() => task(50));
+      more.forEach((t, i) => q.push(`more/${i}`, t));
+
+      let empty = q.empty();
+
+      await expectAsync(empty).toBePending();
+      await expectAsync(q.idle()).toBeResolved();
+      await expectAsync(empty).toBePending();
+
+      tasks.forEach(t => expect(t).toHaveProperty('running', false));
+      more.forEach(t => expect(t).not.toHaveProperty('running'));
+      expect(q.running).toBe(false);
+
+      q.run();
+
+      expect(q.running).toBe(true);
+      await expectAsync(empty).toBePending();
+      await expectAsync(q.idle()).toBeResolved();
+      await expectAsync(empty).toBeResolved();
+
+      more.forEach(t => expect(t).toHaveProperty('running', false));
     });
   });
 
@@ -114,21 +152,75 @@ describe('Unit / Tasks Queue', () => {
 
       expect(task.step).toBe('bar');
       await expectAsync(q.idle()).toBeResolved();
-      await expectAsync(p).toBeRejectedWithError('Canceled');
+      await expectAsync(p).toBeRejected();
     });
   });
 
   describe('#clear()', () => {
     it('removes tasks from the queue', async () => {
-      let tasks = Array(10).fill().map((_, i) => q.push(i, task(100)));
+      let tasks = Array(10).fill().map(() => task(100));
+      let promises = tasks.map((t, i) => q.push(i, t));
       q.clear();
 
       // the first set of tasks is already running, the queue length will return
       // 2 unless we wait for them to settle
-      await tasks[1];
+      await promises[1];
 
       expect(q.size).toBe(0);
       expect(tasks[2]).not.toHaveProperty('running');
+    });
+  });
+
+  describe('#flush()', () => {
+    it('resolves when the queue idles', async () => {
+      let tasks = Array(5).fill().map(() => task(50));
+      tasks.forEach((t, i) => q.push(i, t));
+
+      await expectAsync(q.flush()).toBeResolved();
+      tasks.forEach(t => expect(t).toHaveProperty('running', false));
+    });
+
+    it('automatically runs and stops the queue', async () => {
+      q.stop();
+
+      let tasks = Array(5).fill().map(() => task(50));
+      tasks.forEach((t, i) => q.push(i, t));
+      q.push('stop', () => q.stop());
+
+      let more = Array(5).fill().map(() => task(50));
+      more.forEach((t, i) => q.push(`more/${i}`, t));
+
+      expect(q.running).toBe(false);
+      await expectAsync(q.flush()).toBeResolved();
+      tasks.forEach(t => expect(t).toHaveProperty('running', false));
+      more.forEach(t => expect(t).not.toHaveProperty('running'));
+
+      expect(q.running).toBe(false);
+      await expectAsync(q.flush()).toBeResolved();
+      tasks.forEach(t => expect(t).toHaveProperty('running', false));
+    });
+
+    it('stops the running queue when canceled', async () => {
+      q.stop();
+
+      let tasks = Array(5).fill().map(() => task(50));
+      tasks.forEach((t, i) => q.push(i, t));
+
+      expect(q.running).toBe(false);
+
+      let flushing = q.flush();
+      let flushed = flushing.then();
+
+      expect(tasks[0]).toHaveProperty('running', true);
+      expect(q.running).toBe(true);
+      flushing.cancel();
+
+      await expectAsync(flushed).toBeRejected();
+      await q.idle();
+
+      expect(tasks[0]).toHaveProperty('running', false);
+      expect(tasks[2]).not.toHaveProperty('running');
+      expect(q.running).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## What is this?

Currently, tasks within the internal queue, including snapshots, are cancelable. This is done by utilizing generators as tasks. This PR takes that concept and uses it to make other core methods cancelable as well. Having these methods be cancelable will allow better handling of process termination in the CLI rather than relying on promises to completely settle.

While implementing this, I discovered that I had many hanging Chromium processes after several tests. This prompted me to tighten up some browser internals to alleviate it. Also while implementing this, the upload queue's concurrency was fixed to mirror the snapshot queue, and the `setConfig` method was updated to allow configuring the discovery concurrency after percy has already started.

To make certain core methods cancelable, the queue's cancelable generators were refactored into a common util and used to reimplement the `waitFor` helper. Since this helper is provided to the browser during `execute`, the new `generatePromise` helper must also be provided. This helper wraps an async generator function to become thennable and cancelable. This helper was then used in core methods such as `start`, `stop`, and others to allow them to be cancelable.

While making the `stop` method cancelable, part of it was refactored into a new `flush` method. In the future, this new method could also be used to flush snapshots from the queue when retries are enabled.

One caveat of the cancelable promise-like generator object is some implicit callback promise handling does not work as expected. In these situations, the returned object is awaited on directly to trigger running the underlying generator.