### PR TITLE
✨ Capture different pixel densities in asset discovery

### DIFF
--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -28,6 +28,10 @@ export const configSchema = {
       },
       scope: {
         type: 'string'
+      },
+      deviceScaleFactor: {
+        type: 'integer',
+        default: 1
       }
     }
   },
@@ -137,6 +141,7 @@ export const snapshotSchema = {
         minHeight: { $ref: '/config/snapshot#/properties/minHeight' },
         percyCSS: { $ref: '/config/snapshot#/properties/percyCSS' },
         enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },
+        deviceScaleFactor: { $ref: '/config/snapshot#/properties/deviceScaleFactor' },
         discovery: {
           type: 'object',
           additionalProperties: false,

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -29,7 +29,7 @@ export const configSchema = {
       scope: {
         type: 'string'
       },
-      deviceScaleFactor: {
+      devicePixelRatio: {
         type: 'integer'
       }
     }
@@ -140,7 +140,7 @@ export const snapshotSchema = {
         minHeight: { $ref: '/config/snapshot#/properties/minHeight' },
         percyCSS: { $ref: '/config/snapshot#/properties/percyCSS' },
         enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },
-        deviceScaleFactor: { $ref: '/config/snapshot#/properties/deviceScaleFactor' },
+        devicePixelRatio: { $ref: '/config/snapshot#/properties/devicePixelRatio' },
         discovery: {
           type: 'object',
           additionalProperties: false,

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -30,8 +30,7 @@ export const configSchema = {
         type: 'string'
       },
       deviceScaleFactor: {
-        type: 'integer',
-        default: 1
+        type: 'integer'
       }
     }
   },

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -35,14 +35,9 @@ export class Page {
     this.log.debug('Page closed', this.meta);
   }
 
-  async reload() {
-    await this.session.send('Page.reload');
-    this.log.debug('Page reloaded', this.meta);
-  }
-
   // Resize the page to the specified width and height
   async resize({ width, height, deviceScaleFactor = 1, mobile = false }) {
-    this.log.debug(`Resize page to ${width}x${height} at ${deviceScaleFactor}x scale`);
+    this.log.debug(`Resize page to ${width}x${height} @${deviceScaleFactor}x`);
 
     await this.session.send('Emulation.setDeviceMetricsOverride', {
       deviceScaleFactor,

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -35,13 +35,18 @@ export class Page {
     this.log.debug('Page closed', this.meta);
   }
 
+  async reload() {
+    await this.session.send('Page.reload');
+    this.log.debug('Page reloaded', this.meta);
+  }
+
   // Resize the page to the specified width and height
-  async resize({ width, height }) {
-    this.log.debug(`Resize page to ${width}x${height}`);
+  async resize({ width, height, deviceScaleFactor = 1, mobile = false }) {
+    this.log.debug(`Resize page to ${width}x${height} at ${deviceScaleFactor}x scale`);
 
     await this.session.send('Emulation.setDeviceMetricsOverride', {
-      deviceScaleFactor: 1,
-      mobile: false,
+      deviceScaleFactor,
+      mobile,
       height,
       width
     });

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -324,6 +324,8 @@ function waitForDiscoveryNetworkIdle(page, options) {
 // Used to cache resources across core instances
 const RESOURCE_CACHE_KEY = Symbol('resource-cache');
 
+// Trigger resource requests for a page by iterating over snapshot widths and calling any provided
+// execute options. Additional resize options may be provided to capture resources mobile resources
 function* triggerResourceRequests(page, snapshot, options) {
   // copy widths to prevent mutation later
   let [initialWidth, ...widths] = snapshot.widths;

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -516,7 +516,7 @@ describe('Discovery', () => {
 
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
       '[percy:core:page] Page created',
-      '[percy:core:page] Resize page to 400x1024 at 1x scale',
+      '[percy:core:page] Resize page to 400x1024 @1x',
       '[percy:core:page] Navigate to: http://localhost:8000/',
       '[percy:core:discovery] Handling request: http://localhost:8000/',
       '[percy:core:discovery] - Serving root resource',
@@ -530,7 +530,7 @@ describe('Discovery', () => {
       '[percy:core:discovery] - mimetype: image/gif',
       '[percy:core:page] Page navigated',
       '[percy:core:network] Wait for 100ms idle',
-      '[percy:core:page] Resize page to 1200x1024 at 1x scale',
+      '[percy:core:page] Resize page to 1200x1024 @1x',
       '[percy:core:network] Wait for 100ms idle',
       '[percy:core:page] Page closed'
     ]));

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -650,7 +650,7 @@ describe('Discovery', () => {
       name: 'test responsive',
       url: 'http://localhost:8000',
       domSnapshot: responsiveDOM,
-      deviceScaleFactor: 2,
+      devicePixelRatio: 2,
       widths: [400, 800]
     });
 

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -54,7 +54,6 @@ describe('Percy', () => {
     percy = new Percy({ snapshot: { foo: 'bar' } });
 
     expect(percy.config.snapshot).toEqual({
-      deviceScaleFactor: 1,
       widths: [375, 1280],
       minHeight: 1024,
       percyCSS: ''

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -54,6 +54,7 @@ describe('Percy', () => {
     percy = new Percy({ snapshot: { foo: 'bar' } });
 
     expect(percy.config.snapshot).toEqual({
+      deviceScaleFactor: 1,
       widths: [375, 1280],
       minHeight: 1024,
       percyCSS: ''


### PR DESCRIPTION
## What is this?

With the addition of real native devices in our rendering infrastructure, we now need to capture 2x++ pixel images for pages to render properly (since the real devices have high pixel density screens).

With the new `devicePixelRatio` config option, we now will resize the browser to each specified width at 1x and also whatever the passed value is for `devicePixelRatio`. We also run both `beforeResize` and `afterResize` events with the additional scale resizes. These assets are discovered in their own tab, separate from 1x devicePixelRatio assets to ensure that the right scaled assets are loaded (rather than trying to resize and reset the devicePixelRatio)
