### PR TITLE
🐛 Remove relative path from package files

### DIFF
--- a/packages/cli-build/package.json
+++ b/packages/cli-build/package.json
@@ -14,7 +14,7 @@
     "node": ">=14"
   },
   "files": [
-    "./dist"
+    "dist"
   ],
   "main": "./dist/index.js",
   "type": "module",

--- a/packages/cli-command/package.json
+++ b/packages/cli-command/package.json
@@ -11,7 +11,7 @@
     "access": "public"
   },
   "files": [
-    "./dist"
+    "dist"
   ],
   "engines": {
     "node": ">=14"

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -14,7 +14,7 @@
     "node": ">=14"
   },
   "files": [
-    "./dist"
+    "dist"
   ],
   "main": "./dist/index.js",
   "type": "module",

--- a/packages/cli-exec/package.json
+++ b/packages/cli-exec/package.json
@@ -14,7 +14,7 @@
     "node": ">=14"
   },
   "files": [
-    "./dist"
+    "dist"
   ],
   "main": "./dist/index.js",
   "type": "module",

--- a/packages/cli-snapshot/package.json
+++ b/packages/cli-snapshot/package.json
@@ -14,7 +14,7 @@
     "node": ">=14"
   },
   "files": [
-    "./dist"
+    "dist"
   ],
   "main": "./dist/index.js",
   "type": "module",

--- a/packages/cli-upload/package.json
+++ b/packages/cli-upload/package.json
@@ -14,7 +14,7 @@
     "node": ">=14"
   },
   "files": [
-    "./dist"
+    "dist"
   ],
   "main": "./dist/index.js",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,8 +11,8 @@
     "access": "public"
   },
   "files": [
-    "./bin",
-    "./dist"
+    "bin",
+    "dist"
   ],
   "engines": {
     "node": ">=14"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -14,8 +14,8 @@
     "node": ">=14"
   },
   "files": [
-    "./dist",
-    "./test/helpers.js"
+    "dist",
+    "test/helpers.js"
   ],
   "main": "./dist/index.js",
   "type": "module",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -14,8 +14,8 @@
     "node": ">=14"
   },
   "files": [
-    "./dist",
-    "./types/index.d.ts"
+    "dist",
+    "types/index.d.ts"
   ],
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,10 +14,10 @@
     "node": ">=14"
   },
   "files": [
-    "./dist",
-    "./post-install.js",
-    "./types/index.d.ts",
-    "./test/helpers/server.js"
+    "dist",
+    "post-install.js",
+    "types/index.d.ts",
+    "test/helpers/server.js"
   ],
   "main": "./dist/index.js",
   "types": "types/index.d.ts",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -14,7 +14,7 @@
     "node": ">=14"
   },
   "files": [
-    "./dist"
+    "dist"
   ],
   "main": "./dist/index.js",
   "type": "module",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -14,9 +14,9 @@
     "node": ">=14"
   },
   "files": [
-    "./dist",
-    "./test/helpers.js",
-    "./test/client.js"
+    "dist",
+    "test/helpers.js",
+    "test/client.js"
   ],
   "main": "./dist/index.js",
   "browser": "./dist/bundle.js",

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -14,10 +14,10 @@
     "node": ">=14"
   },
   "files": [
-    "./dist",
-    "./test/server.js",
-    "./test/client.js",
-    "./test/helpers.js"
+    "dist",
+    "test/server.js",
+    "test/client.js",
+    "test/helpers.js"
   ],
   "main": "./dist/index.js",
   "browser": "./dist/bundle.js",


### PR DESCRIPTION
## What is this?

The 1.0.0 release is botched because paths with leading dots cause yarn and npm to not properly package files. 🙃 