### PR TITLE
🐛 Fix duplicate resource URL issues with `snapshot` method

### DIFF
--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -400,11 +400,13 @@ export async function* discoverSnapshotResources(percy, snapshot, callback) {
       for (let snap of allSnapshots) {
         // will wait for timeouts, selectors, and additional network activity
         let { url, dom } = yield page.snapshot({ enableJavaScript, ...snap });
-        resources.set(url, createRootResource(url, dom));
+        let root = createRootResource(url, dom);
+        // use the normalized root url to prevent duplicates
+        resources.set(root.url, root);
         // shallow merge with root snapshot options
         handleSnapshotResources({ ...snapshot, ...snap }, resources, callback);
         // remove the previously captured dom snapshot
-        resources.delete(url);
+        resources.delete(root.url);
       }
     }
 

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -155,6 +155,19 @@ describe('Snapshot', () => {
     ]));
   });
 
+  it('does not duplicate resources when sites redirect', async () => {
+    await percy.snapshot({
+      url: 'http://localhost:8000/',
+      execute() { window.history.pushState(null, null, '#/'); }
+    });
+
+    let resourceURLs = api.requests['/builds/123/snapshots'][0]
+      .body.data.relationships.resources.data.map(resource => resource.attributes['resource-url']);
+    let uniqueURLs = [...new Set(resourceURLs)];
+
+    expect(resourceURLs.length).toEqual(uniqueURLs.length);
+  });
+
   it('logs after taking the snapshot', async () => {
     await percy.snapshot({
       name: 'test snapshot',


### PR DESCRIPTION
## What is this?

The queue mapping was not using the normalized URL for the root resource. This meant if the URL included a hash or just a port it would send the same normalized URL twice (which the API will reject). 

Will fix #641 