### PR TITLE
✨ Allow PascalCase options (and other casing)

### DIFF
--- a/packages/config/src/utils/normalize.js
+++ b/packages/config/src/utils/normalize.js
@@ -7,30 +7,26 @@ const CAMELCASE_MAP = new Map([
   ['javascript', 'JavaScript']
 ]);
 
-// Converts kebab-cased and snake_cased strings to camelCase.
-const KEBAB_SNAKE_REG = /[-_]([^-_]+)/g;
+// Regular expression that matches words from boundaries or consecutive casing
+const WORD_REG = /[a-z]{2,}|[A-Z]{2,}|[0-9]{2,}|[^-_\s]+?(?=[A-Z0-9-_\s]|$)/g;
 
+// Converts kebab-cased and snake_cased strings to camelCase.
 export function camelcase(str) {
   if (typeof str !== 'string') return str;
 
-  return str.replace(KEBAB_SNAKE_REG, (match, word) => (
-    CAMELCASE_MAP.get(word) || (word[0].toUpperCase() + word.slice(1))
-  ));
+  return str.match(WORD_REG).reduce((s, w, i) => s + (i ? (
+    CAMELCASE_MAP.get(w.toLowerCase()) || (
+      w[0].toUpperCase() + w.slice(1).toLowerCase())
+  ) : w.toLowerCase()), '');
 }
 
 // Coverts camelCased and snake_cased strings to kebab-case.
-const CAMEL_SNAKE_REG = /([a-z])([A-Z]+)|_([^_]+)/g;
-
 export function kebabcase(str) {
   if (typeof str !== 'string') return str;
 
   return Array.from(CAMELCASE_MAP)
-    .reduce((str, [word, camel]) => (
-      str.replace(camel, `-${word}`)
-    ), str)
-    .replace(CAMEL_SNAKE_REG, (match, p, n, w) => (
-      `${p || ''}-${(n || w).toLowerCase()}`
-    ));
+    .reduce((str, [word, camel]) => str.replace(camel, `-${word}`), str)
+    .match(WORD_REG).join('-').toLowerCase();
 }
 
 // Removes undefined empty values and renames kebab-case properties to camelCase. Optionally

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -950,18 +950,20 @@ describe('PercyConfig', () => {
         'foo-bar': 'baz',
         foo: { bar_baz: 'qux' },
         'foo_bar-baz': 'qux',
+        'Bar BAZ qux': 'xyzzy',
         'percy-css': '',
         'enable-javascript': false
       })).toEqual({
         fooBar: 'baz',
         foo: { barBaz: 'qux' },
         fooBarBaz: 'qux',
+        barBazQux: 'xyzzy',
         percyCSS: '',
         enableJavaScript: false
       });
     });
 
-    it('can converts keys to kebab-case', () => {
+    it('can convert keys to kebab-case', () => {
       expect(PercyConfig.normalize({
         'foo-bar': 'baz',
         foo: { bar_baz: 'qux' },


### PR DESCRIPTION
## What is this?

While creating the .NET SDK, I noticed that the convention in that land seems to be PascalCase object properties, and as everything is an object, some people might create PascalCase snapshot options objects. However our options normalization does not handle the first word of keys. So even a key of `ALLOWED_HOSTNAMES` would end up becoming `ALLOWEDHostnames`.

With the changes in this PR, the config normalization helpers will now split all words regardless of casing, then convert to the desired casing. Not only does this enable PascalCase options, but will now handle all-caps underscore or even option names with spaces (like `network-idle timeout` but who would do that?).