### PR TITLE
✨ Throw an error when a static server directory does not exist

### DIFF
--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -234,6 +234,8 @@ export class Server extends http.Server {
     if (!directory) [pathname, directory] = ['/', pathname];
 
     let root = path.resolve(directory);
+    if (!fs.existsSync(root)) throw new Error(`Not found: ${directory}`);
+
     let mountPattern = pathToRegexp(pathname, null, { end: false });
     let rewritePath = createRewriter(options?.rewrites, (pathname, rewrite) => {
       try {

--- a/packages/core/test/snapshot-multiple.test.js
+++ b/packages/core/test/snapshot-multiple.test.js
@@ -212,6 +212,11 @@ describe('Snapshot multiple', () => {
       });
     });
 
+    it('throws when the directory cannot be found', async () => {
+      await expectAsync(percy.snapshot({ serve: './output' }))
+        .toBeRejectedWithError('Not found: ./output');
+    });
+
     it('serves and snapshots a static directory', async () => {
       await percy.snapshot({ serve: './public' });
 


### PR DESCRIPTION
## What is this?

Performing this check when starting the static server will prevent us and other SDKs from having to do this check before creating a server at all. Without this error, all URLs will simply 404 since the files would not exist at the configured location.