### PR TITLE
🐛 Check for alternate casing when determining dom snapshot syntax

### DIFF
--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -128,25 +128,18 @@ export async function gatherSnapshots(percy, options) {
 // properties. Eagerly throws an error when missing a URL for any snapshot, and warns about all
 // other invalid options which are also scrubbed from the returned migrated options.
 export function validateSnapshotOptions(options) {
-  let schema;
-
   // decide which schema to validate against
-  if ('domSnapshot' in options) {
-    schema = '/snapshot/dom';
-  } else if ('url' in options) {
-    schema = '/snapshot';
-  } else if ('sitemap' in options) {
-    schema = '/snapshot/sitemap';
-  } else if ('serve' in options) {
-    schema = '/snapshot/server';
-  } else if ('snapshots' in options) {
-    schema = '/snapshot/list';
-  } else {
-    schema = '/snapshot';
-  }
+  let schema = (
+    (['domSnapshot', 'dom-snapshot', 'dom_snapshot']
+      .some(k => k in options) && '/snapshot/dom') ||
+    ('url' in options && '/snapshot') ||
+    ('sitemap' in options && '/snapshot/sitemap') ||
+    ('serve' in options && '/snapshot/server') ||
+    ('snapshots' in options && '/snapshot/list') ||
+    ('/snapshot'));
 
   let {
-    // migrate and remove certain properties from validating
+    // normalize, migrate, and remove certain properties from validating
     clientInfo, environmentInfo, snapshots, ...migrated
   } = PercyConfig.migrate(options, schema);
 

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -306,13 +306,17 @@ describe('Snapshot', () => {
       domSnapshot: testDOM
     }, {
       url: 'http://localhost:8000/two',
-      domSnapshot: testDOM
+      dom_snapshot: testDOM
+    }, {
+      url: 'http://localhost:8000/three',
+      'dom-snapshot': testDOM
     }]);
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
       '[percy] Snapshot taken: /one',
-      '[percy] Snapshot taken: /two'
+      '[percy] Snapshot taken: /two',
+      '[percy] Snapshot taken: /three'
     ]);
   });
 


### PR DESCRIPTION
## What is this?

When alternate snapshot syntaxes were introduced, the validation schema is determined by checking for specific snapshot options. For DOM snapshots, we check for the `domSnapshot` option. However, property normalization is based on the determined schema (such as not normalizing headers for example). Therefore, when determining which schema to use, the options have yet to be normalized. For all other syntaxes, this is no problem. For DOM snapshots however, the accepted property can be either `domSnapshot`, `dom-snapshot`, or `dom_snapshot` (as seen [here in the capybara SDK](https://github.com/percy/percy-capybara/blob/master/lib/percy/capybara.rb#L31)).

This PR updates the schema check to account for these possible combinations of dom snapshot properties. A relevant test was also updated to make sure this does not regress again in the future.