### PR TITLE
✨ Alias default exports with named exports

### DIFF
--- a/.github/.cache-key
+++ b/.github/.cache-key
@@ -6,4 +6,4 @@
               ;   ;
               /   \
 _____________/_ __ \_____________
-Times we have broken CI: 2
+Times we have broken CI: 3

--- a/packages/cli-command/src/command.js
+++ b/packages/cli-command/src/command.js
@@ -6,7 +6,7 @@ import logger from '@percy/logger';
 // The PercyCommand class that all Percy CLI commands should extend
 // from. Provides common #init() and #catch() methods and provides other methods
 // for loading configuration and checking if Percy is enabled.
-export default class PercyCommand extends Command {
+export class PercyCommand extends Command {
   log = logger('cli:command');
 
   //  Initialize flags, args, the loglevel, and attach process handlers to allow
@@ -86,3 +86,5 @@ export default class PercyCommand extends Command {
     });
   }
 }
+
+export default PercyCommand;

--- a/packages/cli-command/src/index.js
+++ b/packages/cli-command/src/index.js
@@ -1,2 +1,2 @@
-export { default } from './command';
+export { default, PercyCommand } from './command';
 export { default as flags } from './flags';

--- a/packages/cli-config/test/helpers.js
+++ b/packages/cli-config/test/helpers.js
@@ -7,4 +7,4 @@ beforeEach(() => {
 });
 
 export { logger };
-export { default as mockConfig, getMockConfig } from '@percy/config/test/helpers';
+export { mockConfig, getMockConfig } from '@percy/config/test/helpers';

--- a/packages/cli-exec/test/helpers.js
+++ b/packages/cli-exec/test/helpers.js
@@ -15,4 +15,4 @@ afterEach(() => {
 });
 
 export { logger, mockAPI };
-export { default as createTestServer } from '@percy/core/test/helpers/server';
+export { createTestServer } from '@percy/core/test/helpers/server';

--- a/packages/cli-upload/src/resources.js
+++ b/packages/cli-upload/src/resources.js
@@ -25,7 +25,7 @@ function createImageResource(url, content, mimetype) {
 // Returns root resource and image resource objects based on an image's
 // filename, contents, and dimensions. The root resource is a generated DOM
 // designed to display an image at it's native size without margins or padding.
-export default function createImageResources(filename, content, width, height) {
+export function createImageResources(filename, content, width, height) {
   let { dir, name, ext } = path.parse(filename);
   let rootUrl = `/${encodeURIComponent(path.join(dir, name))}`;
   let imageUrl = `/${encodeURIComponent(filename)}`;
@@ -52,3 +52,5 @@ export default function createImageResources(filename, content, width, height) {
     createImageResource(imageUrl, content, mimetype)
   ];
 }
+
+export default createImageResources;

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -28,7 +28,7 @@ function validateProjectPath(path) {
 // PercyClient is used to communicate with the Percy API to create and finalize
 // builds and snapshot. Uses @percy/env to collect environment information used
 // during build creation.
-export default class PercyClient {
+export class PercyClient {
   log = logger('client');
   env = new PercyEnvironment(process.env);
   clientInfo = new Set();
@@ -349,3 +349,5 @@ export default class PercyClient {
     return snapshot;
   }
 }
+
+export default PercyClient;

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -1,4 +1,4 @@
-import PercyEnvironment from '@percy/env';
+import PercyEnv from '@percy/env';
 import { git } from '@percy/env/dist/utils';
 import logger from '@percy/logger';
 import pkg from '../package.json';
@@ -30,7 +30,7 @@ function validateProjectPath(path) {
 // during build creation.
 export class PercyClient {
   log = logger('client');
-  env = new PercyEnvironment(process.env);
+  env = new PercyEnv(process.env);
   clientInfo = new Set();
   environmentInfo = new Set();
 

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -1,1 +1,1 @@
-export { default } from './client';
+export { default, PercyClient } from './client';

--- a/packages/client/src/request.js
+++ b/packages/client/src/request.js
@@ -187,7 +187,7 @@ export function proxyAgentFor(url, options) {
 // default, and 404 errors may also be optionally retried. If a callback is provided, it is called
 // with the parsed response body and response details. If the callback returns a value, that value
 // will be returned in the final resolved promise instead of the response body.
-export default function request(url, options = {}, callback) {
+export function request(url, options = {}, callback) {
   // accept `request(url, callback)`
   if (typeof options === 'function') [options, callback] = [{}, options];
   let { body, retries, retryNotFound, interval, noProxy, ...requestOptions } = options;
@@ -255,3 +255,5 @@ export default function request(url, options = {}, callback) {
     req.end(body);
   }, { retries, interval });
 }
+
+export default request;

--- a/packages/config/src/defaults.js
+++ b/packages/config/src/defaults.js
@@ -24,9 +24,11 @@ function getDefaultsFromSchema(schema) {
   }
 }
 
-export default function getDefaults(overrides = {}) {
+export function getDefaults(overrides = {}) {
   return merge([getDefaultsFromSchema(), overrides], (path, prev, next) => {
     // override default array instead of merging
     return isArray(next) && [path, next];
   });
 }
+
+export default getDefaults;

--- a/packages/config/src/index.js
+++ b/packages/config/src/index.js
@@ -5,7 +5,23 @@ import getDefaults from './defaults';
 import normalize from './normalize';
 import stringify from './stringify';
 
-// Export a single object that can be imported as PercyConfig
+export {
+  load,
+  search,
+  cache,
+  explorer,
+  validate,
+  addSchema,
+  resetSchema,
+  migrate,
+  addMigration,
+  clearMigrations,
+  getDefaults,
+  normalize,
+  stringify
+};
+
+// mirror the namespace as the default export
 export default {
   load,
   search,

--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -45,7 +45,7 @@ export function search(path) {
 // unless `bail` is true. Supports kebab-case and camelCase config options and
 // always returns camelCase options. Will automatically convert older config
 // versions to the latest version while printing a warning.
-export default function load({
+export function load({
   path,
   overrides = {},
   reload = false,
@@ -107,3 +107,5 @@ export default function load({
   // merge with defaults
   return getDefaults(config);
 }
+
+export default load;

--- a/packages/config/src/migrate.js
+++ b/packages/config/src/migrate.js
@@ -53,7 +53,7 @@ function deprecate(config, log, path, options) {
 
 // Calls each registered migration function with a normalize provided config
 // and util functions for working with the config object
-export default function migrate(config, schema = '/config') {
+export function migrate(config, schema = '/config') {
   config = normalize(config, { schema }) ?? {};
 
   if (migrations.has(schema)) {
@@ -77,3 +77,5 @@ export default function migrate(config, schema = '/config') {
 
   return config;
 }
+
+export default migrate;

--- a/packages/config/src/normalize.js
+++ b/packages/config/src/normalize.js
@@ -10,7 +10,7 @@ const CAMELCASE_MAP = new Map([
 // Converts kebab-cased and snake_cased strings to camelCase.
 const KEBAB_SNAKE_REG = /[-_]([^-_]+)/g;
 
-function camelcase(str) {
+export function camelcase(str) {
   if (typeof str !== 'string') return str;
 
   return str.replace(KEBAB_SNAKE_REG, (match, word) => (
@@ -21,7 +21,7 @@ function camelcase(str) {
 // Coverts camelCased and snake_cased strings to kebab-case.
 const CAMEL_SNAKE_REG = /([a-z])([A-Z]+)|_([^_]+)/g;
 
-function kebabcase(str) {
+export function kebabcase(str) {
   if (typeof str !== 'string') return str;
 
   return Array.from(CAMELCASE_MAP)
@@ -36,7 +36,7 @@ function kebabcase(str) {
 // Removes undefined empty values and renames kebab-case properties to camelCase. Optionally
 // allows deep merging with options.overrides, converting keys to kebab-case with options.kebab,
 // and normalizing against a schema with options.schema.
-export default function normalize(object, options) {
+export function normalize(object, options) {
   let keycase = options?.kebab ? kebabcase : camelcase;
 
   return merge([object, options?.overrides], path => {
@@ -52,3 +52,5 @@ export default function normalize(object, options) {
     return [path];
   });
 }
+
+export default normalize;

--- a/packages/config/src/stringify.js
+++ b/packages/config/src/stringify.js
@@ -9,7 +9,7 @@ export function inspect(config) {
 
 // Converts a config to a yaml, json, or js string. When no config is provided,
 // falls back to schema defaults.
-export default function stringify(format, config = getDefaults()) {
+export function stringify(format, config = getDefaults()) {
   switch (format) {
     case 'yml':
     case 'yaml':
@@ -22,3 +22,5 @@ export default function stringify(format, config = getDefaults()) {
       throw new Error(`Unsupported format: ${format}`);
   }
 }
+
+export default stringify;

--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -157,7 +157,7 @@ function shouldHideError({ parentSchema, keyword, schemaPath }) {
 }
 
 // Validates data according to the associated schema and returns a list of errors, if any.
-export default function validate(data, key = '/config') {
+export function validate(data, key = '/config') {
   if (!ajv.validate(key, data)) {
     let errors = new Map();
 
@@ -214,3 +214,5 @@ export default function validate(data, key = '/config') {
     return Array.from(errors.values());
   }
 }
+
+export default validate;

--- a/packages/config/test/helpers.js
+++ b/packages/config/test/helpers.js
@@ -3,7 +3,7 @@ import mock from 'mock-require';
 
 export const configs = new Map();
 
-export default function mockConfig(f, c) {
+export function mockConfig(f, c) {
   configs.set(f, () => typeof c === 'function' ? c() : c);
 }
 
@@ -45,3 +45,5 @@ afterAll(() => {
 afterEach(() => {
   configs.clear();
 });
+
+export default mockConfig;

--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -10,7 +10,7 @@ import install from './install';
 import Session from './session';
 import Page from './page';
 
-export default class Browser extends EventEmitter {
+export class Browser extends EventEmitter {
   log = logger('core:browser');
   sessions = new Map();
   readyState = null;
@@ -315,3 +315,5 @@ export default class Browser extends EventEmitter {
     }
   }
 }
+
+export default Browser;

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -219,6 +219,13 @@ export const snapshotDOMSchema = {
   }
 };
 
+// Grouped schemas for easier registration
+export const schemas = [
+  configSchema,
+  snapshotSchema,
+  snapshotDOMSchema
+];
+
 // Config migrate function
 export function configMigration(config, util) {
   /* eslint-disable curly */
@@ -248,13 +255,7 @@ export function snapshotMigration(config, util) {
   util.deprecate('snapshots', { map: 'additionalSnapshots', ...notice });
 }
 
-// Convinient references for schema registrations
-export const schemas = [
-  configSchema,
-  snapshotSchema,
-  snapshotDOMSchema
-];
-
+// Grouped migrations for easier registration
 export const migrations = [
   ['/config', configMigration],
   ['/snapshot', snapshotMigration]

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,9 +1,10 @@
-// Register core config options
-const { default: PercyConfig } = require('@percy/config');
+const PercyConfig = require('@percy/config');
 const CoreConfig = require('./config');
+const { Percy } = require('./percy');
 
 PercyConfig.addSchema(CoreConfig.schemas);
 PercyConfig.addMigration(CoreConfig.migrations);
 
-// Export the Percy class with commonjs compatibility
-module.exports = require('./percy').default;
+// export the Percy class with commonjs compatibility
+module.exports = Percy;
+module.exports.Percy = Percy;

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -8,7 +8,7 @@ import {
 
 // The Interceptor class creates common handlers for dealing with intercepting asset requests
 // for a given page using various devtools protocol events and commands.
-export default class Network {
+export class Network {
   static TIMEOUT = 30000;
 
   log = logger('core:network');
@@ -261,3 +261,5 @@ export default class Network {
     this._forgetRequest(request);
   }
 }
+
+export default Network;

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -7,7 +7,7 @@ import {
   waitFor
 } from './utils';
 
-export default class Page {
+export class Page {
   static TIMEOUT = 30000;
 
   log = logger('core:page');
@@ -265,3 +265,5 @@ export default class Page {
     this.contextId = null;
   }
 }
+
+export default Page;

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -19,7 +19,7 @@ import {
 // creation, asset discovery, and resource uploads, and will finalize the build
 // when stopped. Snapshots are processed concurrently and the build is not
 // finalized until all snapshots have been handled.
-export default class Percy {
+export class Percy {
   log = logger('core');
   readyState = null;
 
@@ -375,3 +375,5 @@ export default class Percy {
     });
   }
 }
+
+export default Percy;

--- a/packages/core/src/queue.js
+++ b/packages/core/src/queue.js
@@ -3,7 +3,7 @@ import {
   waitFor
 } from './utils';
 
-export default class Queue {
+export class Queue {
   running = true;
   closed = false;
 
@@ -148,3 +148,5 @@ export default class Queue {
     }
   }
 }
+
+export default Queue;

--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -96,7 +96,7 @@ export function createServer(routes) {
   return context;
 }
 
-export default function createPercyServer(percy) {
+export function createPercyServer(percy) {
   let log = logger('core:server');
 
   let context = createServer({
@@ -173,3 +173,5 @@ export default function createPercyServer(percy) {
 
   return context;
 }
+
+export default createPercyServer;

--- a/packages/core/src/session.js
+++ b/packages/core/src/session.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import logger from '@percy/logger';
 
-export default class Session extends EventEmitter {
+export class Session extends EventEmitter {
   #callbacks = new Map();
 
   log = logger('core:session');
@@ -92,3 +92,5 @@ export default class Session extends EventEmitter {
     }
   }
 }
+
+export default Session;

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1,4 +1,5 @@
 import { sha256hash, hostnameMatches } from '@percy/client/dist/utils';
+export { request } from '@percy/client/dist/request';
 export { hostnameMatches };
 
 // Returns the hostname portion of a URL.

--- a/packages/core/test/helpers/dedent.js
+++ b/packages/core/test/helpers/dedent.js
@@ -1,4 +1,4 @@
-export default function dedent(raw, ...values) {
+export function dedent(raw, ...values) {
   let result = raw.reduce((acc, str, i) => {
     acc += str.replace(/\\\n[ \t]*/g, '').replace(/\\`/g, '`');
     if (i < values.length) acc += values[i];
@@ -23,3 +23,5 @@ export default function dedent(raw, ...values) {
 
   return result.trim().replace(/\\n/g, '\n');
 }
+
+export default dedent;

--- a/packages/core/test/helpers/index.js
+++ b/packages/core/test/helpers/index.js
@@ -17,5 +17,5 @@ afterEach(done => {
 });
 
 export { logger, mockAPI };
-export { default as createTestServer } from './server';
-export { default as dedent } from './dedent';
+export { createTestServer } from './server';
+export { dedent } from './dedent';

--- a/packages/core/test/helpers/server.js
+++ b/packages/core/test/helpers/server.js
@@ -1,7 +1,7 @@
 // aliased to src for coverage during tests without needing to compile this file
 const { createServer } = require('@percy/core/dist/server');
 
-module.exports = function createTestServer(routes, port = 8000) {
+function createTestServer(routes, port = 8000) {
   let context = createServer(routes);
 
   // handle route errors
@@ -16,3 +16,7 @@ module.exports = function createTestServer(routes, port = 8000) {
   // automatically listen
   return context.listen(port);
 };
+
+// support commonjs environments
+module.exports = createTestServer;
+module.exports.createTestServer = createTestServer;

--- a/packages/dom/src/index.js
+++ b/packages/dom/src/index.js
@@ -1,1 +1,6 @@
-export { default, default as serialize } from './serialize-dom';
+export {
+  default,
+  serializeDOM,
+  // namespace alias
+  serializeDOM as serialize
+} from './serialize-dom';

--- a/packages/dom/src/prepare-dom.js
+++ b/packages/dom/src/prepare-dom.js
@@ -4,10 +4,12 @@ function uid() {
 }
 
 // Marks elements that are to be serialized later with a data attribute.
-export default function prepareDOM(dom) {
+export function prepareDOM(dom) {
   for (let elem of dom.querySelectorAll('input, textarea, select, iframe, canvas')) {
     if (!elem.getAttribute('data-percy-element-id')) {
       elem.setAttribute('data-percy-element-id', uid());
     }
   }
 }
+
+export default prepareDOM;

--- a/packages/dom/src/serialize-canvas.js
+++ b/packages/dom/src/serialize-canvas.js
@@ -1,5 +1,5 @@
 // Serialize in-memory canvas elements into images.
-export default function serializeCanvas(dom, clone) {
+export function serializeCanvas(dom, clone) {
   for (let canvas of dom.querySelectorAll('canvas')) {
     // Note: the `.toDataURL` API requires WebGL canvas elements to use
     // `preserveDrawingBuffer: true`. This is because `.toDataURL` uses the
@@ -31,3 +31,5 @@ export default function serializeCanvas(dom, clone) {
     cloneEl.remove();
   }
 }
+
+export default serializeCanvas;

--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -6,7 +6,7 @@ function isCSSOM(styleSheet) {
 }
 
 // Outputs in-memory CSSOM into their respective DOM nodes.
-export default function serializeCSSOM(dom, clone) {
+export function serializeCSSOM(dom, clone) {
   for (let styleSheet of dom.styleSheets) {
     if (isCSSOM(styleSheet)) {
       let style = clone.createElement('style');
@@ -20,3 +20,5 @@ export default function serializeCSSOM(dom, clone) {
     }
   }
 }
+
+export default serializeCSSOM;

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -21,7 +21,7 @@ function doctype(dom) {
 }
 
 // Serializes a document and returns the resulting DOM string.
-export default function serializeDOM(options) {
+export function serializeDOM(options) {
   let {
     dom = document,
     // allow snake_case or camelCase
@@ -52,3 +52,5 @@ export default function serializeDOM(options) {
 
   return doctype(dom) + doc.outerHTML;
 }
+
+export default serializeDOM;

--- a/packages/dom/src/serialize-frames.js
+++ b/packages/dom/src/serialize-frames.js
@@ -12,7 +12,7 @@ function setBaseURI(dom) {
 }
 
 // Recursively serializes iframe documents into srcdoc attributes.
-export default function serializeFrames(dom, clone, { enableJavaScript }) {
+export function serializeFrames(dom, clone, { enableJavaScript }) {
   for (let frame of dom.querySelectorAll('iframe')) {
     let percyElementId = frame.getAttribute('data-percy-element-id');
     let cloneEl = clone.querySelector(`[data-percy-element-id="${percyElementId}"]`);
@@ -49,3 +49,5 @@ export default function serializeFrames(dom, clone, { enableJavaScript }) {
     }
   }
 }
+
+export default serializeFrames;

--- a/packages/dom/src/serialize-inputs.js
+++ b/packages/dom/src/serialize-inputs.js
@@ -1,5 +1,5 @@
 // Translates JavaScript properties of inputs into DOM attributes.
-export default function serializeInputElements(dom, clone) {
+export function serializeInputElements(dom, clone) {
   for (let elem of dom.querySelectorAll('input, textarea, select')) {
     let inputId = elem.getAttribute('data-percy-element-id');
     let cloneEl = clone.querySelector(`[data-percy-element-id="${inputId}"]`);
@@ -29,3 +29,5 @@ export default function serializeInputElements(dom, clone) {
     }
   }
 }
+
+export default serializeInputElements;

--- a/packages/env/src/environment.js
+++ b/packages/env/src/environment.js
@@ -4,7 +4,7 @@ import {
   github
 } from './utils';
 
-export default class PercyEnvironment {
+export class PercyEnv {
   constructor(vars = process.env) {
     this.vars = vars;
   }
@@ -281,8 +281,8 @@ export default class PercyEnvironment {
 }
 
 // cache getters on initial call so subsequent calls are not re-computed
-Object.defineProperties(PercyEnvironment.prototype, (
-  Object.entries(Object.getOwnPropertyDescriptors(PercyEnvironment.prototype))
+Object.defineProperties(PercyEnv.prototype, (
+  Object.entries(Object.getOwnPropertyDescriptors(PercyEnv.prototype))
     .reduce((proto, [key, { get, ...descr }]) => !get ? proto : (
       Object.assign(proto, {
         [key]: Object.assign(descr, {
@@ -295,3 +295,5 @@ Object.defineProperties(PercyEnvironment.prototype, (
       })
     ), {})
 ));
+
+export default PercyEnv;

--- a/packages/env/src/index.js
+++ b/packages/env/src/index.js
@@ -1,2 +1,2 @@
-export { default } from './environment';
+export { default, PercyEnv } from './environment';
 require('./dotenv').load();

--- a/packages/env/test/appveyor.test.js
+++ b/packages/env/test/appveyor.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('Appveyor', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PERCY_PARALLEL_TOTAL: '-1',
       APPVEYOR_BUILD_ID: 'appveyor-build-id',
       APPVEYOR_REPO_COMMIT: 'appveyor-commit-sha',
@@ -25,7 +25,7 @@ describe('Appveyor', () => {
   });
 
   it('has the correct properties for PR builds', () => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       ...env.vars,
       APPVEYOR_PULL_REQUEST_NUMBER: '512',
       APPVEYOR_PULL_REQUEST_HEAD_COMMIT: 'appveyor-pr-commit-sha',

--- a/packages/env/test/azure.test.js
+++ b/packages/env/test/azure.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('Azure', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PERCY_PARALLEL_TOTAL: '-1',
       BUILD_BUILDID: 'azure-build-id',
       BUILD_SOURCEVERSION: 'azure-commit-sha',
@@ -25,7 +25,7 @@ describe('Azure', () => {
   });
 
   it('has the correct properties for PR builds', () => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       ...env.vars,
       SYSTEM_PULLREQUEST_PULLREQUESTID: '502',
       SYSTEM_PULLREQUEST_PULLREQUESTNUMBER: '512',

--- a/packages/env/test/bitbucket.test.js
+++ b/packages/env/test/bitbucket.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('Bitbucket', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PERCY_PARALLEL_TOTAL: '-1',
       BITBUCKET_BUILD_NUMBER: 'bitbucket-build-number',
       BITBUCKET_COMMIT: 'bitbucket-commit-sha',

--- a/packages/env/test/buildkite.test.js
+++ b/packages/env/test/buildkite.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('Buildkite', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PERCY_PARALLEL_TOTAL: '-1',
       BUILDKITE_COMMIT: 'buildkite-commit-sha',
       BUILDKITE_BRANCH: 'buildkite-branch',
@@ -26,12 +26,12 @@ describe('Buildkite', () => {
   });
 
   it('has the correct properties for PR builds', () => {
-    env = new PercyEnvironment({ ...env.vars, BUILDKITE_PULL_REQUEST: '123' });
+    env = new PercyEnv({ ...env.vars, BUILDKITE_PULL_REQUEST: '123' });
     expect(env).toHaveProperty('pullRequest', '123');
   });
 
   it('returns null sha when commit is HEAD', () => {
-    env = new PercyEnvironment({ ...env.vars, BUILDKITE_COMMIT: 'HEAD' });
+    env = new PercyEnv({ ...env.vars, BUILDKITE_COMMIT: 'HEAD' });
     expect(env).toHaveProperty('commit', null);
   });
 });

--- a/packages/env/test/circle.test.js
+++ b/packages/env/test/circle.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('CircleCI', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PERCY_PARALLEL_TOTAL: '-1',
       CIRCLE_BRANCH: 'circle-branch',
       CIRCLE_SHA1: 'circle-commit-sha',
@@ -26,7 +26,7 @@ describe('CircleCI', () => {
   });
 
   it('has the correct parallel nonce in 2.x', () => {
-    env = new PercyEnvironment({ ...env.vars, CIRCLE_WORKFLOW_ID: 'workflow-id' });
+    env = new PercyEnv({ ...env.vars, CIRCLE_WORKFLOW_ID: 'workflow-id' });
     expect(env).toHaveProperty('parallel.nonce', 'workflow-id');
   });
 });

--- a/packages/env/test/codeship.test.js
+++ b/packages/env/test/codeship.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('CodeShip', () => {
   let env;
 
   beforeEach(function() {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PERCY_PARALLEL_TOTAL: '-1',
       CI_BRANCH: 'codeship-branch',
       CI_BUILD_NUMBER: 'codeship-build-number',
@@ -27,7 +27,7 @@ describe('CodeShip', () => {
   });
 
   it('has nonce fallback for CodeShip Pro', () => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       ...env.vars,
       CI_BUILD_NUMBER: ''
     });

--- a/packages/env/test/defaults.test.js
+++ b/packages/env/test/defaults.test.js
@@ -1,11 +1,11 @@
 import { mockgit } from './helpers';
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('Defaults', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({});
+    env = new PercyEnv({});
   });
 
   it('has default properties', () => {
@@ -22,13 +22,13 @@ describe('Defaults', () => {
   });
 
   it('has default CI info', () => {
-    env = new PercyEnvironment({ CI: 'true' });
+    env = new PercyEnv({ CI: 'true' });
     expect(env).toHaveProperty('ci', 'CI/unknown');
     expect(env).toHaveProperty('info', 'CI/unknown');
   });
 
   it('uses process.env as default vars', () => {
-    expect(new PercyEnvironment()).toHaveProperty('vars', process.env);
+    expect(new PercyEnv()).toHaveProperty('vars', process.env);
   });
 
   it('reads and parses live git commit data', () => {
@@ -71,7 +71,7 @@ describe('Defaults', () => {
   it('uses the raw commit sha when the env sha is invalid', () => {
     mockgit.commit.and.returnValue('COMMIT_SHA:fully-valid-git-sha\n');
 
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       BITBUCKET_BUILD_NUMBER: 'bitbucket-build-number',
       BITBUCKET_COMMIT: 'bitbucket-commit-sha'
     });
@@ -93,7 +93,7 @@ describe('Defaults', () => {
       'COMMIT_MESSAGE:mock commit'
     ].join('\n'));
 
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PERCY_TOKEN: 'percy-token',
       PERCY_COMMIT: 'percy-40-character-commit-sha-aaaaaaaaaa',
       PERCY_BRANCH: 'percy-branch',
@@ -131,7 +131,7 @@ describe('Defaults', () => {
   });
 
   it('does not collect parallel nonce with invalid or no parallel total', () => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PERCY_PARALLEL_NONCE: 'percy-nonce',
       PERCY_PARALLEL_TOTAL: 'invalid'
     });
@@ -139,7 +139,7 @@ describe('Defaults', () => {
     expect(env).toHaveProperty('parallel.nonce', null);
     expect(env).toHaveProperty('parallel.total', null);
 
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PERCY_PARALLEL_NONCE: 'percy-nonce'
     });
 
@@ -151,7 +151,7 @@ describe('Defaults', () => {
     mockgit.commit.and.returnValue('missing or invalid');
     mockgit.branch.and.returnValue('mock branch');
 
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PERCY_COMMIT: 'not-long-enough-sha',
       GIT_AUTHOR_NAME: 'git author',
       GIT_AUTHOR_EMAIL: 'git author@email.com',

--- a/packages/env/test/drone.test.js
+++ b/packages/env/test/drone.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('Drone', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       DRONE: 'true',
       DRONE_COMMIT: 'drone-commit-sha',
       DRONE_BRANCH: 'drone-branch',

--- a/packages/env/test/github.test.js
+++ b/packages/env/test/github.test.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 import { github } from '../src/utils';
 
 describe('GitHub', () => {
@@ -20,7 +20,7 @@ describe('GitHub', () => {
       }
     }));
 
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PERCY_PARALLEL_TOTAL: '-1',
       GITHUB_RUN_ID: 'job-id',
       GITHUB_ACTIONS: 'true',
@@ -51,7 +51,7 @@ describe('GitHub', () => {
 
   describe('without an event payload', () => {
     beforeEach(() => {
-      env = new PercyEnvironment({
+      env = new PercyEnv({
         GITHUB_ACTIONS: 'true',
         GITHUB_SHA: 'gh-env-sha',
         GITHUB_REF: 'refs/head/gh-env-branch'

--- a/packages/env/test/gitlab.test.js
+++ b/packages/env/test/gitlab.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('GitLab', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       GITLAB_CI: 'true',
       CI_COMMIT_SHA: 'gitlab-commit-sha',
       CI_COMMIT_REF_NAME: 'gitlab-branch',
@@ -27,7 +27,7 @@ describe('GitLab', () => {
   });
 
   it('has the correct properties for PR builds', () => {
-    env = new PercyEnvironment({ ...env.vars, CI_MERGE_REQUEST_IID: '2217' });
+    env = new PercyEnv({ ...env.vars, CI_MERGE_REQUEST_IID: '2217' });
     expect(env).toHaveProperty('pullRequest', '2217');
     expect(env).toHaveProperty('branch', 'gitlab-branch');
     expect(env).toHaveProperty('commit', 'gitlab-commit-sha');

--- a/packages/env/test/heroku.test.js
+++ b/packages/env/test/heroku.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('Heroku', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PERCY_PARALLEL_TOTAL: '-1',
       HEROKU_TEST_RUN_COMMIT_VERSION: 'heroku-commit-sha',
       HEROKU_TEST_RUN_BRANCH: 'heroku-branch',

--- a/packages/env/test/jenkins.test.js
+++ b/packages/env/test/jenkins.test.js
@@ -1,11 +1,11 @@
 import { mockgit } from './helpers';
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('Jenkins', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       JENKINS_URL: 'http://jenkins.local/',
       GIT_COMMIT: 'jenkins-commit-sha',
       GIT_BRANCH: 'jenkins-branch',
@@ -26,7 +26,7 @@ describe('Jenkins', () => {
   });
 
   it('has the correct properties for PR builds', () => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       ...env.vars,
       CHANGE_ID: '111',
       CHANGE_BRANCH: 'jenkins-branch'
@@ -37,7 +37,7 @@ describe('Jenkins', () => {
   });
 
   it('has the correct properties for merge PR builds', () => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       ...env.vars,
       CHANGE_ID: '111',
       CHANGE_BRANCH: 'jenkins-branch'
@@ -60,7 +60,7 @@ describe('Jenkins', () => {
 
   describe('with the PRB plugin', () => {
     beforeEach(() => {
-      env = new PercyEnvironment({
+      env = new PercyEnv({
         JENKINS_URL: 'http://jenkins.local/',
         BUILD_NUMBER: '111',
         ghprbPullId: '256',

--- a/packages/env/test/netlify.test.js
+++ b/packages/env/test/netlify.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('Netlify', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       NETLIFY: 'true',
       COMMIT_REF: 'netlify-sha',
       HEAD: 'netlify-branch',

--- a/packages/env/test/probo.test.js
+++ b/packages/env/test/probo.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('Probo', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       PROBO_ENVIRONMENT: 'TRUE',
       BUILD_ID: 'probo-build-id',
       COMMIT_REF: 'probo-commit-sha',

--- a/packages/env/test/semaphore.test.js
+++ b/packages/env/test/semaphore.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('Semaphore', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       SEMAPHORE: 'true',
       BRANCH_NAME: 'semaphore-branch',
       REVISION: 'semaphore-commit-sha',
@@ -29,7 +29,7 @@ describe('Semaphore', () => {
 
   describe('Semaphore 2.0', () => {
     beforeEach(() => {
-      env = new PercyEnvironment({
+      env = new PercyEnv({
         SEMAPHORE: 'true',
         SEMAPHORE_GIT_SHA: 'semaphore-2-sha',
         SEMAPHORE_GIT_BRANCH: 'semaphore-2-branch',
@@ -51,7 +51,7 @@ describe('Semaphore', () => {
     });
 
     it('has the correct properties for PR builds', () => {
-      env = new PercyEnvironment({
+      env = new PercyEnv({
         SEMAPHORE: 'true',
         SEMAPHORE_GIT_SHA: 'semaphore-2-sha',
         SEMAPHORE_GIT_PR_SHA: 'semaphore-2-pr-sha',

--- a/packages/env/test/travis.test.js
+++ b/packages/env/test/travis.test.js
@@ -1,10 +1,10 @@
-import PercyEnvironment from '../src';
+import PercyEnv from '../src';
 
 describe('Travis', () => {
   let env;
 
   beforeEach(() => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       TRAVIS_BUILD_ID: '1234',
       TRAVIS_PULL_REQUEST: 'false',
       TRAVIS_PULL_REQUEST_BRANCH: '',
@@ -27,7 +27,7 @@ describe('Travis', () => {
   });
 
   it('has the correct properties for PR builds', () => {
-    env = new PercyEnvironment({
+    env = new PercyEnv({
       ...env.vars,
       TRAVIS_PULL_REQUEST: '256',
       TRAVIS_PULL_REQUEST_BRANCH: 'travis-pr-branch'

--- a/packages/logger/src/browser.js
+++ b/packages/logger/src/browser.js
@@ -1,7 +1,7 @@
 import { ANSI_COLORS, ANSI_REG } from './util';
 import PercyLogger from './logger';
 
-export default class BrowserLogger extends PercyLogger {
+export class PercyBrowserLogger extends PercyLogger {
   write(level, message) {
     let out = ['warn', 'error'].includes(level) ? level : 'log';
     let colors = [];
@@ -18,3 +18,5 @@ export default class BrowserLogger extends PercyLogger {
     console.error('The log.progress() method is not supported in browsers');
   }
 }
+
+export default PercyBrowserLogger;

--- a/packages/logger/src/logger.js
+++ b/packages/logger/src/logger.js
@@ -5,7 +5,7 @@ const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
 
 // A PercyLogger instance retains logs in-memory for quick lookups while also writing log
 // messages to stdout and stderr depending on the log level and debug string.
-export default class PercyLogger {
+export class PercyLogger {
   // default log level
   level = 'info';
 
@@ -298,3 +298,5 @@ export default class PercyLogger {
     };
   }
 }
+
+export default PercyLogger;

--- a/packages/sdk-utils/src/percy-dom.js
+++ b/packages/sdk-utils/src/percy-dom.js
@@ -2,7 +2,7 @@ import percy from './percy-info';
 import request from './request';
 
 // Fetch and cache the @percy/dom script
-export default async function fetchPercyDOM() {
+export async function fetchPercyDOM() {
   if (percy.domScript == null) {
     let response = await request('/percy/dom.js');
     percy.domScript = response.body;
@@ -10,3 +10,5 @@ export default async function fetchPercyDOM() {
 
   return percy.domScript;
 }
+
+export default fetchPercyDOM;

--- a/packages/sdk-utils/src/percy-enabled.js
+++ b/packages/sdk-utils/src/percy-enabled.js
@@ -19,7 +19,7 @@ async function connectRemoteLogger() {
 }
 
 // Check if Percy is enabled using the healthcheck endpoint
-export default async function isPercyEnabled() {
+export async function isPercyEnabled() {
   if (percy.enabled == null) {
     let log = logger('utils');
     let error;
@@ -50,3 +50,5 @@ export default async function isPercyEnabled() {
 
   return percy.enabled;
 }
+
+export default isPercyEnabled;

--- a/packages/sdk-utils/src/post-snapshot.js
+++ b/packages/sdk-utils/src/post-snapshot.js
@@ -3,7 +3,7 @@ import request from './request';
 
 // Post snapshot data to the snapshot endpoint. If the snapshot endpoint responds with a closed
 // error message, signal that Percy has been disabled.
-export default async function postSnapshot(options, params) {
+export async function postSnapshot(options, params) {
   let query = params ? `?${new URLSearchParams(params)}` : '';
 
   await request.post(`/percy/snapshot${query}`, options).catch(err => {
@@ -14,3 +14,5 @@ export default async function postSnapshot(options, params) {
     }
   });
 }
+
+export default postSnapshot;

--- a/packages/sdk-utils/src/request.js
+++ b/packages/sdk-utils/src/request.js
@@ -1,7 +1,7 @@
 import percy from './percy-info';
 
 // Helper to send a request to the local CLI API
-export default async function request(path, options = {}) {
+export async function request(path, options = {}) {
   let response = await request.fetch(`${percy.address}${path}`, options);
 
   // maybe parse response body as json
@@ -67,3 +67,5 @@ if (process.env.__PERCY_BROWSERIFIED__) {
     });
   };
 }
+
+export default request;


### PR DESCRIPTION
## What is this?

Default exports are a handy convenience for ES modules. However, with dynamic imports and commonjs modules, the default export must always be destructured due to `default` being a reserved word.

```js
// esm
import thing from './thing';
// commonjs
const { default: thing } = require('./thing');
// dynamic import
const { default: thing } = await import('./thing');
// re-export
export { default as thing } from './thing';
```

By exporting defaults as named exports and aliasing them to default exports, much cleaner code can be written:

```js
// esm
import thing from './thing';
// commonjs
const { thing } = require('./thing');
// dynamic import
const { thing } = await import ('./thing');
// re-export
export { thing } from './thing';
```

### Tangential changes

- While adding a named `@percy/env` export, I felt compelled to rename the class to match the package name more accurately (`PercyEnv`).

- Packages that rely on `@percy/core` frequently need to perform some sort of request and utilize `request` from `@percy/client` to do so. When we add support for Yarn 2+, these packages will need to specifically declare a direct dependency on `@percy/client`, which will then trigger extra unnecessary dependency notifications.
 
  This small inconvenience can be alleviated by re-exporting `request` through `@percy/core` which already has a direct dependency on `@percy/client`. While this PR adds the necessary export, imports throughout other packages will need to be updated when adding support for Yarn 2+.