### PR TITLE
✨ Allow a function to gather snapshots using alternate syntaxes

### DIFF
--- a/packages/core/test/snapshot-multiple.test.js
+++ b/packages/core/test/snapshot-multiple.test.js
@@ -107,6 +107,20 @@ describe('Snapshot multiple', () => {
       ]));
     });
 
+    it('can supply a function that returns an array of snapshots', async () => {
+      let getSnaps = () => [...snapshots, '/pricing'];
+      await percy.snapshot({ baseUrl, snapshots: getSnaps });
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Snapshot taken: home',
+        '[percy] Snapshot taken: /about',
+        '[percy] Snapshot taken: /blog',
+        '[percy] Snapshot taken: /blog (page 2)',
+        '[percy] Snapshot taken: /pricing'
+      ]));
+    });
+
     it('throws with invalid or missing URLs', () => {
       expect(() => percy.snapshot([
         'http://localhost:8000/valid',


### PR DESCRIPTION
## What is this?

A small improvement to the new snapshot syntaxes: functional snapshot gathering.

When using a syntax with the `snapshots: []` option, you can now provide a function to return a list of snapshots. This function will receive the `baseUrl` as its only argument. With the `serve` syntax, the `baseUrl` includes the server address allowing this function to scrape snapshots from alternate sources other than a sitemap.

For example, the Storybook SDK can collect story snapshots using this function. Similarly, if other component libraries allow access to an API which returns snapshots, this new option makes it extremely simple to integrate with Percy.