### PR TITLE
✨ Automatically handle json bodies in client request util

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -94,19 +94,17 @@ export class PercyClient {
   // Performs a GET request for an API endpoint with appropriate headers.
   get(path) {
     return request(`${this.apiUrl}/${path}`, {
-      method: 'GET',
-      headers: this.headers()
+      headers: this.headers(),
+      method: 'GET'
     });
   }
 
   // Performs a POST request to a JSON API endpoint with appropriate headers.
   post(path, body = {}) {
     return request(`${this.apiUrl}/${path}`, {
+      headers: this.headers({ 'Content-Type': 'application/vnd.api+json' }),
       method: 'POST',
-      body: JSON.stringify(body),
-      headers: this.headers({
-        'Content-Type': 'application/vnd.api+json'
-      })
+      body
     });
   }
 

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -358,7 +358,7 @@ export class Percy {
         if (typeof options === 'function') options = await options();
         await this.client.sendSnapshot(this.build.id, options);
       } catch (error) {
-        let failed = error.response?.status === 422 && (
+        let failed = error.response?.statusCode === 422 && (
           error.response.body.errors.find(e => (
             e.source?.pointer === '/data/attributes/build'
           )));


### PR DESCRIPTION
## What is this?

The client request util is used in various places internally. This PR adds a small feature to automatically stringify json bodies and add the appropriate `application/json` content-type header. 

One planned future use of this feature is within our own tests. As such, response headers were also added to request errors (along with renaming the error response status to match the response property name).