### PR TITLE
✨ Accept alternate core snapshot syntaxes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@ plugins:
   - babel
 rules:
   prefer-const: off
+  no-extra-parens: off
   no-unused-expressions: off
   babel/no-unused-expressions: warn
   import/no-extraneous-dependencies: error

--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -1,77 +1,22 @@
-import { snapshotSchema } from '@percy/core/dist/config';
-
-// Common schemas referenced by other schemas
-export const commonSchema = {
-  $id: '/snapshot/cli',
-  $refs: {
-    predicate: {
-      oneOf: [
-        { type: 'string' },
-        { instanceof: 'RegExp' },
-        { instanceof: 'Function' },
-        { type: 'array', items: { $ref: '#/$refs/predicate' } }
-      ]
-    }
-  }
-};
-
 // Config schema for static directories
 export const configSchema = {
   static: {
     type: 'object',
-    additionalProperties: false,
+    $ref: '/snapshot#/$defs/filter',
+    unevaluatedProperties: false,
     properties: {
-      baseUrl: {
-        type: 'string',
-        pattern: '^/',
-        errors: {
-          pattern: 'must start with a forward slash (/)'
-        }
-      },
-      include: {
-        $ref: '/snapshot/cli#/$refs/predicate'
-      },
-      exclude: {
-        $ref: '/snapshot/cli#/$refs/predicate'
-      },
-      cleanUrls: {
-        type: 'boolean',
-        default: false
-      },
-      rewrites: {
-        type: 'object',
-        normalize: false,
-        additionalProperties: { type: 'string' }
-      },
-      overrides: {
-        type: 'array',
-        items: {
-          type: 'object',
-          additionalProperties: false,
-          properties: {
-            include: { $ref: '/snapshot/cli#/$refs/predicate' },
-            exclude: { $ref: '/snapshot/cli#/$refs/predicate' },
-            // schemas have no concept of inheritance, but we can leverage JS for brevity
-            ...snapshotSchema.properties
-          }
-        }
-      }
+      baseUrl: { $ref: '/snapshot/server#/properties/baseUrl' },
+      cleanUrls: { $ref: '/snapshot/server#/properties/cleanUrls' },
+      rewrites: { $ref: '/snapshot/server#/properties/rewrites' },
+      overrides: { $ref: '/snapshot#/$defs/options' }
     }
   },
-
   sitemap: {
     type: 'object',
-    additionalProperties: false,
+    $ref: '/snapshot#/$defs/filter',
+    unevaluatedProperties: false,
     properties: {
-      include: {
-        $ref: '/snapshot/cli#/$refs/predicate'
-      },
-      exclude: {
-        $ref: '/snapshot/cli#/$refs/predicate'
-      },
-      overrides: {
-        $ref: '/config/static#/properties/overrides'
-      }
+      overrides: { $ref: '/snapshot#/$defs/options' }
     }
   }
 };
@@ -79,30 +24,10 @@ export const configSchema = {
 // Snapshots file schema
 export const snapshotsFileSchema = {
   $id: '/snapshot/file',
-  oneOf: [{
-    type: 'array',
-    items: {
-      oneOf: [
-        { $ref: '/snapshot' },
-        { type: 'string' }
-      ]
-    }
-  }, {
-    type: 'object',
-    required: ['snapshots'],
-    properties: {
-      baseUrl: {
-        type: 'string',
-        pattern: '^https?://',
-        errors: {
-          pattern: 'must include with a protocol and hostname'
-        }
-      },
-      include: { $ref: '/snapshot/cli#/$refs/predicate' },
-      exclude: { $ref: '/snapshot/cli#/$refs/predicate' },
-      snapshots: { $ref: '#/oneOf/0' }
-    }
-  }]
+  oneOf: [
+    { $ref: '/snapshot#/$defs/snapshots' },
+    { $ref: '/snapshot/list' }
+  ]
 };
 
 export function configMigration(config, util) {

--- a/packages/cli-snapshot/src/snapshot.js
+++ b/packages/cli-snapshot/src/snapshot.js
@@ -64,7 +64,6 @@ export const snapshot = command('snapshot', {
 
   config: {
     schemas: [
-      SnapshotConfig.commonSchema,
       SnapshotConfig.configSchema,
       SnapshotConfig.snapshotsFileSchema
     ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,8 @@
     "content-disposition": "^0.5.4",
     "cross-spawn": "^7.0.3",
     "extract-zip": "^2.0.1",
+    "fast-glob": "^3.2.11",
+    "micromatch": "^4.0.4",
     "mime-types": "^2.1.34",
     "path-to-regexp": "^6.2.0",
     "rimraf": "^3.0.2",

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -110,120 +110,217 @@ export const configSchema = {
 // Common per-snapshot capture options
 export const snapshotSchema = {
   $id: '/snapshot',
-  type: 'object',
-  required: ['url'],
-  additionalProperties: false,
-  $refs: {
+  $ref: '#/$defs/snapshot',
+  $defs: {
+    common: {
+      type: 'object',
+      properties: {
+        widths: { $ref: '/config/snapshot#/properties/widths' },
+        minHeight: { $ref: '/config/snapshot#/properties/minHeight' },
+        percyCSS: { $ref: '/config/snapshot#/properties/percyCSS' },
+        enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },
+        discovery: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            allowedHostnames: { $ref: '/config/discovery#/properties/allowedHostnames' },
+            requestHeaders: { $ref: '/config/discovery#/properties/requestHeaders' },
+            authorization: { $ref: '/config/discovery#/properties/authorization' },
+            disableCache: { $ref: '/config/discovery#/properties/disableCache' },
+            userAgent: { $ref: '/config/discovery#/properties/userAgent' }
+          }
+        }
+      }
+    },
     exec: {
       oneOf: [
         { oneOf: [{ type: 'string' }, { instanceof: 'Function' }] },
-        { type: 'array', items: { $ref: '#/$refs/exec/oneOf/0' } }
+        { type: 'array', items: { $ref: '/snapshot#/$defs/exec/oneOf/0' } }
       ]
-    }
-  },
-  properties: {
-    url: { type: 'string' },
-    name: { type: 'string' },
-    widths: { $ref: '/config/snapshot#/properties/widths' },
-    minHeight: { $ref: '/config/snapshot#/properties/minHeight' },
-    percyCSS: { $ref: '/config/snapshot#/properties/percyCSS' },
-    enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },
-    discovery: {
+    },
+    precapture: {
       type: 'object',
-      additionalProperties: false,
       properties: {
-        allowedHostnames: { $ref: '/config/discovery#/properties/allowedHostnames' },
-        requestHeaders: { $ref: '/config/discovery#/properties/requestHeaders' },
-        authorization: { $ref: '/config/discovery#/properties/authorization' },
-        disableCache: { $ref: '/config/discovery#/properties/disableCache' },
-        userAgent: { $ref: '/config/discovery#/properties/userAgent' }
+        waitForSelector: { type: 'string' },
+        waitForTimeout: { type: 'integer', minimum: 1, maximum: 30000 },
+        execute: {
+          oneOf: [{ $ref: '/snapshot#/$defs/exec' }, {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              afterNavigation: { $ref: '/snapshot#/$defs/exec' },
+              beforeResize: { $ref: '/snapshot#/$defs/exec' },
+              afterResize: { $ref: '/snapshot#/$defs/exec' },
+              beforeSnapshot: { $ref: '/snapshot#/$defs/exec' }
+            }
+          }]
+        }
       }
     },
-    waitForSelector: {
-      type: 'string'
-    },
-    waitForTimeout: {
-      type: 'integer',
-      minimum: 1,
-      maximum: 30000
-    },
-    execute: {
-      oneOf: [{
-        $ref: '/snapshot#/$refs/exec'
-      }, {
-        type: 'object',
-        additionalProperties: false,
-        properties: {
-          afterNavigation: { $ref: '/snapshot#/$refs/exec' },
-          beforeResize: { $ref: '/snapshot#/$refs/exec' },
-          afterResize: { $ref: '/snapshot#/$refs/exec' },
-          beforeSnapshot: { $ref: '/snapshot#/$refs/exec' }
+    capture: {
+      type: 'object',
+      allOf: [
+        { $ref: '/snapshot#/$defs/common' },
+        { $ref: '/snapshot#/$defs/precapture' }
+      ],
+      properties: {
+        name: { type: 'string' },
+        additionalSnapshots: {
+          type: 'array',
+          items: {
+            type: 'object',
+            $ref: '/snapshot#/$defs/precapture',
+            unevaluatedProperties: false,
+            oneOf: [{
+              required: ['name']
+            }, {
+              anyOf: [
+                { required: ['prefix'] },
+                { required: ['suffix'] }
+              ]
+            }],
+            properties: {
+              name: { type: 'string' },
+              prefix: { type: 'string' },
+              suffix: { type: 'string' }
+            },
+            errors: {
+              oneOf: ({ params }) => params.passingSchemas
+                ? 'prefix & suffix are ignored when a name is provided'
+                : 'missing required name, prefix, or suffix'
+            }
+          }
         }
+      }
+    },
+    predicate: {
+      oneOf: [{
+        oneOf: [
+          { type: 'string' },
+          { instanceof: 'RegExp' },
+          { instanceof: 'Function' }
+        ]
+      }, {
+        type: 'array',
+        items: { $ref: '/snapshot#/$defs/predicate/oneOf/0' }
       }]
     },
-    additionalSnapshots: {
+    filter: {
+      type: 'object',
+      properties: {
+        include: { $ref: '/snapshot#/$defs/predicate' },
+        exclude: { $ref: '/snapshot#/$defs/predicate' }
+      }
+    },
+    options: {
+      oneOf: [{
+        type: 'object',
+        unevaluatedProperties: false,
+        allOf: [
+          { $ref: '/snapshot#/$defs/filter' },
+          { $ref: '/snapshot#/$defs/capture' }
+        ]
+      }, {
+        type: 'array',
+        items: { $ref: '/snapshot#/$defs/options/oneOf/0' }
+      }]
+    },
+    snapshot: {
+      type: 'object',
+      required: ['url'],
+      $ref: '/snapshot#/$defs/capture',
+      unevaluatedProperties: false,
+      properties: {
+        url: { type: 'string' }
+      }
+    },
+    snapshots: {
       type: 'array',
       items: {
-        type: 'object',
-        additionalProperties: false,
-        oneOf: [{
-          required: ['name']
-        }, {
-          anyOf: [
-            { required: ['prefix'] },
-            { required: ['suffix'] }
-          ]
-        }],
-        properties: {
-          prefix: { type: 'string' },
-          suffix: { type: 'string' },
-          name: { $ref: '/snapshot#/properties/name' },
-          waitForTimeout: { $ref: '/snapshot#/properties/waitForTimeout' },
-          waitForSelector: { $ref: '/snapshot#/properties/waitForSelector' },
-          execute: { $ref: '/snapshot#/$refs/exec' }
+        oneOf: [
+          { $ref: '/snapshot#/$defs/snapshot' },
+          { $ref: '/snapshot#/$defs/snapshot/properties/url' }
+        ]
+      }
+    },
+    dom: {
+      type: 'object',
+      $id: '/snapshot/dom',
+      $ref: '/snapshot#/$defs/common',
+      required: ['url', 'domSnapshot'],
+      unevaluatedProperties: false,
+      properties: {
+        url: { type: 'string' },
+        name: { type: 'string' },
+        domSnapshot: { type: 'string' }
+      },
+      errors: {
+        unevaluatedProperties: e => (
+          snapshotSchema.$defs.precapture.properties[e.params.unevaluatedProperty] ||
+          snapshotSchema.$defs.capture.properties[e.params.unevaluatedProperty]
+        ) ? 'not accepted with DOM snapshots' : 'unknown property'
+      }
+    },
+    list: {
+      type: 'object',
+      $id: '/snapshot/list',
+      $ref: '/snapshot#/$defs/filter',
+      unevaluatedProperties: false,
+      required: ['snapshots'],
+      properties: {
+        baseUrl: {
+          type: 'string',
+          pattern: '^https?://',
+          errors: { pattern: 'must include a protocol and hostname' }
         },
-        errors: {
-          oneOf: ({ params }) => (
-            params.passingSchemas
-              ? 'prefix & suffix are ignored when a name is provided'
-              : 'missing required name, prefix, or suffix'
-          )
-        }
+        snapshots: { $ref: '/snapshot#/$defs/snapshots' },
+        options: { $ref: '/snapshot#/$defs/options' }
+      }
+    },
+    server: {
+      type: 'object',
+      $id: '/snapshot/server',
+      $ref: '/snapshot#/$defs/filter',
+      unevaluatedProperties: false,
+      required: ['serve'],
+      properties: {
+        serve: { type: 'string' },
+        port: { type: 'integer' },
+        baseUrl: {
+          type: 'string',
+          pattern: '^/',
+          errors: { pattern: 'must start with a forward slash (/)' }
+        },
+        cleanUrls: {
+          type: 'boolean'
+        },
+        rewrites: {
+          type: 'object',
+          normalize: false,
+          additionalProperties: { type: 'string' }
+        },
+        snapshots: { $ref: '/snapshot#/$defs/snapshots' },
+        options: { $ref: '/snapshot#/$defs/options' }
+      }
+    },
+    sitemap: {
+      type: 'object',
+      $id: '/snapshot/sitemap',
+      $ref: '/snapshot#/$defs/filter',
+      required: ['sitemap'],
+      unevaluatedProperties: false,
+      properties: {
+        sitemap: { type: 'string' },
+        options: { $ref: '/snapshot#/$defs/options' }
       }
     }
-  }
-};
-
-// Disallow capture options for dom snapshots
-export const snapshotDOMSchema = {
-  $id: '/snapshot/dom',
-  type: 'object',
-  additionalProperties: false,
-  required: [
-    'url',
-    'domSnapshot'
-  ],
-  disallowed: [
-    'additionalSnapshots',
-    'waitForTimeout',
-    'waitForSelector',
-    'execute'
-  ],
-  errors: {
-    disallowed: 'not accepted with DOM snapshots'
-  },
-  properties: {
-    domSnapshot: { type: 'string' },
-    // schemas have no concept of inheritance, but we can leverage JS for brevity
-    ...snapshotSchema.properties
   }
 };
 
 // Grouped schemas for easier registration
 export const schemas = [
   configSchema,
-  snapshotSchema,
-  snapshotDOMSchema
+  snapshotSchema
 ];
 
 // Config migrate function
@@ -246,17 +343,46 @@ export function configMigration(config, util) {
 }
 
 // Snapshot option migrate function
-export function snapshotMigration(config, util) {
+export function snapshotMigration(config, util, root = '') {
   let notice = { type: 'snapshot', until: '1.0.0', warn: true };
   // discovery options have moved
-  util.deprecate('authorization', { map: 'discovery.authorization', ...notice });
-  util.deprecate('requestHeaders', { map: 'discovery.requestHeaders', ...notice });
+  util.deprecate(`${root}.authorization`, { map: `${root}.discovery.authorization`, ...notice });
+  util.deprecate(`${root}.requestHeaders`, { map: `${root}.discovery.requestHeaders`, ...notice });
   // snapshots option was renamed
-  util.deprecate('snapshots', { map: 'additionalSnapshots', ...notice });
+  util.deprecate(`${root}.snapshots`, { map: `${root}.additionalSnapshots`, ...notice });
+}
+
+// Snapshot list options migrate function
+export function snapshotListMigration(config, util) {
+  if (config.snapshots) {
+    // migrate each snapshot options
+    for (let i in config.snapshots) {
+      if (typeof config.snapshots[i] !== 'string') {
+        snapshotMigration(config, util, `snapshots[${i}]`);
+      }
+    }
+  }
+
+  // overrides option was renamed
+  let notice = { type: 'snapshot', until: '1.0.0', warn: true };
+  util.deprecate('overrides', { map: 'options', ...notice });
+
+  // migrate options
+  if (Array.isArray(config.options)) {
+    for (let i in config.options) {
+      snapshotMigration(config, util, `options[${i}]`);
+    }
+  } else {
+    snapshotMigration(config, util, 'options');
+  }
 }
 
 // Grouped migrations for easier registration
 export const migrations = {
   '/config': configMigration,
-  '/snapshot': snapshotMigration
+  '/snapshot': snapshotMigration,
+  '/snapshot/dom': snapshotMigration,
+  '/snapshot/list': snapshotListMigration,
+  '/snapshot/server': snapshotListMigration,
+  '/snapshot/sitemap': snapshotListMigration
 };

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -476,7 +476,7 @@ describe('Discovery', () => {
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
       '[percy:core:page] Page created',
       '[percy:core:page] Resize page to 400x1024',
-      '[percy:core:page] Navigate to: http://localhost:8000',
+      '[percy:core:page] Navigate to: http://localhost:8000/',
       '[percy:core:discovery] Handling request: http://localhost:8000/',
       '[percy:core:discovery] - Serving root resource',
       '[percy:core:discovery] Handling request: http://localhost:8000/style.css',

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -261,7 +261,7 @@ describe('Percy', () => {
       expect(mockAPI.requests['/builds']).toBeUndefined();
 
       // process deferred uploads
-      percy.snapshot({ url: 'http://localhost:8000' });
+      percy.snapshot('http://localhost:8000');
       await percy.flush();
 
       expect(mockAPI.requests['/builds']).toBeDefined();
@@ -295,7 +295,7 @@ describe('Percy', () => {
       await percy.start();
 
       // take a snapshot for
-      percy.snapshot({ url: 'http://localhost:8000' });
+      percy.snapshot('http://localhost:8000');
       await percy.flush();
 
       expect(mockAPI.requests['/builds']).toBeDefined();
@@ -489,9 +489,9 @@ describe('Percy', () => {
     it('logs the total number of snapshots when dry-running', async () => {
       await reset({ dryRun: true });
 
-      percy.snapshot({ url: 'http://localhost:8000/one' });
-      percy.snapshot({ url: 'http://localhost:8000/two' });
-      percy.snapshot({ url: 'http://localhost:8000/three' });
+      percy.snapshot('http://localhost:8000/one');
+      percy.snapshot('http://localhost:8000/two');
+      percy.snapshot('http://localhost:8000/three');
 
       await expectAsync(percy.stop()).toBeResolved();
 
@@ -518,9 +518,9 @@ describe('Percy', () => {
 
     it('does not clean up if canceled while waiting on pending tasks', async () => {
       let snapshots = [
-        percy.snapshot({ url: 'http://localhost:8000/one' }),
-        percy.snapshot({ url: 'http://localhost:8000/two' }),
-        percy.snapshot({ url: 'http://localhost:8000/three' })
+        percy.snapshot('http://localhost:8000/one'),
+        percy.snapshot('http://localhost:8000/two'),
+        percy.snapshot('http://localhost:8000/three')
       ];
 
       // #stop returns a promise-like generator
@@ -560,7 +560,7 @@ describe('Percy', () => {
     it('does not error if the browser was never launched', async () => {
       await reset({ dryRun: true });
 
-      percy.snapshot({ url: 'http://localhost:8000' });
+      percy.snapshot('http://localhost:8000');
 
       expect(percy.browser.isConnected()).toBe(false);
       await expectAsync(percy.stop()).toBeResolved();

--- a/packages/core/test/snapshot-multiple.test.js
+++ b/packages/core/test/snapshot-multiple.test.js
@@ -1,0 +1,290 @@
+import quibble from 'quibble';
+import * as memfs from 'memfs';
+import { logger, createTestServer } from './helpers';
+import Percy from '../src';
+
+describe('Snapshot multiple', () => {
+  let percy, server, sitemap;
+
+  beforeEach(async () => {
+    logger.mock();
+
+    percy = await Percy.start({
+      token: 'PERCY_TOKEN',
+      snapshot: { widths: [1000] },
+      discovery: { concurrency: 1 },
+      clientInfo: 'client-info',
+      environmentInfo: 'env-info',
+      server: false
+    });
+
+    sitemap = ['/'];
+
+    server = await createTestServer({
+      default: () => [200, 'text/html', '<p>Test</p>'],
+      '/sitemap.xml': () => [200, 'application/xml', [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+        ...sitemap.map(p => `  <url><loc>http://localhost:8000${p}</loc></url>`),
+        '</urlset>'
+      ].join('\n')]
+    });
+
+    logger.reset(true);
+  });
+
+  afterEach(async () => {
+    await percy.stop(true);
+    await server?.close();
+  });
+
+  describe('list syntax', () => {
+    const baseUrl = 'http://localhost:8000';
+    const snapshots = [
+      { url: '/', name: 'home' },
+      '/about',
+      {
+        url: '/blog',
+        additionalSnapshots: [{
+          suffix: ' (page 2)',
+          execute: () => window.location += '?page=2'
+        }]
+      }
+    ];
+
+    it('snapshots an array of snapshots or urls', async () => {
+      // suppliment the base url for each snapshot
+      await percy.snapshot(snapshots.map(s => {
+        if (typeof s === 'string') s = baseUrl + s;
+        else s.url = baseUrl + s.url;
+        return s;
+      }));
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Snapshot taken: home',
+        '[percy] Snapshot taken: /about',
+        '[percy] Snapshot taken: /blog',
+        '[percy] Snapshot taken: /blog (page 2)'
+      ]));
+    });
+
+    it('can supply a base-url for all snapshots', async () => {
+      await percy.snapshot({ baseUrl, snapshots });
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Snapshot taken: home',
+        '[percy] Snapshot taken: /about',
+        '[percy] Snapshot taken: /blog',
+        '[percy] Snapshot taken: /blog (page 2)'
+      ]));
+    });
+
+    it('can apply additional options to snapshots', async () => {
+      percy.loglevel('debug');
+
+      await percy.snapshot({
+        baseUrl,
+        snapshots,
+        options: {
+          enableJavaScript: true
+        }
+      });
+
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy:core] Snapshot taken: home',
+        '[percy:core] Snapshot taken: /about',
+        '[percy:core] Snapshot taken: /blog',
+        '[percy:core] Snapshot taken: /blog (page 2)'
+      ]));
+      expect(logger.stderr).toEqual(jasmine.arrayContaining([
+        '[percy:core:snapshot] Handling snapshot: home',
+        '[percy:core:snapshot] - enableJavaScript: true',
+        '[percy:core:snapshot] Handling snapshot: /about',
+        '[percy:core:snapshot] - enableJavaScript: true',
+        '[percy:core:snapshot] Handling snapshot: /blog',
+        '[percy:core:snapshot] - enableJavaScript: true',
+        '[percy:core:snapshot] Additional snapshot: /blog (page 2)'
+      ]));
+    });
+
+    it('throws with invalid or missing URLs', () => {
+      expect(() => percy.snapshot([
+        'http://localhost:8000/valid',
+        'http://localhost:invalid/'
+      ])).toThrowError(
+        'Invalid snapshot URL: http://localhost:invalid/'
+      );
+
+      expect(() => percy.snapshot([
+        'http://localhost:8000/valid',
+        { name: 'missing' }
+      ])).toThrowError(
+        'Missing required URL for snapshot'
+      );
+    });
+  });
+
+  describe('sitemap syntax', () => {
+    it('snapshots urls from a sitemap url', async () => {
+      sitemap.push('/one', '/two');
+
+      await percy.snapshot('http://localhost:8000/sitemap.xml');
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Snapshot taken: /',
+        '[percy] Snapshot taken: /one',
+        '[percy] Snapshot taken: /two'
+      ]));
+    });
+
+    it('optionally filters sitemap urls to snapshot', async () => {
+      sitemap = Array.from({ length: 20 }, (_, i) => `/${i + 1}`);
+
+      await percy.snapshot({
+        sitemap: 'http://localhost:8000/sitemap.xml',
+        include: [/^\/[1-3]$/, '/1{0,1,2}', s => parseInt(s.name.substr(1)) >= 18],
+        exclude: '/0$/'
+      });
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Snapshot taken: /1',
+        '[percy] Snapshot taken: /2',
+        '[percy] Snapshot taken: /3',
+        '[percy] Snapshot taken: /11',
+        '[percy] Snapshot taken: /12',
+        '[percy] Snapshot taken: /18',
+        '[percy] Snapshot taken: /19'
+      ]));
+    });
+
+    it('can apply additional options to snapshots', async () => {
+      sitemap.push('/foo', '/bar');
+      percy.loglevel('debug');
+
+      await percy.snapshot({
+        sitemap: 'http://localhost:8000/sitemap.xml',
+        options: [
+          { enableJavaScript: true },
+          { include: '/bar', enableJavaScript: false }
+        ]
+      });
+
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy:core] Snapshot taken: /',
+        '[percy:core] Snapshot taken: /foo',
+        '[percy:core] Snapshot taken: /bar'
+      ]));
+      expect(logger.stderr).toEqual(jasmine.arrayContaining([
+        '[percy:core:snapshot] Handling snapshot: /',
+        '[percy:core:snapshot] - enableJavaScript: true',
+        '[percy:core:snapshot] Handling snapshot: /foo',
+        '[percy:core:snapshot] - enableJavaScript: true',
+        '[percy:core:snapshot] Handling snapshot: /bar',
+        '[percy:core:snapshot] - enableJavaScript: false'
+      ]));
+    });
+
+    it('throws when given an invalid sitemap', async () => {
+      await expectAsync(percy.snapshot({
+        sitemap: 'http://localhost:8000/not-a-sitemap'
+      })).toBeRejectedWithError(
+        'The sitemap must be an XML document, but the content-type was "text/html"'
+      );
+    });
+  });
+
+  describe('server syntax', () => {
+    beforeEach(() => {
+      quibble('fs', memfs.fs);
+
+      memfs.vol.fromJSON({
+        './public/index.html': 'index',
+        './public/about.html': 'about',
+        './public/blog/foo.html': 'foo',
+        './public/blog/bar.html': 'bar'
+      });
+    });
+
+    afterEach(() => {
+      quibble.reset(true);
+      memfs.vol.reset();
+    });
+
+    it('serves and snapshots a static directory', async () => {
+      await percy.snapshot({ serve: './public' });
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Snapshot taken: /index.html',
+        '[percy] Snapshot taken: /about.html',
+        '[percy] Snapshot taken: /blog/foo.html',
+        '[percy] Snapshot taken: /blog/bar.html'
+      ]));
+    });
+
+    it('accepts an array of specific snapshots', async () => {
+      await percy.snapshot({
+        serve: './public',
+        snapshots: ['/index.html', '/about.html']
+      });
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Snapshot taken: /index.html',
+        '[percy] Snapshot taken: /about.html'
+      ]));
+      expect(logger.stdout).not.toEqual(jasmine.arrayContaining([
+        '[percy] Snapshot taken: /blog/foo.html',
+        '[percy] Snapshot taken: /blog/bar.html'
+      ]));
+    });
+
+    it('optionally filters or rewrites snapshots', async () => {
+      await percy.snapshot({
+        serve: './public',
+        include: '/blog/*',
+        rewrites: {
+          '/blog/:name': '/blog/:name.html'
+        }
+      });
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Snapshot taken: /blog/foo',
+        '[percy] Snapshot taken: /blog/bar'
+      ]));
+    });
+
+    it('can apply additional options to snapshots', async () => {
+      percy.loglevel('debug');
+
+      await percy.snapshot({
+        serve: './public',
+        cleanUrls: true,
+        options: {
+          include: '/blog/*',
+          enableJavaScript: true
+        }
+      });
+
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy:core] Snapshot taken: /',
+        '[percy:core] Snapshot taken: /about',
+        '[percy:core] Snapshot taken: /blog/foo',
+        '[percy:core] Snapshot taken: /blog/bar'
+      ]));
+      expect(logger.stderr).toEqual(jasmine.arrayContaining([
+        '[percy:core:snapshot] Handling snapshot: /',
+        '[percy:core:snapshot] Handling snapshot: /about',
+        '[percy:core:snapshot] Handling snapshot: /blog/foo',
+        '[percy:core:snapshot] - enableJavaScript: true',
+        '[percy:core:snapshot] Handling snapshot: /blog/bar',
+        '[percy:core:snapshot] - enableJavaScript: true'
+      ]));
+    });
+  });
+});

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -70,17 +70,17 @@ describe('Snapshot', () => {
       waitForTimeout: 3,
       waitForSelector: 'd',
       execute: 'e',
-      additionalSnapshots: [
-        { prefix: 'f' }
-      ]
+      additionalSnapshots: [{ prefix: 'f' }],
+      foobar: 'baz'
     });
 
     expect(logger.stderr).toEqual([
       '[percy] Invalid snapshot options:',
-      '[percy] - additionalSnapshots: not accepted with DOM snapshots',
       '[percy] - waitForTimeout: not accepted with DOM snapshots',
       '[percy] - waitForSelector: not accepted with DOM snapshots',
-      '[percy] - execute: not accepted with DOM snapshots'
+      '[percy] - execute: not accepted with DOM snapshots',
+      '[percy] - additionalSnapshots: not accepted with DOM snapshots',
+      '[percy] - foobar: unknown property'
     ]);
   });
 
@@ -241,7 +241,7 @@ describe('Snapshot', () => {
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
       '[percy:core:snapshot] ---------',
       '[percy:core:snapshot] Handling snapshot: test snapshot',
-      '[percy:core:snapshot] - url: http://localhost:8000',
+      '[percy:core:snapshot] - url: http://localhost:8000/',
       '[percy:core:snapshot] - widths: 400px, 1200px',
       '[percy:core:snapshot] - minHeight: 1024px',
       '[percy:core:snapshot] - discovery.allowedHostnames: localhost, example.com',
@@ -283,7 +283,7 @@ describe('Snapshot', () => {
     ]);
   });
 
-  it('accepts multiple snapshots', async () => {
+  it('accepts multiple dom snapshots', async () => {
     await percy.snapshot([{
       url: 'http://localhost:8000/one',
       domSnapshot: testDOM

--- a/yarn.lock
+++ b/yarn.lock
@@ -3663,6 +3663,17 @@ fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
+fast-glob@^3.2.11:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -5344,6 +5355,14 @@ micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
+micromatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.2.3"
+
 mime-db@1.45.0:
   version "1.45.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
@@ -6202,7 +6221,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.3.0:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==


### PR DESCRIPTION
## What is this?

This PR makes use of the new static server capabilities within `@percy/core` (#781) and the updated config schema from `@percy/config` (#804) to allow the `snapshot()` method to accept several alternate syntaxes for taking snapshots.

The updated config work is necessary to allow validating options against several related schemas which all share commonly used properties. Before, these properties would need to be repeated for each schema. With the updated schema spec, these schemas can inherit from one another and better reference each other within nested properties.

The new internal static server is started and stopped around a group of snapshots when providing specific snapshot server options. This better couples static servers to core's own internals which will help prevent issues where an SDKs own server might be shut down prematurely before asset discovery is finished.

This new snapshot server feature can become a drop in replacement for the `@percy/cli-snapshot` static server, which also accepts static server options as well as variable snapshot options, including filtering. These additional options are also shared by `@percy/cli-snapshot`'s other two features: snapshot lists and sitemaps. Because of that, the remaining unshared option, specifically `sitemap`, was also made to be a supported core snapshot syntax.

### New syntaxes

The following syntaxes are now all supported by core's `percy.snapshot()` method:

`percy.snapshot(url|{url}|[...url|{url}])` — The current syntax mixed with a new shorthand syntax where a URL string can be used in place of an entire snapshot options object.

`percy.snapshot({snapshots:[...url|{url}]})` — An object containing a top-level `snapshots` array may be provided instead of providing an array of snapshots directly. This allows other useful top-level options, such as a `baseUrl` prepended to snapshot URLs missing their own, and an `options` object or array of objects that apply common snapshot options to one or more snapshots.

`percy.snapshot(sitemap|{sitemap})` — The new sitemap syntax accepts a sitemap URL ending in `.xml` or an object containing a top-level `sitemap` property. This syntax also accepts an `options` property just like the list syntax and additional `include`/`exclude` options to filter the sitemap.

`percy.snapshot({serve})` — The new server syntax accepts an object containing a top-level `serve` property, which should be a path to the static directory to serve. This syntax shares all of the list syntax options from above, with the only exception being the `baseUrl` option. The `baseUrl` option when used with the server syntax should **not** include a protocol or hostname since those are derived from the servers address. This new server syntax also accepts options from `@percy/cli-snapshot` such as `cleanUrls`, `rewrites`, `include`, and `exclude`.

[More details about the accepted options can be found in the updated README](https://github.com/percy/cli/blob/f5525221f4a3cf213e30910a451ce7ed75ba967b/packages/core/README.md#snapshotoptions).

### Next steps

Once this is merged, it could be safely release since the existing syntax did not change. However there is duplicated code in `@percy/cli-snapshot` to delete in a follow up PR which will also move it to fully leaning on these new core syntaxes.

The Gatsby and Storybook SDKs can also benefit from these changes since both of those SDKs start a static server for taking snapshots. While Storybook is a CLI plugin, and safely handles closing the server at the right time, Gatsby will majorly benefit from this as it currently has an issue closing it's server too early.