### PR TITLE
🐛 Pass authorization config to asset discovery direct requests

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -41,7 +41,7 @@ export function createRequestHandler(network, { disableCache, disallowedHostname
   };
 }
 
-export function createRequestFinishedHandler(network, authorization, {
+export function createRequestFinishedHandler(network, {
   enableJavaScript,
   allowedHostnames,
   disableCache,
@@ -88,10 +88,12 @@ export function createRequestFinishedHandler(network, authorization, {
         // font responses from the browser may not be properly encoded, so request them directly
         if (mimeType?.includes('font')) {
           log.debug('- Requesting asset directly');
-          if (!headers.Authorization && authorization?.username) {
-            let token = Buffer.from(authorization.password
-              ? `${authorization.username}:${authorization.password}`
-              : `${authorization.username}:`).toString('base64');
+
+          if (!headers.Authorization && network.authorization?.username) {
+            let token = Buffer.from([
+              network.authorization.username,
+              network.authorization.password || ''
+            ].join(':')).toString('base64');
 
             headers.Authorization = `Basic ${token}`;
           }

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -31,7 +31,7 @@ export class Network {
 
     if (this.interceptEnabled) {
       this.onRequest = createRequestHandler(this, options.intercept);
-      this.onRequestFinished = createRequestFinishedHandler(this, options.intercept);
+      this.onRequestFinished = createRequestFinishedHandler(this, options.authorization, options.intercept);
       this.onRequestFailed = createRequestFailedHandler(this, options.intercept);
     }
   }

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -31,7 +31,7 @@ export class Network {
 
     if (this.interceptEnabled) {
       this.onRequest = createRequestHandler(this, options.intercept);
-      this.onRequestFinished = createRequestFinishedHandler(this, options.authorization, options.intercept);
+      this.onRequestFinished = createRequestFinishedHandler(this, options.intercept);
       this.onRequestFailed = createRequestFailedHandler(this, options.intercept);
     }
   }


### PR DESCRIPTION
## What is this?

Turns out when using the `authorization` config in `.percy.yml` (where you pass a username/password rather than encoding it as a header), those aren't passed as request headers. So simply grabbing the same headers and passing them to the node request won't work here. We need to check if the `authorization` config exists and if it does, apply that header to the Node request. 