### PR TITLE
🐛 Update `bin/run` to not use an esm dynamic import

### DIFF
--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -6,8 +6,9 @@ if (parseInt(process.version.split('.')[0].substring(1), 10) < 12) {
   process.exit(1);
 }
 
-import('../dist/index.js').then(
-  async ({ checkForUpdate, percy }) => {
-    await checkForUpdate();
-    await percy(process.argv.slice(2));
-  });
+let { checkForUpdate, percy } = require('../dist/index.js');
+
+(async function() {
+  await checkForUpdate();
+  await percy(process.argv.slice(2));
+})();


### PR DESCRIPTION
## What is this?

Currently the `bin/run` file uses an ESM dynamic import. This wasn't something intended to ship _yet_ (especially since that file isn't touched by babel to transpile). Very soon we'll be going all in on ESM (which will require node 12.22+), but it shouldn't have slipped into the past two releases. This only impacts folks running a very old version of Node.