### PR TITLE
🐛 Fix core snapshot method compatibility with cli-snapshot command

### DIFF
--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import logger from '@percy/logger';
 import Server from './server';
 import pkg from '../package.json';
@@ -79,11 +80,11 @@ export function createStaticServer(options) {
     // reverse rewrites' src, dest, & order
     Object.entries(options?.rewrites ?? {})
       .reduce((acc, rw) => [rw.reverse(), ...acc], [])
-  ), (filename, rewrite) => new URL((
+  ), (filename, rewrite) => new URL(path.posix.join(baseUrl, (
     // cleanUrls will trim trailing .html/index.html from paths
-    !options?.cleanUrls ? rewrite(filename) : (
+    !options.cleanUrls ? rewrite(filename) : (
       rewrite(filename).replace(/(\/index)?\.html$/, ''))
-  ), server.address()));
+  )), server.address()));
 
   // include automatic sitemap route
   server.route('get', '/sitemap.xml', async (req, res) => {

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -238,11 +238,14 @@ export class Percy {
     if (!this.skipUploads && this.#uploads.size) {
       if (close) this.#uploads.close();
 
-      yield* this.#uploads.flush(s => {
-        // do not log a count when not closing or while creating a build
-        if (!close || this.#uploads.has('build/create')) return;
-        this.log.progress(`Uploading ${s} snapshot${s !== 1 ? 's' : ''}...`, !!s);
-      });
+      // prevent creating an empty build when deferred
+      if (!this.deferUploads || !this.#uploads.has('build/create') || this.#uploads.size > 1) {
+        yield* this.#uploads.flush(s => {
+          // do not log a count when not closing or while creating a build
+          if (!close || this.#uploads.has('build/create')) return;
+          this.log.progress(`Uploading ${s} snapshot${s !== 1 ? 's' : ''}...`, !!s);
+        });
+      }
     }
   }.bind(this)).canceled(() => {
     // reopen closed queues when canceled

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -372,14 +372,13 @@ export class Percy {
         if (!options.snapshots) options.sitemap = new URL('sitemap.xml', options.baseUrl).href;
       }
 
-      let snapshots = options.snapshots ||
+      let snapshots = mapSnapshotOptions((options.snapshots ||
         ('sitemap' in options && await getSitemapSnapshots(options)) ||
-        ('url' in options && [options]);
+        ('url' in options && [options])
+      ), options);
 
-      await Promise.all(mapSnapshotOptions(snapshots, options, (
-        snapshot => this._takeSnapshot(snapshot)
-      )));
-
+      if (!snapshots.length) throw new Error('No snapshots found');
+      await Promise.all(snapshots.map(s => this._takeSnapshot(s)));
       await server?.close();
     });
   }

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -75,16 +75,18 @@ export function snapshotMatches(snapshot, include, exclude) {
 }
 
 // Accepts an array of snapshots to filter and map with matching options.
-export function mapSnapshotOptions(snapshots, config, map) {
+export function mapSnapshotOptions(snapshots, config) {
+  if (!snapshots?.length) return [];
+
   // reduce options into a single function
   let applyOptions = [].concat(config?.options || [])
     .reduceRight((next, { include, exclude, ...opts }) => snap => next(
       // assign additional options to included snaphots
       snapshotMatches(snap, include, exclude) ? Object.assign(snap, opts) : snap
-    ), map);
+    ), s => s);
 
   // reduce snapshots with overrides
-  return [...snapshots].reduce((acc, snapshot) => {
+  return snapshots.reduce((acc, snapshot) => {
     // transform snapshot URL shorthand into an object
     if (typeof snapshot === 'string') snapshot = { url: snapshot };
 
@@ -157,7 +159,7 @@ export async function getSitemapSnapshots(options) {
     }
 
     // parse XML content into a list of URLs
-    let urls = body.match(/(?<=<loc>)(.*)(?=<\/loc>)/ig);
+    let urls = body.match(/(?<=<loc>)(.*)(?=<\/loc>)/ig) ?? [];
 
     // filter out duplicate URLs that differ by a trailing slash
     return urls.filter((url, i) => {

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -40,7 +40,9 @@ export function snapshotMatches(snapshot, include, exclude) {
     if (predicate && typeof predicate === 'string') {
       // snapshot name matches exactly or matches a glob
       let result = snapshot.name === predicate ||
-        micromatch.isMatch(snapshot.name, predicate);
+        micromatch.isMatch(snapshot.name, predicate, {
+          basename: !predicate.startsWith('/')
+        });
 
       // snapshot might match a string-based regexp pattern
       if (!result) {

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -290,16 +290,23 @@ describe('Percy', () => {
       // processing deferred uploads should not result in a new build
       await percy.flush();
       expect(mockAPI.requests['/builds']).toBeUndefined();
+    });
 
-      // start without canceling to verify it still works
-      await percy.start();
+    it('does not create an empty build when uploads are deferred', async () => {
+      percy = new Percy({ token: 'PERCY_TOKEN', deferUploads: true });
+      await expectAsync(percy.start()).toBeResolved();
+      expect(mockAPI.requests['/builds']).toBeUndefined();
 
-      // take a snapshot for
+      // flush queues without uploads
+      await percy.flush();
+
+      expect(mockAPI.requests['/builds']).toBeUndefined();
+
+      // flush a snapshot to create a build
       percy.snapshot('http://localhost:8000');
       await percy.flush();
 
       expect(mockAPI.requests['/builds']).toBeDefined();
-      expect(percy.readyState).toEqual(1);
     });
 
     it('does not create a build when uploads are skipped', async () => {

--- a/packages/core/test/snapshot-multiple.test.js
+++ b/packages/core/test/snapshot-multiple.test.js
@@ -195,6 +195,14 @@ describe('Snapshot multiple', () => {
         'The sitemap must be an XML document, but the content-type was "text/html"'
       );
     });
+
+    it('throws when a sitemap is empty', async () => {
+      sitemap = [];
+
+      await expectAsync(percy.snapshot({
+        sitemap: 'http://localhost:8000/sitemap.xml'
+      })).toBeRejectedWithError('No snapshots found');
+    });
   });
 
   describe('server syntax', () => {


### PR DESCRIPTION
## What is this?

Removing components of `@percy/cli-snapshot` and replacing them with the new `@percy/core` snapshot syntaxes revealed a couple of small gaps in implementation details.

- Static server snapshots, when missing a specific list of snapshot, will fallback to the sitemap of the static server, however it is currently missing any provided `baseUrl`. This is fixed by joining the `baseUrl` with `path.posix.join`.

- If a glob pattern for the new `include`/`exclude` options does not start with a leading slash, it has erratic matching behavior. This is made more predictable by only matching on the path basename when missing a leading slash.

- With default options, a build will be created on start and finalized on stop, even if a sitemap, static server, or invalid list of snapshot results in no snapshots being taken. When `deferUploads` is set, a build is not created until the queue is flushed, usually when core is stopping. However, an extra check is required to ensure empty builds are not created if no uploads are queued behind it.

- On the note of a sitemap, static server, or invalid list of snapshot resulting in no snapshots being taken: a new error was added to the snapshot method to alert of missing snapshots.