### PR TITLE
🐛 Add back browser executable environment variable

### DIFF
--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -79,6 +79,7 @@ export class Browser extends EventEmitter {
 
     let { cookies = [], launchOptions = {} } = this.percy.config.discovery;
     let { executable, headless = true, args = [], timeout } = launchOptions;
+    executable ??= process.env.PERCY_BROWSER_EXECUTABLE;
 
     // transform cookies object to an array of cookie params
     this.cookies = Array.isArray(cookies) ? cookies : (

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -25,6 +25,7 @@ describe('Discovery', () => {
   beforeEach(async () => {
     captured = [];
     await setupTest();
+    delete process.env.PERCY_BROWSER_EXECUTABLE;
 
     api.reply('/builds/123/snapshots', ({ body }) => {
       // resource order is not important, stabilize it for testing
@@ -1238,6 +1239,19 @@ describe('Discovery', () => {
 
       expect(logger.stderr).toEqual([
         '[percy] Browser executable not found: ./404'
+      ]);
+    });
+
+    it('can provide an executable via an environment variable', async () => {
+      process.env.PERCY_BROWSER_EXECUTABLE = './from-var';
+
+      percy = await Percy.start({
+        token: 'PERCY_TOKEN',
+        snapshot: { widths: [1000] }
+      });
+
+      expect(logger.stderr).toEqual([
+        '[percy] Browser executable not found: ./from-var'
       ]);
     });
 


### PR DESCRIPTION
## What is this?

This area of the browser class was refactored slightly with #922 and the environment variable was accidentally forgotten about and never added back. An added test should ensure that doesn't happen again.