### PR TITLE
✨@percy/config util improvements

### DIFF
--- a/packages/config/src/utils/merge.js
+++ b/packages/config/src/utils/merge.js
@@ -90,15 +90,17 @@ export function map(object, from, to, transform = v => v) {
 }
 
 // Steps through an object's properties calling the function with the path and value of each
-function walk(object, fn, path = []) {
+function walk(object, fn, path = [], visited = new Set()) {
   if (path.length && fn([...path], object) === false) return;
+  if (visited.has(object)) return;
+  visited.add(object);
 
   if (object != null && typeof object === 'object') {
     let isArrayObject = isArray(object);
 
     for (let [key, value] of entries(object)) {
       if (isArrayObject) key = parseInt(key, 10);
-      walk(value, fn, [...path, key]);
+      walk(value, fn, [...path, key], new Set(visited));
     }
   }
 }

--- a/packages/config/src/utils/normalize.js
+++ b/packages/config/src/utils/normalize.js
@@ -40,9 +40,14 @@ export function normalize(object, options) {
   if (typeof options === 'string') options = { schema: options };
   let keycase = options?.kebab ? kebabcase : camelcase;
 
-  return merge([object, options?.overrides], path => {
+  return merge([object, options?.overrides], (path, value) => {
     let schemas = getSchema(options?.schema, path.map(camelcase));
-    let skip = schemas.shift()?.normalize === false;
+    let skip = schemas.shift()?.normalize === false || options?.skip?.(path, value);
+
+    // skip normalizing paths of class instances
+    if (!skip && typeof value === 'object' && value?.constructor) {
+      skip = Object.getPrototypeOf(value) !== Object.prototype;
+    }
 
     path = path.map((k, i) => {
       if (skip) return k;

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -919,6 +919,14 @@ describe('PercyConfig', () => {
       });
     });
 
+    it('removes circular references', () => {
+      let foo = { bar: 'baz' };
+      foo.foo = foo;
+
+      expect(PercyConfig.normalize(foo))
+        .toEqual({ bar: 'baz' });
+    });
+
     it('does not remove all empty "objects"', () => {
       let config = {
         regex: /foobar/,

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -969,7 +969,17 @@ describe('PercyConfig', () => {
       });
     });
 
-    it('ignores normalizing properties as determined by their schema', () => {
+    it('skips normalizing properties of class instances', () => {
+      expect(PercyConfig.normalize({
+        inst: new (class { 'don_t-doThis' = 'plz' })(),
+        'why_mix-case': 'no'
+      })).toEqual({
+        inst: jasmine.objectContaining({ 'don_t-doThis': 'plz' }),
+        whyMixCase: 'no'
+      });
+    });
+
+    it('skips normalizing properties as determined by their schema', () => {
       // this schema is purposefully complex to generate better coverage
       PercyConfig.addSchema({
         $id: '/test',
@@ -1044,6 +1054,18 @@ describe('PercyConfig', () => {
           [true, { quxFour: 8 }],
           'xyzzy'
         ]
+      });
+    });
+
+    it('skips normalizing properties when skip returns true', () => {
+      expect(PercyConfig.normalize({
+        'fix-this_property': 1,
+        'skip-this_property': 2
+      }, {
+        skip: path => path[0].startsWith('skip')
+      })).toEqual({
+        fixThisProperty: 1,
+        'skip-this_property': 2
       });
     });
   });


### PR DESCRIPTION
## What is this?

This PR allows the normalization config util to accept a custom `skip` option and also ensures normalization is always skipped for class instance properties.

Also, to avoid infinite recursion when merging objects with circular references, such objects are ignored completely during a merge. If we absolutely need to handle creating circular references in the future, we might need to refactor the current merge strategy.