### PR TITLE
🐛 Fix regex matching accepting non-regex patterns

### DIFF
--- a/packages/cli-snapshot/test/directory.test.js
+++ b/packages/cli-snapshot/test/directory.test.js
@@ -37,7 +37,7 @@ describe('percy snapshot <directory>', () => {
   });
 
   it('starts a static server and snapshots matching files', async () => {
-    await snapshot(['./', '--include=test-*.html']);
+    await snapshot(['./', '--include=/test-*.html']);
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
@@ -88,7 +88,7 @@ describe('percy snapshot <directory>', () => {
       '  options:',
       '  - additionalSnapshots:',
       '    - suffix: " (2)"',
-      '  - include: "*-1.html"',
+      '  - include: "/*-1.html"',
       '    name: First'
     ].join('\n'));
 

--- a/packages/cli-snapshot/test/file.test.js
+++ b/packages/cli-snapshot/test/file.test.js
@@ -161,7 +161,7 @@ describe('percy snapshot <file>', () => {
     ].join('\n'));
     /* eslint-enable no-template-curly-in-string */
 
-    await snapshot(['./lengthy.js', '--include=*2', '--exclude=[13579]']);
+    await snapshot(['./lengthy.js', '--include=*2', '--exclude=/[13579]/']);
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([

--- a/packages/cli-snapshot/test/sitemap.test.js
+++ b/packages/cli-snapshot/test/sitemap.test.js
@@ -75,7 +75,7 @@ describe('percy snapshot <sitemap>', () => {
       '  options:',
       '  - additionalSnapshots:',
       '    - suffix: " (2)"',
-      '  - include: "^/$"',
+      '  - include: /^\\/$/',
       '    name: Home'
     ].join('\n'));
 

--- a/packages/core/test/snapshot-multiple.test.js
+++ b/packages/core/test/snapshot-multiple.test.js
@@ -145,6 +145,20 @@ describe('Snapshot multiple', () => {
       expect(logger.stdout).toEqual([]);
       expect(logger.stderr).toEqual([]);
     });
+
+    it('can filter snapshots by name', async () => {
+      snapshots.push('/skip', '/do-not/skip');
+      await percy.snapshot({ baseUrl, snapshots, exclude: ['/skip'] });
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Snapshot taken: home',
+        '[percy] Snapshot taken: /about',
+        '[percy] Snapshot taken: /blog',
+        '[percy] Snapshot taken: /blog (page 2)',
+        '[percy] Snapshot taken: /do-not/skip'
+      ]));
+    });
   });
 
   describe('sitemap syntax', () => {


### PR DESCRIPTION
### What is this?

When given a path such as `/index.html`, the fallback regular expression matching would match anything containing the string, including paths such as `/other-path/index.html`.

This PR fixes the issue by not using the predicate as a fallback regular expression. To use a regular expression pattern, the pattern should look like: `/regex-here/` (like a normal JS regular expression).

I also adjusted two merge snapshot option paths that I noticed were being logged as empty arrays.