### PR TITLE
🐛 Insert serialized CSSOM `style` tag after CSSOM `ownerNode`

### DIFF
--- a/packages/dom/src/prepare-dom.js
+++ b/packages/dom/src/prepare-dom.js
@@ -5,7 +5,7 @@ function uid() {
 
 // Marks elements that are to be serialized later with a data attribute.
 export function prepareDOM(dom) {
-  for (let elem of dom.querySelectorAll('input, textarea, select, iframe, canvas, video')) {
+  for (let elem of dom.querySelectorAll('input, textarea, select, iframe, canvas, video, style')) {
     if (!elem.getAttribute('data-percy-element-id')) {
       elem.setAttribute('data-percy-element-id', uid());
     }

--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -10,13 +10,15 @@ export function serializeCSSOM(dom, clone) {
   for (let styleSheet of dom.styleSheets) {
     if (isCSSOM(styleSheet)) {
       let style = clone.createElement('style');
+      let styleId = styleSheet.ownerNode.getAttribute('data-percy-element-id');
+      let cloneOwnerNode = clone.querySelector(`[data-percy-element-id="${styleId}"]`);
 
       style.type = 'text/css';
       style.setAttribute('data-percy-cssom-serialized', 'true');
       style.innerHTML = Array.from(styleSheet.cssRules)
         .reduce((prev, cssRule) => prev + cssRule.cssText, '');
 
-      clone.head.appendChild(style);
+      cloneOwnerNode.parentNode.insertBefore(style, cloneOwnerNode.nextSibling);
     }
   }
 }

--- a/packages/dom/test/serialize-css.test.js
+++ b/packages/dom/test/serialize-css.test.js
@@ -20,8 +20,8 @@ describe('serializeCSSOM', () => {
     let $css = parseDOM(serializeDOM())('style');
 
     expect($css).toHaveSize(3);
-    expect($css[0].innerHTML).toBe('.box { height: 500px; width: 500px; background-color: green; }');
-    expect($css[0].getAttribute('data-percy-cssom-serialized')).toBeDefined();
+    expect($css[1].innerHTML).toBe('.box { height: 500px; width: 500px; background-color: green; }');
+    expect($css[1].getAttribute('data-percy-cssom-serialized')).toBeDefined();
     // style #2 (index 1) is the original injected style tag for `withCSSOM`
     expect($css[2].innerHTML).toBe('div { display: inline-block; }');
     expect($css[2].getAttribute('data-percy-cssom-serialized')).toBeNull();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5346,10 +5346,10 @@ mime-db@1.45.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
   integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
 
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+mime-db@1.51.0:
+  version "1.51.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
+  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
 mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.28"


### PR DESCRIPTION
## What is this? 

Currently when we serialize in memory CSS (CSSOM) we only append the serialized styles to the bottom the documents `<head>`. This can cause issues with the ordering of the CSS. In order to fix this we should append the serialized styles _right after_ the CSSOM's `<style>` tag. 