### PR TITLE
🐛 Fix sdk-utils test helper log capture

### DIFF
--- a/packages/sdk-utils/src/logger.js
+++ b/packages/sdk-utils/src/logger.js
@@ -6,7 +6,7 @@ const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
 // Create a small logger util using the specified namespace
 export function logger(namespace) {
   return Object.keys(LOG_LEVELS).reduce((ns, lvl) => (
-    Object.assign(ns, { [lvl]: log.bind(null, namespace, lvl) })
+    Object.assign(ns, { [lvl]: (...a) => logger.log(namespace, lvl, ...a) })
   ), {});
 }
 
@@ -90,8 +90,8 @@ const remote = logger.remote = async timeout => {
     if (log.history) ws.send(JSON.stringify({ messages: log.history }));
   } catch (err) {
     // there was an error connecting, will fallback to minimal logging
-    log('utils', 'debug', 'Unable to connect to remote logger');
-    log('utils', 'debug', err);
+    logger.log('utils', 'debug', 'Unable to connect to remote logger');
+    logger.log('utils', 'debug', err);
   }
 };
 


### PR DESCRIPTION
## What is this?

Since our sdk-utils logger got a little less sophisticated, so did how we mock it during tests. However, the simple mock was a little too simple and would sometimes capture logs that it didn't need to.

This PR updates the sdk-utils test helper to only capture logs during a `logger.log()` call. Usage of `log()` or `log.bind()` within the file was updated to include the `logger` namespace so stubs work no matter when a logging group was created.