### PR TITLE
Added possibility to set custom writer for the logger

### DIFF
--- a/packages/logger/src/index.js
+++ b/packages/logger/src/index.js
@@ -11,7 +11,8 @@ Object.defineProperties(logger, {
   instance: { get: () => new Logger() },
   query: { value: (...args) => logger.instance.query(...args) },
   format: { value: (...args) => logger.instance.format(...args) },
-  loglevel: { value: (...args) => logger.instance.loglevel(...args) }
+  loglevel: { value: (...args) => logger.instance.loglevel(...args) },
+  setWriter: { value: (...args) => logger.instance.setWriter(...args) }
 });
 
 export default logger;

--- a/packages/logger/test/logger.test.js
+++ b/packages/logger/test/logger.test.js
@@ -432,4 +432,24 @@ describe('logger', () => {
       });
     });
   });
+
+  describe('custom writer', () => {
+    let writer;
+
+    beforeEach(() => {
+      log = logger('custom');
+      writer = jasmine.createSpy('writer');
+
+      logger.setWriter(writer);
+
+      log.info('info message');
+      log.error('error message', { name: 'test' });
+    });
+
+    it('calls custom writer with data to log', () => {
+      expect(writer).toHaveBeenCalledTimes(2);
+      expect(writer).toHaveBeenCalledWith('info', 'custom', 'info message', {}, jasmine.any(Number), inst);
+      expect(writer).toHaveBeenCalledWith('error', 'custom', 'error message', { name: 'test' }, jasmine.any(Number), inst);
+    });
+  });
 });


### PR DESCRIPTION
These changes would allow to override the `logger`'s `write` method with a custom implementation. This should simplify integration with other logging systems to be able to send logs not only to `stdout`.