### PR TITLE
🐛 Fix sitemap xml parsing regex (stop when the lookahead matches)

### DIFF
--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -180,7 +180,7 @@ export async function getSitemapSnapshots(options) {
     }
 
     // parse XML content into a list of URLs
-    let urls = body.match(/(?<=<loc>)(.*)(?=<\/loc>)/ig) ?? [];
+    let urls = body.match(/(?<=<loc>)(.*?)(?=<\/loc>)/ig) ?? [];
 
     // filter out duplicate URLs that differ by a trailing slash
     return urls.filter((url, i) => {


### PR DESCRIPTION
## What is this?

Sometimes when there's other content inside of a sitemap `<loc>` (like `<image:image>`), the current regex will keep matching. This causes the URLs to include invalid content, making the snapshot(s) fail. The `?` makes the regex not greedy and it'll stop matching when the lookahead matches. 