### PR TITLE
🐛 Wrap `serializeVideos` in try/catch to catch security errors

### DIFF
--- a/packages/dom/src/serialize-video.js
+++ b/packages/dom/src/serialize-video.js
@@ -9,10 +9,11 @@ export function serializeVideos(dom, clone) {
     let canvas = document.createElement('canvas');
     let width = canvas.width = video.videoWidth;
     let height = canvas.height = video.videoHeight;
+    let dataUrl;
 
     canvas.getContext('2d').drawImage(video, 0, 0, width, height);
+    try { dataUrl = canvas.toDataURL(); } catch {}
 
-    let dataUrl = canvas.toDataURL();
     // If the canvas produces a blank image, skip
     if (!dataUrl || dataUrl === 'data:,') continue;
 

--- a/packages/dom/test/serialize-videos.test.js
+++ b/packages/dom/test/serialize-videos.test.js
@@ -37,4 +37,15 @@ describe('serializeVideos', () => {
     $ = parseDOM(serializeDOM());
     expect($('#video')[0].getAttribute('poster')).toBe(null);
   });
+
+  it('does not hang serialization when there is an error thrown', () => {
+    withExample(`
+       <video src="//:0" id="video" />
+    `);
+
+    spyOn(window.HTMLCanvasElement.prototype, 'toDataURL').and.throwError(new Error('An error'));
+
+    $ = parseDOM(serializeDOM());
+    expect($('#video')[0].getAttribute('poster')).toBe(null);
+  });
 });


### PR DESCRIPTION
## What is this?

Sometimes it's not possible to serialize videos into poster due to security (`Tainted canvases may not be exported.`). Wrapping the `serializeVideos` function call in a try/catch will allow the DOM serialization to continue.

Will close #845 