### PR TITLE
✨ Use default widths instead of throwing an error when missing

### DIFF
--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -44,12 +44,6 @@ describe('Snapshot', () => {
       .toThrowError('Missing required URL for snapshot');
   });
 
-  it('errors when missing snapshot widths', () => {
-    percy.config.snapshot.widths = [];
-    expect(() => percy.snapshot({ url: 'http://localhost:8000' }))
-      .toThrowError('Missing required widths for snapshot');
-  });
-
   it('warns when missing additional snapshot names', async () => {
     percy.close(); // close queues so snapshots fail
 
@@ -146,6 +140,25 @@ describe('Snapshot', () => {
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
       '[percy] Encountered an error taking snapshot: test snapshot',
       '[percy] Error: Navigation failed: net::ERR_ABORTED'
+    ]));
+  });
+
+  it('handles missing snapshot widths', async () => {
+    let url = 'http://localhost:8000';
+    percy.loglevel('debug');
+
+    percy.config.snapshot.widths = [600];
+    await percy.snapshot({ url, widths: [] });
+
+    expect(logger.stderr).toEqual(jasmine.arrayContaining([
+      '[percy:core:snapshot] - widths: 600px'
+    ]));
+
+    percy.config.snapshot.widths = [];
+    await percy.snapshot({ url, widths: [] });
+
+    expect(logger.stderr).toEqual(jasmine.arrayContaining([
+      '[percy:core:snapshot] - widths: 375px, 1280px'
     ]));
   });
 


### PR DESCRIPTION
## What is this?

Currently, there is logic to produce a hard error when widths are missing from a snapshot. In reality, when widths are missing from a snapshot (even after invalid widths are scrubbed), the empty array is removed and the default Percy config widths are used. If the user provides empty config widths, they are also removed and the default ends up being used.

Having a hard error on missing widths also makes it difficult to reason about snapshot option overrides with upcoming features where options may or may not apply to a provided set of snapshots. This also raises the question as to why don't we produce hard errors for any other invalid options? Historically there has only ever been a hard error for missing snapshot URLs and widths.

This PR removes the hard error on missing widths while also making it clear that default widths will be used when missing other widths. In the future, we may want to explore throwing a hard error on _any_ invalid option so to not waste screenshot usage when accidentally making configuration mistakes.

This PR also adds logic to deduplicate widths just in case the same width is provided multiple times.