### PR TITLE
✨ Autoload CLI plugin from the current working directory

### DIFF
--- a/packages/cli/src/commands.js
+++ b/packages/cli/src/commands.js
@@ -105,6 +105,7 @@ export async function importCommands() {
     // find any current project dependencies
     process.cwd()
   ]), async (roots, dir) => {
+    if (fs.existsSync(path.join(dir, 'package.json'))) roots.push(dir);
     roots.push(...await findModulePackages(dir));
     roots.push(...await findPnpPackages(dir));
     return roots;

--- a/packages/cli/test/commands.test.js
+++ b/packages/cli/test/commands.test.js
@@ -9,6 +9,20 @@ describe('CLI commands', () => {
     await mockfs({ $modules: true });
   });
 
+  describe('from a project', () => {
+    it('imports the project command', async () => {
+      fs.writeFileSync('command.js', 'module.exports.name = "foobar"');
+      fs.writeFileSync('package.json', '{ "@percy/cli": { "commands": ["./command.js"] } }');
+
+      await expectAsync(importCommands()).toBeResolvedTo([
+        jasmine.objectContaining({ name: 'foobar' })
+      ]);
+
+      expect(logger.stdout).toEqual([]);
+      expect(logger.stderr).toEqual([]);
+    });
+  });
+
   describe('from node_modules', () => {
     const mockCmds = {
       '@percy/cli-exec': { name: 'exec' },


### PR DESCRIPTION
## What is this?

When working on CLI plugins, like the Storybook SDK, it can be useful to be able to manually test the plugin without releasing it or linking it in another project. This PR adds package.json detection in the current directory so the `percy` command can now autoload a CLI plugin the plugin's own directory.