### PR TITLE
✅ More test adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ oclif.manifest.json
 .local-chromium
 packages/logger/test/client.js
 packages/sdk-utils/test/client.js
+packs

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "lerna run build --stream",
     "build:watch": "lerna run build --stream -- --watch",
+    "build:pack": "mkdir -p ./packs && lerna exec npm pack && mv ./packages/*/*.tgz ./packs",
     "bump-version": "lerna version --exact --no-git-tag-version --no-push",
     "chromium-revision": "./scripts/chromium-revision",
     "clean": "git clean -Xdf -e !node_modules -e !**/node_modules/**",

--- a/packages/cli/test/commands.test.js
+++ b/packages/cli/test/commands.test.js
@@ -5,9 +5,8 @@ import { importCommands } from '../src/commands.js';
 
 describe('CLI commands', () => {
   beforeEach(async () => {
-    await logger.mock();
-    logger.loglevel('debug');
-    mockfs({ $modules: true });
+    await logger.mock({ level: 'debug' });
+    await mockfs({ $modules: true });
   });
 
   describe('from node_modules', () => {
@@ -30,28 +29,28 @@ describe('CLI commands', () => {
     ];
 
     it('imports from dependencies', async () => {
-      mockModuleCommands(path.resolve('.'), mockCmds);
+      await mockModuleCommands(path.resolve('.'), mockCmds);
       await expectAsync(importCommands()).toBeResolvedTo(expectedCmds);
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([]);
     });
 
     it('imports from a parent directory', async () => {
-      mockModuleCommands(path.resolve('../..'), mockCmds);
+      await mockModuleCommands(path.resolve('../..'), mockCmds);
       await expectAsync(importCommands()).toBeResolvedTo(expectedCmds);
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([]);
     });
 
     it('imports from the current project', async () => {
-      mockModuleCommands(process.cwd(), mockCmds);
+      await mockModuleCommands(process.cwd(), mockCmds);
       await expectAsync(importCommands()).toBeResolvedTo(expectedCmds);
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([]);
     });
 
     it('automatically includes package information', async () => {
-      mockModuleCommands(path.resolve('.'), mockCmds);
+      await mockModuleCommands(path.resolve('.'), mockCmds);
       let cmds = await importCommands();
 
       expect(cmds[0].packageInformation.name).toEqual('@percy/cli-config');
@@ -96,7 +95,7 @@ describe('CLI commands', () => {
 
   describe('legacy support', () => {
     it('transforms oclif-like classes', async () => {
-      mockLegacyCommands(process.cwd(), {
+      await mockLegacyCommands(process.cwd(), {
         '@percy/cli-legacy': { name: 'a' },
         '@percy/cli-legacy-topic': { name: 'b', index: true },
         '@percy/cli-legacy-index': { name: 'c', topic: true }
@@ -125,7 +124,7 @@ describe('CLI commands', () => {
     it('runs oclif init hooks', async () => {
       let init = jasmine.createSpy('init');
 
-      mockLegacyCommands(process.cwd(), {
+      await mockLegacyCommands(process.cwd(), {
         'percy-cli-legacy': { name: 'test', init }
       });
 

--- a/packages/cli/test/helpers.js
+++ b/packages/cli/test/helpers.js
@@ -10,9 +10,9 @@ export function mockUpdateCache(data, createdAt = Date.now()) {
 }
 
 // Mocks the filesystem and require cache to simulate installed commands
-export function mockModuleCommands(atPath, cmdMocks) {
+export async function mockModuleCommands(atPath, cmdMocks) {
   let modulesPath = `${atPath}/node_modules`;
-  let vol = mockfs({ $modules: true, [modulesPath]: null });
+  let vol = await mockfs({ $modules: true, [modulesPath]: null });
   let write = (rel, str) => vol.fromJSON({ [`${modulesPath}/${rel}`]: str });
 
   // for coverage
@@ -57,7 +57,7 @@ export async function mockPnpCommands(atPath, cmdMocks) {
   findPackageLocator.withArgs(projectInfo.packageLocation).and.returnValue(projectLoc);
   getPackageInformation.withArgs(projectLoc).and.returnValue(projectInfo);
 
-  let vol = mockfs({ $modules: true });
+  let vol = await mockfs({ $modules: true });
   let pnpPath = path.join('/.yarn/berry/cache');
   let write = (fp, str) => vol.fromJSON({ [`${pnpPath}/${fp}`]: str });
 
@@ -80,9 +80,9 @@ export async function mockPnpCommands(atPath, cmdMocks) {
 }
 
 // Mocks the filesystem and require cache to simulate installed legacy commands
-export function mockLegacyCommands(atPath, cmdMocks) {
+export async function mockLegacyCommands(atPath, cmdMocks) {
   let modulesPath = `${atPath}/node_modules`;
-  let vol = mockfs({ $modules: true, [modulesPath]: null });
+  let vol = await mockfs({ $modules: true, [modulesPath]: null });
   let write = (fp, str) => vol.fromJSON({ [`${modulesPath}/${fp}`]: str });
 
   for (let [pkgName, cmdMock] of Object.entries(cmdMocks)) {

--- a/packages/cli/test/update.test.js
+++ b/packages/cli/test/update.test.js
@@ -7,7 +7,7 @@ describe('CLI update check', () => {
 
   beforeEach(async () => {
     let pkg = { name: '@percy/cli', version: '1.0.0' };
-    mockfs({ './package.json': JSON.stringify(pkg) });
+    await mockfs({ './package.json': JSON.stringify(pkg) });
     ghAPI = await mockRequests('https://api.github.com');
     await logger.mock();
   });

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -16,7 +16,7 @@
   "files": [
     "dist",
     "types/index.d.ts",
-    "tests/helpers.js"
+    "test/helpers.js"
   ],
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -4,9 +4,9 @@ import PercyConfig from '@percy/config';
 
 describe('PercyConfig', () => {
   beforeEach(async () => {
+    await resetPercyConfig(true);
     await logger.mock();
-    resetPercyConfig(true);
-    mockfs();
+    await mockfs();
 
     PercyConfig.addSchema({
       test: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,8 @@
     "./utils": "./dist/utils.js",
     "./config": "./dist/config.js",
     "./install": "./dist/install.js",
-    "./test/helpers": "./test/helpers/index.js"
+    "./test/helpers": "./test/helpers/index.js",
+    "./test/helpers/server": "./test/helpers/server.js"
   },
   "scripts": {
     "build": "node ../../scripts/build",

--- a/packages/core/test/helpers/index.js
+++ b/packages/core/test/helpers/index.js
@@ -22,10 +22,10 @@ export async function setupTest({
   loggerTTY,
   apiDelay
 } = {}) {
-  await logger.mock({ isTTY: loggerTTY });
   await api.mock({ delay: apiDelay });
-  resetPercyConfig(resetConfig);
-  mockfs(filesystem);
+  await logger.mock({ isTTY: loggerTTY });
+  await resetPercyConfig(resetConfig);
+  await mockfs(filesystem);
 }
 
 export * from '@percy/client/test/helpers';

--- a/packages/core/test/helpers/server.js
+++ b/packages/core/test/helpers/server.js
@@ -1,4 +1,4 @@
-// aliased to src for coverage during tests without needing to compile this file
+// aliased to src during tests
 import Server from '../../dist/server.js';
 
 export function createTestServer({ default: defaultReply, ...replies }, port = 8000) {

--- a/packages/core/test/unit/install.test.js
+++ b/packages/core/test/unit/install.test.js
@@ -11,7 +11,7 @@ describe('Unit / Install', () => {
 
   beforeEach(async () => {
     await logger.mock({ isTTY: true });
-    mockfs();
+    await mockfs();
 
     // mock a fake download api
     dl = await mockRequests('https://fake-download.org/archive.zip');

--- a/packages/core/test/unit/server.test.js
+++ b/packages/core/test/unit/server.test.js
@@ -9,9 +9,9 @@ describe('Unit / Server', () => {
     return request(new URL(path, server.address()), ...args);
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     server = new Server({ port: 8000 });
-    mockfs();
+    await mockfs();
   });
 
   afterEach(async () => {

--- a/packages/logger/test/helpers.js
+++ b/packages/logger/test/helpers.js
@@ -46,6 +46,10 @@ const helpers = {
   async mock(options = {}) {
     helpers.reset();
 
+    if (options.level) {
+      loglevel(options.level);
+    }
+
     if (process.env.__PERCY_BROWSERIFIED__) {
       spy(Logger.prototype, 'write', function(lvl, msg) {
         let stdio = lvl === 'info' ? 'stdout' : 'stderr';

--- a/packages/sdk-utils/test/server.js
+++ b/packages/sdk-utils/test/server.js
@@ -4,7 +4,7 @@ import path from 'path';
 
 // create a testing context for mocking the local percy server and a local testing site
 export async function context() {
-  let { createTestServer } = await import('@percy/core/test/helpers');
+  let { createTestServer } = await import('@percy/core/test/helpers/server');
 
   let ctx = {
     async call(path, ...args) {


### PR DESCRIPTION
## What is this?

Besides misspelling a file in the last PR, we've been running into issue with package manager's `pack` output. This PR fixes the misspelling and adds a command to aid in packing up unreleased packages for testing.

This PR also changes config test helpers to lazily import their required deps. This makes it so packages can import these helpers without installing those deps. They will only need to be installed if one of the helpers that requires it is used.

Along with this import change, core exports were updated to allow import `test/helpers/server` directly rather than through the main `test/helpers` entry. This makes it so the sdk-utils test helper does not end up incidentally importing config and client helpers when it doesn't need them.