### PR TITLE
🐛 Request fonts as binary via Node

### DIFF
--- a/packages/client/test/helpers.js
+++ b/packages/client/test/helpers.js
@@ -62,7 +62,7 @@ export class MockRequest extends EventEmitter {
 
       // maybe delay response data
       setTimeout(() => {
-        res.emit('data', data);
+        res.emit('data', Buffer.from(data));
         res.emit('end');
       }, this.delay);
     })();


### PR DESCRIPTION
## What is this?

_todo, add more of a description before undrafting PR_

Sometimes, through the SDKs, fonts are captured as corrupted. This has been a
long standing problem in Percy's SDKs. It turns out we cannot trust the decoding
the browser does in request interception with fonts -- a lot of the time those
fonts network responses are already corrupted by the time our SDK wants to save
the response body.

In order to work around this, we use Node to request the font files directly as
binary data. This solves all issues we've seen with fonts being captured as
corrupt.