### PR TITLE
🐛 Avoid recursion in generators due to no tail-call optimizations

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -100,14 +100,16 @@ export function waitFor(predicate, options) {
     ? { timeout: options } : (options || {});
 
   return generatePromise(async function* check(start, done) {
-    if (timeout && Date.now() - start >= timeout) {
-      throw new Error(`Timeout of ${timeout}ms exceeded.`);
-    } else if (!predicate()) {
-      yield new Promise(r => setTimeout(r, poll));
-      return yield* check(start);
-    } else if (idle && !done) {
-      yield new Promise(r => setTimeout(r, idle));
-      return yield* check(start, true);
+    while (true) {
+      if (timeout && Date.now() - start >= timeout) {
+        throw new Error(`Timeout of ${timeout}ms exceeded.`);
+      } else if (!predicate()) {
+        yield new Promise(r => setTimeout(r, poll, (done = false)));
+      } else if (idle && !done) {
+        yield new Promise(r => setTimeout(r, idle, (done = true)));
+      } else {
+        return;
+      }
     }
   }(Date.now()));
 }


### PR DESCRIPTION
## What is this?

The check within the `waitFor` util was originally created as a recursive function. With recent changes, the util was converted to make use of the cancelability of generators. However, generators cannot be tail-call optimized like the previous implementation was. This is due to technical reasons within V8 around the nature of how generator's `next()` function handles script evaluation.

Because the `waitFor` util polls and may run for a long time, the lack of tail-call optimization caused the call stack to continuously grow the longer the util took to resolve. Eventually this could/will result in call stack errors (#735).

This PR refactors the generator within the util to use a `while (true)` loop rather than a recursive `yield*`. The infinite loop is broken if the `predicate` passes at least once and at least one more time if `idle` is provided.