### PR TITLE
✨ Minor @percy/config improvements

### DIFF
--- a/packages/cli-command/src/command.js
+++ b/packages/cli-command/src/command.js
@@ -39,8 +39,8 @@ function withBuiltIns(definition) {
 
   // add percy specific built-in config options
   if (def.percy) {
-    def.config.schemas.unshift(...CoreConfig.schemas);
-    def.config.migrations.unshift(...CoreConfig.migrations);
+    def.config.schemas.unshift(CoreConfig.schemas);
+    def.config.migrations.unshift(CoreConfig.migrations);
   }
 
   return def;

--- a/packages/config/src/migrate.js
+++ b/packages/config/src/migrate.js
@@ -11,9 +11,9 @@ const migrations = new Map();
 // Register a migration function for the main config schema by default
 export function addMigration(migration, schema = '/config') {
   if (Array.isArray(migration)) {
-    // accept schema as the first item in a tuple
-    if (typeof migration[0] === 'string') [schema, ...migration] = migration;
     return migration.map(m => addMigration(m, schema));
+  } else if (typeof migration !== 'function') {
+    return Object.entries(migration).map(([s, m]) => addMigration(m, s));
   }
 
   if (!migrations.has(schema)) migrations.set(schema, []);
@@ -36,8 +36,9 @@ function defaultMigration(config, { set }) {
 // Migrate util for deprecated options
 function deprecate(config, log, path, options) {
   if (get(config, path) == null) return;
-  let { type, until: ver, map: to, alt, warn } = options;
+  let { type, until: ver, map: mapto, alt, warn } = options;
   let name = joinPropertyPath(path);
+  let to = joinPropertyPath(mapto);
 
   let message = 'The ' + [
     type ? `${type} option \`${name}\`` : `\`${name}\` option`,

--- a/packages/config/src/utils.js
+++ b/packages/config/src/utils.js
@@ -24,17 +24,17 @@ export function parsePropertyPath(path) {
   return isArray(path) ? path : path.split('.').reduce((full, part) => {
     return full.concat(part.split('[').reduce((f, p) => {
       if (p.endsWith(']')) p = p.slice(0, -1);
-      return f.concat(isArrayKey(p) ? parseInt(p, 10) : p);
+      return f.concat(isArrayKey(p) ? parseInt(p, 10) : (p || []));
     }, []));
   }, []);
 }
 
 // Join an array of path parts into a single path string
 export function joinPropertyPath(path) {
-  if (typeof path === 'string') return path;
-  let joined = path.map(k => isArrayKey(k) ? `[${k}]` : `.${k}`).join('');
-  if (joined.startsWith('.')) return joined.substr(1);
-  return joined;
+  path = !Array.isArray(path) ? path : path.filter(Boolean)
+    .map(k => isArrayKey(k) ? `[${k}]` : `.${k}`).join('');
+  while (path?.startsWith('.')) path = path.substr(1);
+  return path;
 }
 
 // Gets a value in the object at the path

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -256,7 +256,7 @@ export function snapshotMigration(config, util) {
 }
 
 // Grouped migrations for easier registration
-export const migrations = [
-  ['/config', configMigration],
-  ['/snapshot', snapshotMigration]
-];
+export const migrations = {
+  '/config': configMigration,
+  '/snapshot': snapshotMigration
+};


### PR DESCRIPTION
## What is this?

This PR implements a few `@percy/config` improvements which are needed for some soon-to-ship features to work properly.

- Use newer JSON Schema 2019 specification for validations.
- Refactor `getSchema` to respect new spec for schema inheritance.
- Hide some confusing errors as a result of deep schema references.
- Add validation message for new `unevaluatedProperties` spec.
- Handle parsing paths that having missing property names.
- When registering multiple migrations, accept an object instead of a reverse argument tuple.
- Normalize migration deprecation util mapping to allow easier migration composition.