### PR TITLE
🐛 Fix legacy process termination when missing instance method

### DIFF
--- a/packages/cli-command/src/legacy.js
+++ b/packages/cli-command/src/legacy.js
@@ -89,7 +89,7 @@ export function legacyCommand(name, constructor) {
 
     // legacy signal handling
     let signals = ['SIGHUP', 'SIGINT', 'SIGTERM'];
-    let cleanup = () => instance.finally(new Error('SIGTERM'));
+    let cleanup = () => instance.finally?.(new Error('SIGTERM'));
     for (let e of signals) process.on(e, cleanup);
 
     // run and handle legacy command


### PR DESCRIPTION
## What is this?

Some legacy commands do not define their own `finally` method. If they extend from a class that also does not have a `finally` method (like if they accidentally extend from the `command` function), process termination throws an error.