### PR TITLE
✅ Include all core test helpers in packaged files

### DIFF
--- a/packages/config/test/helpers.js
+++ b/packages/config/test/helpers.js
@@ -86,6 +86,7 @@ export function mockfs({
   installFakes(fs, mock);
 
   // allow tests access to the in-memory filesystem
+  fs.$bypass = bypass;
   fs.$vol = vol;
   return vol;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,10 +17,10 @@
     "dist",
     "post-install.js",
     "types/index.d.ts",
-    "test/helpers/server.js"
+    "test/helpers"
   ],
   "main": "./dist/index.js",
-  "types": "types/index.d.ts",
+  "types": "./types/index.d.ts",
   "type": "module",
   "exports": {
     ".": "./dist/index.js",


### PR DESCRIPTION
## What is this?

According to core's `exports`, packages should be able to access `test/helpers` however the `index.js` file is not included in the packaged files. This PR fixes this by including all test helpers in the packaged files.

Additionally, this PR adds a small feature to the filesystem test helper to allow tests access to the bypass list.