### PR TITLE
🐛 Pass auth headers when requesting assets directly

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -86,7 +86,8 @@ export function createRequestFinishedHandler(network, {
 
         if (mimeType?.includes('font')) {
           // font responses from the browser may not be properly encoded, so request them directly
-          body = await makeRequest(response.url, { buffer: true });
+          log.debug('- Requesting asset directly');
+          body = await makeRequest(response.url, { buffer: true, headers: request.headers });
         }
 
         resource = createResource(url, body, mimeType, {


### PR DESCRIPTION
## What is this? 

In https://github.com/percy/cli/pull/921 we realized font responses were being corrupted through the browsers request interception API. To get around that, we now request and save fonts straight from node as a binary (no encoding). In that PR, I forgot to pass the auth config to the request that's being made, which will prevent sites behind auth from capturing fonts properly.

This PR adds the request headers the browser has to the node request we made to capture the fonts directly. Also adds a debug log when we are requesting these fonts directly. 

Closes #969