### PR TITLE
🐛 Fix additional snapshots executing string functions

### DIFF
--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -182,8 +182,9 @@ export default class Page {
     }
 
     // execute any javascript
-    await this.evaluate(typeof execute === 'function'
-      ? execute : execute?.beforeSnapshot);
+    await this.evaluate(
+      typeof execute === 'object' && !Array.isArray(execute)
+        ? execute.beforeSnapshot : execute);
 
     // wait for any final network activity before capturing the dom snapshot
     await this.network.idle();

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -228,16 +228,16 @@ export async function* discoverSnapshotResources(percy, snapshot, callback) {
       yield waitForDiscoveryNetworkIdle(page, snapshot.discovery);
       handleSnapshotResources(snapshot, resources, callback);
     } else {
+      let { enableJavaScript } = snapshot;
+
       // capture snapshots sequentially
       for (let snap of allSnapshots) {
-        // shallow merge snapshot options
-        let options = { ...snapshot, ...snap };
         // will wait for timeouts, selectors, and additional network activity
-        let { url, dom } = yield page.snapshot(options);
-
-        // handle resources and remove previously captured dom snapshots
+        let { url, dom } = yield page.snapshot({ enableJavaScript, ...snap });
         resources.set(url, createRootResource(url, dom));
-        handleSnapshotResources(options, resources, callback);
+        // shallow merge with root snapshot options
+        handleSnapshotResources({ ...snapshot, ...snap }, resources, callback);
+        // remove the previously captured dom snapshot
         resources.delete(url);
       }
     }

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -494,7 +494,7 @@ describe('Snapshot', () => {
         execute: () => document.querySelector('p').classList.add('eval-1'),
         additionalSnapshots: [
           { suffix: ' 2', execute: () => document.querySelector('p').classList.add('eval-2') },
-          { suffix: ' 3', execute: () => document.querySelector('p').classList.add('eval-3') },
+          { suffix: ' 3', execute: "document.querySelector('p').classList.add('eval-3')" },
           { suffix: ' 4' }
         ]
       });


### PR DESCRIPTION
## What is this?

Fixes #600 (`additionalSnapshots.execute` not working with a string value). The config schema for additional snapshots specifically allows strings, functions, or arrays of strings and/or functions. This PR inverts the previous check to only use `execute.beforeSnapshot` if the `execute` option is an object but not an array.

This also fixes an issue where `execute` could be incorrectly inherited by additional snapshots and run multiple times.