### PR TITLE
🐛 Fix `@percy/sdk-utils` exports field for browser based SDKs

### DIFF
--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -22,10 +22,16 @@
   "main": "./dist/index.js",
   "browser": "./dist/bundle.js",
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "node": "./dist/index.js",
+      "default": "./dist/bundle.js"
+    },
     "./test/server": "./test/server.js",
     "./test/client": "./test/client.js",
-    "./test/helpers": "./test/helpers.js"
+    "./test/helpers": {
+      "node": "./test/helpers.js",
+      "default": "./test/client.js"
+    }
   },
   "scripts": {
     "build": "node ../../scripts/build",


### PR DESCRIPTION
## What is this?

This PR fixes browser based SDKs from grabbing the wrong bundle for the wrong environment. Currently they may try to use the node bundle (`index.js`), when it should be using the browser complied version (`bundle.js`). https://webpack.js.org/guides/package-exports/#providing-different-versions-depending-on-target-environment