### PR TITLE
🐛 Fix @percy/client retries

### DIFF
--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -61,15 +61,11 @@ export function pool(generator, context, concurrency) {
 // passed to `retry`.
 export function retry(fn, { retries = 5, interval = 50 }) {
   return new Promise((resolve, reject) => {
-    // run the function, decrement retries
-    let run = () => {
-      fn(resolve, reject, retry);
-      retries--;
-    };
+    let run = () => fn(resolve, reject, retry);
 
     // wait an interval to try again or reject with the error
     let retry = err => {
-      if (retries) {
+      if (retries-- > 0) {
         setTimeout(run, interval);
       } else {
         reject(err);

--- a/packages/client/test/unit/request.test.js
+++ b/packages/client/test/unit/request.test.js
@@ -257,11 +257,11 @@ describe('Unit / Request', () => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
-    it('fails retrying after 5 attempts', async () => {
+    it('fails after 5 additional retries', async () => {
       server.reply('/fail', () => [502]);
       await expectAsync(server.request('/fail'))
         .toBeRejectedWithError('502 Bad Gateway');
-      expect(server.received.length).toBe(5);
+      expect(server.received.length).toBe(6);
     });
   });
 


### PR DESCRIPTION
## What is this?

Given zero retries, the retry util would always retry at leasty once. Given any number of retries, the retry util would count the first try against remaining retries. For example, a failed request without retries would always retry at least once, and a failed request with 5 retries would fail once, then retry 4 times.

When properly counting retries, the first try is not counted against retries, and similarly will not retry when given zero retries.