### PR TITLE
✨ Introduce `scope` snapshot option

### DIFF
--- a/packages/cli-upload/test/upload.test.js
+++ b/packages/cli-upload/test/upload.test.js
@@ -84,6 +84,7 @@ describe('percy upload', () => {
         attributes: {
           name: 'test-1.png',
           widths: [10],
+          scope: null,
           'minimum-height': 10,
           'enable-javascript': null
         },

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -286,6 +286,7 @@ export class PercyClient {
   async createSnapshot(buildId, {
     name,
     widths,
+    scope,
     minHeight,
     enableJavaScript,
     clientInfo,
@@ -308,6 +309,7 @@ export class PercyClient {
         attributes: {
           name: name || null,
           widths: widths || null,
+          scope: scope || null,
           'minimum-height': minHeight || null,
           'enable-javascript': enableJavaScript || null
         },

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -480,6 +480,7 @@ describe('PercyClient', () => {
       await expectAsync(client.createSnapshot(123, {
         name: 'snapfoo',
         widths: [1000],
+        scope: '#main',
         minHeight: 1000,
         enableJavaScript: true,
         clientInfo: 'sdk/info',
@@ -506,6 +507,7 @@ describe('PercyClient', () => {
           attributes: {
             name: 'snapfoo',
             widths: [1000],
+            scope: '#main',
             'minimum-height': 1000,
             'enable-javascript': true
           },
@@ -537,6 +539,7 @@ describe('PercyClient', () => {
           attributes: {
             name: null,
             widths: null,
+            scope: null,
             'minimum-height': null,
             'enable-javascript': null
           },
@@ -597,6 +600,7 @@ describe('PercyClient', () => {
           type: 'snapshots',
           attributes: {
             name: 'test snapshot name',
+            scope: null,
             'enable-javascript': null,
             'minimum-height': null,
             widths: null

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -25,6 +25,9 @@ export const configSchema = {
       },
       enableJavaScript: {
         type: 'boolean'
+      },
+      scope: {
+        type: 'string'
       }
     }
   },
@@ -130,6 +133,7 @@ export const snapshotSchema = {
       type: 'object',
       properties: {
         widths: { $ref: '/config/snapshot#/properties/widths' },
+        scope: { $ref: '/config/snapshot#/properties/scope' },
         minHeight: { $ref: '/config/snapshot#/properties/minHeight' },
         percyCSS: { $ref: '/config/snapshot#/properties/percyCSS' },
         enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -254,6 +254,7 @@ function debugSnapshotConfig(snapshot, showInfo) {
   };
 
   debugProp(snapshot, 'url');
+  debugProp(snapshot, 'scope');
   debugProp(snapshot, 'widths', v => `${v}px`);
   debugProp(snapshot, 'minHeight', v => `${v}px`);
   debugProp(snapshot, 'enableJavaScript');


### PR DESCRIPTION
## What is this?

Add a snapshot option to scope a screenshot down to a specific selector. This currently won't work since it relies on infrastructure & API changes to be made, but now the SDKs will pass this option to the API.