### PR TITLE
✨ In testing mode, clear logs on reset

### DIFF
--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -102,8 +102,9 @@ export function createPercyServer(percy, port) {
       body = Buffer.isBuffer(body) ? body.toString() : body;
 
       if (cmd === 'reset') {
-        // the reset command will reset testing mode to its default options
+        // the reset command will reset testing mode and clear any logs
         percy.testing = {};
+        logger.instance.messages.clear();
       } else if (cmd === 'version') {
         // the version command will update the api version header for testing
         percy.testing.version = body;


### PR DESCRIPTION
## What is this?

During testing mode, full logs are rarely useful, but individual snapshot logs are more important to test against. Clearing logs on reset will allow SDK tests to read only recent and relevant logs without having to filter them.