### PR TITLE
🐛 Core snapshot validation bug fixes

### DIFF
--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -158,8 +158,7 @@ function shouldHideError(key, path, error) {
   let { parentSchema, keyword, schemaPath } = error;
 
   return !(parentSchema.error || parentSchema.errors?.[keyword]) && (
-    HIDE_NESTED_KEYWORDS.some(k => schemaPath.includes(`/${k}`)) ||
-      getSchema(key, path)[path.length] !== parentSchema
+    HIDE_NESTED_KEYWORDS.some(k => schemaPath.includes(`/${k}`))
   );
 }
 

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -158,6 +158,7 @@ export function validateSnapshotOptions(options) {
 
   // add back snapshots before validating and scrubbing; function snapshots are validated later
   if (snapshots) migrated.snapshots = typeof snapshots === 'function' ? [] : snapshots;
+  else if (!isSnapshot && options.snapshots) migrated.snapshots = [];
   let errors = PercyConfig.validate(migrated, schema);
 
   if (errors) {

--- a/packages/core/test/snapshot-multiple.test.js
+++ b/packages/core/test/snapshot-multiple.test.js
@@ -136,6 +136,15 @@ describe('Snapshot multiple', () => {
         'Missing required URL for snapshot'
       );
     });
+
+    it('rejects when missing snapshots', async () => {
+      await expectAsync(
+        percy.snapshot({ baseUrl, snapshots: () => [] })
+      ).toBeRejectedWithError('No snapshots found');
+
+      expect(logger.stdout).toEqual([]);
+      expect(logger.stderr).toEqual([]);
+    });
   });
 
   describe('sitemap syntax', () => {


### PR DESCRIPTION
## What is this?

This PR fixes two small bugs related to snapshot options validation.

1. **Do not pre-scrub empty snapshot lists.** When pre-scrubbed, empty lists are removed and cause warnings due to the missing property. By adding back an empty array when needed, the incorrect validate warning no longer occurs.

2. **Remove method of validation error suppression.** Before schemas could be properly inherited, a check would ensure that errors bubbled from the correct schema. Now with inheritance, errors can bubble from related schemas as well.