### PR TITLE
🐛 Add percy config mapping for cli-exec port flag

### DIFF
--- a/packages/cli-exec/src/common.js
+++ b/packages/cli-exec/src/common.js
@@ -2,6 +2,7 @@ export const flags = [{
   name: 'port',
   description: 'Local CLI server port',
   env: 'PERCY_SERVER_PORT',
+  percyrc: 'port',
   type: 'number',
   parse: Number,
   default: 5338,

--- a/packages/cli-exec/src/exec.js
+++ b/packages/cli-exec/src/exec.js
@@ -65,8 +65,8 @@ export const exec = command('exec', {
   }
 
   // provide SDKs with useful env vars
-  env.PERCY_SERVER_ADDRESS ||= percy?.address();
-  env.PERCY_LOGLEVEL ||= log.loglevel();
+  env.PERCY_SERVER_ADDRESS = percy?.address();
+  env.PERCY_LOGLEVEL = log.loglevel();
 
   // run the provided command
   log.info(`Running "${[command, ...args].join(' ')}"`);

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -149,4 +149,19 @@ describe('percy exec', () => {
       '[percy] Stopping percy...'
     );
   });
+
+  it('provides the child process with a percy server address env var', async () => {
+    await exec(['--port=1234', '--', 'node', '--eval', [
+      'require("@percy/client/dist/request")',
+      '.request(new URL("/percy/healthcheck", process.env.PERCY_SERVER_ADDRESS))',
+      '.catch(e => (console.error(e), process.exit(1)))'
+    ].join('')]);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      '[percy] Percy has started!',
+      jasmine.stringMatching('\\[percy] Running "node --eval '),
+      '[percy] Finalized build #1: https://percy.io/test/test/123'
+    ]);
+  });
 });

--- a/packages/cli-exec/test/ping.test.js
+++ b/packages/cli-exec/test/ping.test.js
@@ -23,10 +23,21 @@ describe('percy exec:ping', () => {
 
     await ping();
 
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual(['[percy] Percy is running']);
     expect(percyServer.requests).toEqual([['/percy/healthcheck']]);
+  });
+
+  it('can ping /percy/healthcheck at an alternate port', async () => {
+    percyServer = await createTestServer({
+      '/percy/healthcheck': () => [200, 'application/json', { success: true }]
+    }, 1234);
+
+    await ping(['--port=1234']);
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual(['[percy] Percy is running']);
+    expect(percyServer.requests).toEqual([['/percy/healthcheck']]);
   });
 
   it('logs an error when the endpoint errors', async () => {

--- a/packages/cli-exec/test/start.test.js
+++ b/packages/cli-exec/test/start.test.js
@@ -20,11 +20,19 @@ describe('percy exec:start', () => {
   });
 
   afterEach(async () => {
-    await stop();
+    // it's important that percy is still running or we terminate the test process
+    if (started) process.emit('SIGTERM');
+    await started;
   });
 
   it('starts a long-running percy process', async () => {
     let response = await request('http://localhost:5338/percy/healthcheck');
+    expect(response).toHaveProperty('success', true);
+  });
+
+  it('can start on an alternate port', async () => {
+    start(['--quiet', '--port=1234']);
+    let response = await request('http://localhost:1234/percy/healthcheck');
     expect(response).toHaveProperty('success', true);
   });
 

--- a/packages/cli-exec/test/stop.test.js
+++ b/packages/cli-exec/test/stop.test.js
@@ -38,6 +38,22 @@ describe('percy exec:stop', () => {
     expect(check).toEqual(2);
   });
 
+  it('can stop a server on another port', async () => {
+    percyServer = await createTestServer({
+      '/percy/stop': () => [200, 'application/json', { success: true }]
+    }, 1234);
+
+    await stop(['--port=1234']);
+
+    expect(percyServer.requests).toEqual([
+      ['/percy/stop'],
+      ['/percy/healthcheck']
+    ]);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual(['[percy] Percy has stopped']);
+  });
+
   it('logs when percy is disabled', async () => {
     process.env.PERCY_ENABLE = '0';
     await stop();


### PR DESCRIPTION
## What is this?

After CLI commands were migrated to the new `cli-command` framework, the `cli-exec` command's `--port` flag was inadvertently disconnected from where it was previously passed in. With the new framework, all that's needed is an extra property to appropriately set this option.

This PR also fixes env assignments for currently relevant vars. This shouldn't be an issue in practice, but was causing tests to pollute each other.

Will fix #786 