### PR TITLE
✅ Fix sdk-utils test server shutdown

### DIFF
--- a/packages/sdk-utils/test/server.js
+++ b/packages/sdk-utils/test/server.js
@@ -128,7 +128,7 @@ async function start(args, log) {
 
   wss.on('connection', ws => {
     ws.on('message', data => {
-      if (data === 'CLOSE') return close();
+      if (data.toString() === 'CLOSE') return close();
       let { id, event, args = [] } = JSON.parse(data);
 
       Promise.resolve().then(async () => {


### PR DESCRIPTION
## What is this?

While running tests for the entire repo, I noticed that tests for `@percy/sdk-utils` would occasionally log an error but not fail. After some brief digging, I found it was because the data being asserted against is a buffer, not a string like the comparison is expecting. This PR adds `.toString()` to this check to ensure that it's actually comparing against a string.