### PR TITLE
🔊 Small logging improvements

### DIFF
--- a/packages/logger/src/logger.js
+++ b/packages/logger/src/logger.js
@@ -41,8 +41,8 @@ export default class PercyLogger {
 
   // Change log level at any time or return the current log level
   loglevel(level) {
-    if (!level) return this.level;
-    this.level = level;
+    if (level) this.level = level;
+    return this.level;
   }
 
   // Change namespaces by generating an array of namespace regular expressions from a

--- a/packages/logger/src/logger.js
+++ b/packages/logger/src/logger.js
@@ -78,9 +78,13 @@ export default class PercyLogger {
       .reduce((group, level) => Object.assign(group, {
         [level]: this.log.bind(this, name, level)
       }), {
-        progress: this.progress.bind(this, name),
         deprecated: this.deprecated.bind(this, name),
-        shouldLog: this.shouldLog.bind(this, name)
+        shouldLog: this.shouldLog.bind(this, name),
+        progress: this.progress.bind(this, name),
+        format: this.format.bind(this, name),
+        loglevel: this.loglevel.bind(this),
+        stdout: this.constructor.stdout,
+        stderr: this.constructor.stderr
       });
   }
 
@@ -90,9 +94,17 @@ export default class PercyLogger {
   }
 
   // Formats messages before they are logged to stdio
-  format(message, debug, level, elapsed) {
+  format(debug, level, message, elapsed) {
     let label = 'percy';
     let suffix = '';
+
+    if (arguments.length === 1) {
+      // format(message)
+      [debug, message] = [null, debug];
+    } else if (arguments.length === 2) {
+      // format(debug, message)
+      [level, message] = [null, level];
+    }
 
     if (this.level === 'debug') {
       // include debug info in the label
@@ -126,7 +138,7 @@ export default class PercyLogger {
     let { stdout } = this.constructor;
 
     if (stdout.isTTY || !this._progress) {
-      message &&= this.format(message, debug);
+      message &&= this.format(debug, message);
       if (stdout.isTTY) stdout.cursorTo(0);
       else message &&= message + '\n';
       if (message) stdout.write(message);
@@ -190,7 +202,7 @@ export default class PercyLogger {
     if (this.shouldLog(debug, level)) {
       let elapsed = timestamp - (this.lastlog || timestamp);
       if (isError && this.level !== 'debug') message = error.toString();
-      this.write(level, this.format(message, debug, error ? 'error' : level, elapsed));
+      this.write(level, this.format(debug, error ? 'error' : level, message, elapsed));
       this.lastlog = timestamp;
     }
   }

--- a/packages/logger/src/util.js
+++ b/packages/logger/src/util.js
@@ -8,10 +8,11 @@ export const ANSI_REG = new RegExp((
 
 // color names by ansi escape code
 export const ANSI_COLORS = {
-  '31m': 'red',
-  '33m': 'yellow',
+  '91m': 'red',
+  '32m': 'green',
+  '93m': 'yellow',
   '34m': 'blue',
-  '35m': 'magenta',
+  '95m': 'magenta',
   '90m': 'grey'
 };
 

--- a/packages/logger/test/helpers.js
+++ b/packages/logger/test/helpers.js
@@ -109,10 +109,10 @@ const helpers = {
 
     logger.loglevel('debug');
 
-    write(logger.format('--- DUMPING LOGS ---', 'testing', 'warn'));
+    write(logger.format('testing', 'warn', '--- DUMPING LOGS ---'));
 
     logs.reduce((lastlog, { debug, level, message, timestamp }) => {
-      write(logger.format(message, debug, level, timestamp - lastlog));
+      write(logger.format(debug, level, message, timestamp - lastlog));
       return timestamp;
     }, logs[0].timestamp);
   }

--- a/packages/logger/test/logger.test.js
+++ b/packages/logger/test/logger.test.js
@@ -25,6 +25,7 @@ describe('logger', () => {
   });
 
   it('has a default log level', () => {
+    expect(log.loglevel()).toEqual('info');
     expect(logger.loglevel()).toEqual('info');
   });
 
@@ -132,29 +133,36 @@ describe('logger', () => {
   });
 
   it('exposes a message formatting method', () => {
-    expect(logger.format('information')).toEqual(
-      `[${colors.magenta('percy')}] information`
-    );
+    expect(log.format('grouped')).toEqual(
+      `[${colors.magenta('percy')}] grouped`);
+    expect(log.format('warn', 'level')).toEqual(
+      `[${colors.magenta('percy')}] ${colors.yellow('level')}`);
+    expect(log.format('error', 'level')).toEqual(
+      `[${colors.magenta('percy')}] ${colors.red('level')}`);
 
-    logger.loglevel('debug');
+    expect(logger.format('ungrouped')).toEqual(
+      `[${colors.magenta('percy')}] ungrouped`);
+    expect(logger.format('other', 'long')).toEqual(
+      `[${colors.magenta('percy')}] long`);
+    expect(logger.format('other', 'warn', 'long level')).toEqual(
+      `[${colors.magenta('percy')}] ${colors.yellow('long level')}`);
+    expect(logger.format('other', 'error', 'elapsed', 100)).toEqual(
+      `[${colors.magenta('percy')}] ${colors.red('elapsed')}`);
 
-    expect(logger.format('wat')).toEqual(
-      `[${colors.magenta('percy')}] wat`
-    );
+    log.loglevel('debug');
 
-    expect(logger.format('debugging', 'test')).toEqual(
-      `[${colors.magenta('percy:test')}] debugging`
-    );
+    expect(log.format('grouped')).toEqual(
+      `[${colors.magenta('percy:test')}] grouped`);
+    expect(log.format('error', 'level')).toEqual(
+      `[${colors.magenta('percy:test')}] ${colors.red('level')}`);
 
-    expect(logger.format('failure', 'test', 'error')).toEqual(
-      `[${colors.magenta('percy:test')}] ${colors.red('failure')}`
-    );
-
-    logger.loglevel('error');
-
-    expect(logger.format('warning', 'test', 'warn')).toEqual(
-      `[${colors.magenta('percy')}] ${colors.yellow('warning')}`
-    );
+    expect(logger.format('ungrouped')).toEqual(
+      `[${colors.magenta('percy')}] ungrouped`);
+    expect(logger.format('other', 'long')).toEqual(
+      `[${colors.magenta('percy:other')}] long`);
+    expect(logger.format('other', 'warn', 'elapsed', 100)).toEqual(
+      `[${colors.magenta('percy:other')}] ` +
+        `${colors.yellow('elapsed')} ${colors.grey('(100ms)')}`);
   });
 
   it('exposes own stdout and stderr streams', () => {
@@ -164,9 +172,8 @@ describe('logger', () => {
 
   describe('levels', () => {
     it('can be initially set by defining PERCY_LOGLEVEL', () => {
-      process.env.PERCY_LOGLEVEL = 'error';
       helpers.reset();
-
+      process.env.PERCY_LOGLEVEL = 'error';
       expect(logger.loglevel()).toEqual('error');
     });
 
@@ -184,7 +191,7 @@ describe('logger', () => {
     });
 
     it('logs only warnings and errors when loglevel is "warn"', () => {
-      logger.loglevel('warn');
+      log.loglevel('warn');
 
       log.info('Info log');
       log.warn('Warn log');
@@ -199,7 +206,7 @@ describe('logger', () => {
     });
 
     it('logs only errors when loglevel is "error"', () => {
-      logger.loglevel('error');
+      log.loglevel('error');
 
       log.info('Info log');
       log.warn('Warn log');
@@ -213,7 +220,7 @@ describe('logger', () => {
     });
 
     it('logs everything when loglevel is "debug"', () => {
-      logger.loglevel('debug');
+      log.loglevel('debug');
 
       log.info('Info log');
       log.warn('Warn log');
@@ -232,7 +239,7 @@ describe('logger', () => {
 
     it('logs error stack traces when loglevel is "debug"', () => {
       let error = new Error('test');
-      logger.loglevel('debug');
+      log.loglevel('debug');
       log.error(error);
 
       expect(helpers.stderr).toEqual([
@@ -242,7 +249,7 @@ describe('logger', () => {
 
     it('stringifies error-like objects when loglevel is "debug"', () => {
       let errorlike = { toString: () => 'ERROR' };
-      logger.loglevel('debug');
+      log.loglevel('debug');
       log.debug(errorlike);
 
       expect(helpers.stderr).toEqual([


### PR DESCRIPTION
## What is this?

This PR consists of two small changes to `@percy/logger`:

### Give access to additional logger group properties

When a logger group is created with the default `logger(namespace)` function, it only has access to methods that will produce logs (and an additional `shouldLog` util). This PR adds other useful properties that are currently used in various places directly from `logger[property]` equivalents. The top-level properties will still exist, with the difference being that the first argument is bound to the group namespace for new group equivalent methods. This is useful when passing a logging group around without needing to import `logger` directly to have access to these methods. With this change, the `format()` method arguments were ordered to match other method arguments order which makes binding more consistent and straightforward during the logger group creation.

### Use brighter colors when logging

While adding a green color for future packages to use, I noticed a usability issue with our warning color. Being a colorblind person myself, it was hard to distinguish between green and yellow using default terminal colors. On the wiki for ansi color codes, I found [a table that shows how the color codes are represented in various environments](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors). Using this as a guide, I updated our red, yellow, and magenta colors to be brighter versions of themselves.