### PR TITLE
Modify cloneNode to handle shadow dom.

### DIFF
--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -5,6 +5,8 @@ import serializeCSSOM from './serialize-cssom';
 import serializeCanvas from './serialize-canvas';
 import serializeVideos from './serialize-video';
 
+import { cloneNodeAndShadow, customOuterHTML } from './wc-clone';
+
 // Returns a copy or new doctype for a document.
 function doctype(dom) {
   let { name = 'html', publicId = '', systemId = '' } = dom?.doctype ?? {};
@@ -32,7 +34,7 @@ export function serializeDOM(options) {
 
   prepareDOM(dom);
 
-  let clone = dom.cloneNode(true);
+  let clone = cloneNodeAndShadow(dom);
   serializeInputs(dom, clone);
   serializeFrames(dom, clone, { enableJavaScript });
   serializeVideos(dom, clone);
@@ -52,7 +54,7 @@ export function serializeDOM(options) {
     }
   }
 
-  return doctype(dom) + doc.outerHTML;
+  return doctype(dom) + customOuterHTML(doc);
 }
 
 export default serializeDOM;

--- a/packages/dom/src/wc-clone.js
+++ b/packages/dom/src/wc-clone.js
@@ -1,0 +1,64 @@
+/**
+ * Custom deep clone function that replaces Percy's current clone behavior.
+ * This enables us to capture shadow DOM in snapshots. It takes advantage of `attachShadow`'s mode option set to open 
+ * https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#parameters
+ */
+const deepClone = host => {
+  let cloneNode = (node, parent) => {
+    let walkTree = (nextn, nextp) => {
+      while (nextn) {
+        cloneNode(nextn, nextp);
+        nextn = nextn.nextSibling;
+      }
+    };
+
+    let clone = node.cloneNode();
+    parent.appendChild(clone);
+
+    if (node.shadowRoot) {
+      if (clone.shadowRoot) {
+        // it may be set up in a custom element's constructor
+        clone.shadowRoot.innerHTML = '';
+      } else {
+        clone.attachShadow({
+          mode: 'open'
+        });
+      }
+
+      for (let sheet of node.shadowRoot.adoptedStyleSheets) {
+        let cssText = Array.from(sheet.rules).map(rule => rule.cssText).join('\n');
+        let style = document.createElement('style');
+        style.appendChild(document.createTextNode(cssText));
+        clone.shadowRoot.prepend(style);
+      }
+    }
+
+    if (node.shadowRoot) {
+      walkTree(node.shadowRoot.firstChild, clone.shadowRoot);
+    }
+
+    walkTree(node.firstChild, clone);
+  };
+
+  let fragment = document.createDocumentFragment();
+  cloneNode(host, fragment);
+  return fragment;
+};
+
+/**
+ * Sets up the document clone to mirror the result of Node.cloneNode() 
+ * using the deep clone function able of cloning shadow dom
+ */
+const cloneNodeAndShadow = doc => {
+  let clonedDocumentElementFragment = deepClone(doc.documentElement);
+  clonedDocumentElementFragment.head = document.createDocumentFragment();
+  clonedDocumentElementFragment.documentElement = clonedDocumentElementFragment.firstChild;
+  return clonedDocumentElementFragment;
+};
+
+const customOuterHTML = docElement => {
+  return `<html class="hydrated">${docElement.getInnerHTML()}</html>`;
+};
+
+
+export { cloneNodeAndShadow, customOuterHTML }


### PR DESCRIPTION
Currently, Percy does not provide support for capturing shadow dom as outlined in this issue: https://github.com/percy/cli/issues/280

@mmun previously did some exploration and created a working modification to Percy's cloning behavior that enables capturing shadow dom in Chrome. This PR contains the modification necessary to allow shadow dom to be properly cloned.