### PR TITLE
✨ Allow alternate snapshot syntaxes to be cancelable

### DIFF
--- a/packages/cli-exec/src/exec.js
+++ b/packages/cli-exec/src/exec.js
@@ -56,7 +56,7 @@ export const exec = command('exec', {
     log.warn('Percy is disabled');
   } else {
     try {
-      yield* percy.start();
+      yield* percy.yield.start();
     } catch (error) {
       if (error.canceled) throw error;
       log.warn('Skipping visual tests');

--- a/packages/cli-exec/src/start.js
+++ b/packages/cli-exec/src/start.js
@@ -16,7 +16,7 @@ export const start = command('start', {
   if (!percy) exit(0, 'Percy is disabled');
 
   // start percy
-  yield* percy.start();
+  yield* percy.yield.start();
 
   try {
     // run until stopped or terminated

--- a/packages/cli-snapshot/src/snapshot.js
+++ b/packages/cli-snapshot/src/snapshot.js
@@ -97,9 +97,9 @@ export const snapshot = command('snapshot', {
       options = merge(percy.config.sitemap, config);
     }
 
-    yield* percy.start();
-    yield percy.snapshot(options);
-    yield* percy.stop();
+    yield* percy.yield.start();
+    yield* percy.yield.snapshot(options);
+    yield* percy.yield.stop();
   } catch (error) {
     await percy.stop(true);
     throw error;

--- a/packages/cli-upload/src/upload.js
+++ b/packages/cli-upload/src/upload.js
@@ -81,7 +81,7 @@ export const upload = command('upload', {
   percy.setConfig({ discovery: { concurrency: config.concurrency } });
 
   // do not launch a browser when starting
-  yield* percy.start({ browser: false });
+  yield* percy.yield.start({ browser: false });
 
   for (let filename of pathnames) {
     let file = path.parse(filename);
@@ -111,7 +111,7 @@ export const upload = command('upload', {
   }
 
   try {
-    yield* percy.stop();
+    yield* percy.yield.stop();
   } catch (error) {
     await percy.stop(true);
     throw error;

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -1,4 +1,5 @@
 import { logger, api, setupTest, createTestServer } from './helpers';
+import { generatePromise } from '../src/utils';
 import Percy from '../src';
 
 describe('Percy', () => {
@@ -279,8 +280,8 @@ describe('Percy', () => {
       spyOn(percy.browser, 'launch').and.callFake(() => sleep(10));
       spyOn(percy.server, 'listen').and.callFake(() => sleep(500));
 
-      // #start returns a promise-like generator
-      let starting = percy.start();
+      // #yield.start returns a generator
+      let starting = generatePromise(percy.yield.start());
       let started = starting.then();
 
       // wait until server.listen is called but before it finishes
@@ -534,8 +535,8 @@ describe('Percy', () => {
         percy.snapshot('http://localhost:8000/three')
       ];
 
-      // #stop returns a promise-like generator
-      let stopping = percy.stop();
+      // #yield.stop returns a generator
+      let stopping = generatePromise(percy.yield.stop());
       let stopped = stopping.then();
 
       // wait until the first snapshot is done before canceling

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -317,17 +317,17 @@ describe('Snapshot', () => {
   });
 
   it('handles the browser closing early', async () => {
-    spyOn(percy.browser, 'page').and.callThrough();
+    // close the browser after a page target is created
+    spyOn(percy.browser, 'send').and.callFake((...args) => {
+      let send = percy.browser.send.and.originalFn.apply(percy.browser, args);
+      if (args[0] === 'Target.createTarget') percy.browser.close();
+      return send;
+    });
 
-    let snap = percy.snapshot({
+    await percy.snapshot({
       name: 'test snapshot',
       url: 'http://localhost:8000'
     });
-
-    // wait until a page is requested
-    await waitFor(() => percy.browser.page.calls.any());
-    percy.browser.close();
-    await snap;
 
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
       '[percy] Encountered an error taking snapshot: test snapshot',


### PR DESCRIPTION
## What is this?

Amongst the new alternate snapshot syntaxes, the sitemap and serve options should be cancelable. Both should be cancelable either during URL gathering, or during snapshotting itself. Since all snapshots are queued immediately, relevant cancel code was moved into a dedicated method that is called for each snapshot when canceled.

The snapshot method is meant to be useable asynchronously. When providing missing or invalid snapshot URLs, it will throw immediately. Also calling the method without awaiting on it will queue snapshots regardless. With the current approach to cancelable methods, the `generatePromise` helper returns a promise-like generator that must be await on or yielded to in order to run. This would prevent synchronous snapshots from working as they would not automatically run.

The existing cancelable methods were refactored to be async generators with try-catches to handle cancelations. In the constructor, these methods are overridden to return promises and the original generator methods are moved to a new `.yield` property. This allows using `yield*` with `.yield.<method>` while preserving normal promise behavior of running without having to explicitly await.