### PR TITLE
🐛 Import local `@percy/cli` to avoid caching/multiple CLI issues

### DIFF
--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -6,7 +6,7 @@ if (parseInt(process.version.split('.')[0].substring(1), 10) < 12) {
   process.exit(1);
 }
 
-import('@percy/cli').then(
+import('../dist/index.js').then(
   async ({ checkForUpdate, percy }) => {
     await checkForUpdate();
     await percy(process.argv.slice(2));


### PR DESCRIPTION
## What is this?

It looks like `npx` is doing weird caching of `@percy/cli`, so when we do `import('@percy/cli')`, it's possible for the import to be an old cached (incorrect) version of the CLI.

To avoid this, we're going to require the root CLI package so it's _always_ getting the same package & ensure the package matches the invoking bin