### PR TITLE
Disable message colors when stream is not a TTY

### DIFF
--- a/packages/logger/src/logger.js
+++ b/packages/logger/src/logger.js
@@ -112,21 +112,21 @@ export class PercyLogger {
 
       // include elapsed time since last log
       if (elapsed != null) {
-        suffix = ' ' + colors.grey(`(${elapsed}ms)`);
+        suffix = ' ' + this.colorize(`(${elapsed}ms)`, colors.grey);
       }
     }
 
-    label = colors.magenta(label);
+    label = this.colorize(label, colors.magenta);
 
     if (level === 'error') {
       // red errors
-      message = colors.red(message);
+      message = this.colorize(message, colors.red);
     } else if (level === 'warn') {
       // yellow warnings
-      message = colors.yellow(message);
+      message = this.colorize(message, colors.yellow);
     } else if (level === 'info' || level === 'debug') {
       // blue info and debug URLs
-      message = message.replace(URL_REGEXP, colors.blue('$&'));
+      message = message.replace(URL_REGEXP, this.colorize('$&', colors.blue));
     }
 
     return `[${label}] ${message}${suffix}`;
@@ -199,6 +199,10 @@ export class PercyLogger {
     (level === 'info' ? stdout : stderr).write(message + '\n');
     if (!this._progress?.persist) delete this._progress;
     else if (progress) stdout.write(progress.message);
+  }
+
+  colorize(message, color) {
+    return this.constructor.stdout.isTTY ? color(message) : message;
   }
 }
 

--- a/packages/logger/test/logger.test.js
+++ b/packages/logger/test/logger.test.js
@@ -187,7 +187,7 @@ describe('logger', () => {
 
     it('does not colorize formatted messages', () => {
       expect(log.format('warn', 'level')).toEqual('[percy] level');
-      expect(log.format('error', 'level')).toEqual(`[percy] level`);
+      expect(log.format('error', 'level')).toEqual('[percy] level');
       expect(logger.format('other', 'error', 'elapsed', 100)).toEqual('[percy] elapsed');
 
       log.loglevel('debug');


### PR DESCRIPTION
The progress is not used when output stream is not a TTY. At the same time such streams do not accept color formatting of the messages.

Also as I see the `colors` package is used in test helpers, why doesn't it used in the `logger` package? It has built-in detection of the supported environments.