### PR TITLE
🐛 Make config normalize skip option behave as expected

### DIFF
--- a/packages/config/src/utils/normalize.js
+++ b/packages/config/src/utils/normalize.js
@@ -42,20 +42,21 @@ export function normalize(object, options) {
 
   return merge([object, options?.overrides], (path, value) => {
     let schemas = getSchema(options?.schema, path.map(camelcase));
-    let skip = schemas.shift()?.normalize === false || options?.skip?.(path, value);
+    let skip = schemas.shift()?.normalize === false;
+    let mapped = [];
 
     // skip normalizing paths of class instances
     if (!skip && typeof value === 'object' && value?.constructor) {
       skip = Object.getPrototypeOf(value) !== Object.prototype;
     }
 
-    path = path.map((k, i) => {
-      if (skip) return k;
+    for (let [i, k] of path.entries()) {
+      skip ||= options?.skip?.(mapped.concat(k));
+      mapped.push(skip ? k : keycase(k));
       skip ||= schemas[i]?.normalize === false;
-      return keycase(k);
-    });
+    }
 
-    return [path];
+    return [mapped];
   });
 }
 


### PR DESCRIPTION
## What is this?

The `@percy/config` util, `normalize`, recent received a `skip` option. However the option was implemented to skip all or nothing; i.e. completely skipping normalizing higher level keys if a lower level key was intended to be skipped. 

By moving the skip check to within the key map loop during normalization, it allows the opportunity to skip any one specific key within the value's key-path array.