### PR TITLE
✨ Add sdk-utils waitForPercyIdle helper

### DIFF
--- a/packages/sdk-utils/src/index.js
+++ b/packages/sdk-utils/src/index.js
@@ -2,6 +2,7 @@ import logger from '@percy/logger';
 import percy from './percy-info';
 import request from './request';
 import isPercyEnabled from './percy-enabled';
+import waitForPercyIdle from './percy-idle';
 import fetchPercyDOM from './percy-dom';
 import postSnapshot from './post-snapshot';
 
@@ -13,6 +14,7 @@ export {
   percy,
   request,
   isPercyEnabled,
+  waitForPercyIdle,
   fetchPercyDOM,
   postSnapshot
 };

--- a/packages/sdk-utils/src/percy-idle.js
+++ b/packages/sdk-utils/src/percy-idle.js
@@ -1,0 +1,13 @@
+import request from './request';
+
+const RETRY_ERROR_CODES = ['ECONNRESET', 'ETIMEDOUT'];
+
+export async function waitForPercyIdle() {
+  try {
+    return !!(await request('/percy/idle'));
+  } catch (e) {
+    return RETRY_ERROR_CODES.includes(e.code) && waitForPercyIdle();
+  }
+}
+
+export default waitForPercyIdle;

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -126,6 +126,27 @@ describe('SDK Utils', () => {
     });
   });
 
+  describe('waitForPercyIdle()', () => {
+    let { waitForPercyIdle } = utils;
+
+    it('gets idle state from the CLI API idle endpoint', async () => {
+      await expectAsync(waitForPercyIdle()).toBeResolvedTo(true);
+      await expectAsync(helpers.getRequests()).toBeResolvedTo([['/percy/idle']]);
+    });
+
+    it('polls the CLI API idle endpoint on timeout', async () => {
+      spyOn(utils.request, 'fetch').and.callFake((...args) => {
+        return utils.request.fetch.calls.count() > 2
+          ? utils.request.fetch.and.originalFn(...args)
+          // eslint-disable-next-line prefer-promise-reject-errors
+          : Promise.reject({ code: 'ETIMEDOUT' });
+      });
+
+      await expectAsync(waitForPercyIdle()).toBeResolvedTo(true);
+      expect(utils.request.fetch).toHaveBeenCalledTimes(3);
+    });
+  });
+
   describe('fetchPercyDOM()', () => {
     let { fetchPercyDOM } = utils;
 

--- a/packages/sdk-utils/test/server.js
+++ b/packages/sdk-utils/test/server.js
@@ -50,7 +50,8 @@ function context() {
         { success: true, config: { snapshot: { widths: [1280] } } })],
       '/percy/config': ({ body }) => [200, 'application/json', (
         { success: true, config: body })],
-      '/percy/snapshot': () => [200, 'application/json', { success: true }]
+      '/percy/snapshot': () => [200, 'application/json', { success: true }],
+      '/percy/idle': () => [200, 'application/json', { success: true }]
     }, 5338);
 
     ctx.server.route((req, res, next) => {


### PR DESCRIPTION
## What is this?

When requesting the `/percy/idle` endpoint, if queued snapshots take longer to idle than the request timeout, the request will throw an error. This new `@percy/sdk-utils` helper will recursively call itself when the request times out, resulting in the ability to await on long running idle requests.

There is no logic for aborting the idle wait since the server should always eventually respond with a success or error. Even if the server hangs, killing it will result in a connection refused/disconnect error rather than a timeout. This new helper will always return true when idle, or false when a non-timeout error occurs (which will be logged by the CLI).