### PR TITLE
🐛 Fix logger TTY logic for logging progress

### DIFF
--- a/packages/logger/src/logger.js
+++ b/packages/logger/src/logger.js
@@ -190,7 +190,12 @@ export class PercyLogger {
   write(level, message) {
     let { stdout, stderr } = this.constructor;
     let progress = stdout.isTTY && this._progress;
-    if (progress) stdout.cursorTo(0).clearLine();
+
+    if (progress) {
+      stdout.cursorTo(0);
+      stdout.clearLine(0);
+    }
+
     (level === 'info' ? stdout : stderr).write(message + '\n');
     if (!this._progress?.persist) delete this._progress;
     else if (progress) stdout.write(progress.message);

--- a/packages/logger/test/helpers.js
+++ b/packages/logger/test/helpers.js
@@ -66,8 +66,8 @@ const helpers = {
         logger.constructor[stdio] = Object.assign(new Writable(), {
           isTTY: options.isTTY,
           columns: options.isTTY ? 100 : null,
-          cursorTo() { return this; },
-          clearLine() { return this; },
+          cursorTo() { return true; },
+          clearLine() { return true; },
           _write(chunk, encoding, callback) {
             helpers[stdio].push(sanitizeLog(chunk.toString(), options));
             callback();

--- a/packages/logger/test/logger.test.js
+++ b/packages/logger/test/logger.test.js
@@ -361,7 +361,7 @@ describe('logger', () => {
 
       expect(stdout.cursorTo).toHaveBeenCalledWith(0);
       expect(stdout.cursorTo).toHaveBeenCalledBefore(stdout.clearLine);
-      expect(stdout.clearLine).toHaveBeenCalledWith();
+      expect(stdout.clearLine).toHaveBeenCalledWith(0);
       expect(stdout.clearLine).toHaveBeenCalledBefore(stdout.write);
       expect(stdout.write).toHaveBeenCalledWith(`[${colors.magenta('percy')}] bar\n`);
     });
@@ -385,7 +385,7 @@ describe('logger', () => {
       log.info('bar');
 
       expect(stdout.cursorTo).toHaveBeenCalledWith(0);
-      expect(stdout.clearLine).toHaveBeenCalledWith();
+      expect(stdout.clearLine).toHaveBeenCalledWith(0);
       expect(stdout.write).toHaveBeenCalledWith(`[${colors.magenta('percy')}] bar\n`);
       expect(stdout.write).toHaveBeenCalledWith(`[${colors.magenta('percy')}] foo`);
     });


### PR DESCRIPTION
## What is this?

In #916 the logger was refactored slightly. While doing so, I misread Node docs that `cursorTo` returned `this`. 

Turns out, it returns a boolean.