### PR TITLE
🐛 Fix tail call recursion in core util

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -104,10 +104,10 @@ export function waitFor(predicate, options) {
       throw new Error(`Timeout of ${timeout}ms exceeded.`);
     } else if (!predicate()) {
       yield new Promise(r => setTimeout(r, poll));
-      yield* check(start);
+      return yield* check(start);
     } else if (idle && !done) {
       yield new Promise(r => setTimeout(r, idle));
-      yield* check(start, true);
+      return yield* check(start, true);
     }
   }(Date.now()));
 }


### PR DESCRIPTION
## What is this?

This fixes the `waitFor` util in `@percy/core` to properly return the tail call. Without tail call optimization, error stacks that bubble from within the util can grow exponentially.