### PR TITLE
🐛 Audit package file exports

### DIFF
--- a/packages/cli-command/package.json
+++ b/packages/cli-command/package.json
@@ -11,7 +11,8 @@
     "access": "public"
   },
   "files": [
-    "dist"
+    "dist",
+    "test/helpers.js"
   ],
   "engines": {
     "node": ">=14"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -15,7 +15,8 @@
   },
   "files": [
     "dist",
-    "types/index.d.ts"
+    "types/index.d.ts",
+    "tests/helpers.js"
   ],
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -14,7 +14,8 @@
     "node": ">=14"
   },
   "files": [
-    "dist"
+    "dist",
+    "test/helpers.js"
   ],
   "main": "./dist/index.js",
   "type": "module",


### PR DESCRIPTION
## What is this?

Like #862, except I audited all package.json files. If a file is available in the `exports` field, it should also be included in the packaged files. 
