### PR TITLE
✅ Fix sdk-utils test server shutdown (again)

### DIFF
--- a/packages/sdk-utils/test/server.js
+++ b/packages/sdk-utils/test/server.js
@@ -123,6 +123,7 @@ async function start(args, log) {
     close.called = true;
 
     if (ctx) ctx.call('close');
+    for (let ws of wss.clients) ws.terminate();
     wss.close(() => log('info', 'Closed SDK testing server'));
   };
 


### PR DESCRIPTION
## What is this?

Following #669, the test server no longer throws an error on close. The error would result in the test server shutting down anyway, but now without the error, I've found that the test server process continues to hang around even though it is no longer accepting connections.

This is because some sockets connected through tests leave broken connections when the tests finish. When the test socket server shuts down, it emits to and waits until all connected sockets have disconnected. Since there are no longer any sockets on the other end of the connection, the socket server hangs.

A similar situation exists for normal requests and our own internal CLI server. There, we forcefully destroy any connections before closing the server. We can apply that same technique to the socket server connections which will allow the test server process to successfully close.