### PR TITLE
✨ Add option to delay uploads without deferring until the end

### DIFF
--- a/packages/cli-snapshot/src/snapshot.js
+++ b/packages/cli-snapshot/src/snapshot.js
@@ -58,7 +58,7 @@ export const snapshot = command('snapshot', {
   ],
 
   percy: {
-    deferUploads: true
+    delayUploads: true
   },
 
   config: {

--- a/packages/cli-snapshot/test/directory.test.js
+++ b/packages/cli-snapshot/test/directory.test.js
@@ -45,7 +45,7 @@ describe('percy snapshot <directory>', () => {
       '[percy] Snapshot taken: /test-1.html',
       '[percy] Snapshot taken: /test-2.html',
       '[percy] Snapshot taken: /test-3.html',
-      '[percy] Uploading 3 snapshots...',
+      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots'),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]));
   });
@@ -60,7 +60,7 @@ describe('percy snapshot <directory>', () => {
       '[percy] Snapshot taken: /base/test-2.html',
       '[percy] Snapshot taken: /base/test-3.html',
       '[percy] Snapshot taken: /base/test-index/index.html',
-      '[percy] Uploading 4 snapshots...',
+      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots'),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]));
   });

--- a/packages/cli-snapshot/test/file.test.js
+++ b/packages/cli-snapshot/test/file.test.js
@@ -120,7 +120,7 @@ describe('percy snapshot <file>', () => {
       '[percy] Snapshot taken: JS Snapshot',
       '[percy] Snapshot taken: JS Snapshot 2',
       '[percy] Snapshot taken: Other JS Snapshot',
-      '[percy] Uploading 3 snapshots...',
+      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots'),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]);
   });
@@ -146,7 +146,7 @@ describe('percy snapshot <file>', () => {
       '[percy] Snapshot taken: /',
       '[percy] Snapshot taken: /one',
       '[percy] Snapshot taken: /two',
-      '[percy] Uploading 3 snapshots...',
+      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots'),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]));
   });
@@ -171,7 +171,7 @@ describe('percy snapshot <file>', () => {
       '[percy] Snapshot taken: Snapshot #42',
       '[percy] Snapshot taken: Snapshot #62',
       '[percy] Snapshot taken: Snapshot #82',
-      '[percy] Uploading 5 snapshots...',
+      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots'),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]));
   });


### PR DESCRIPTION
## What is this?

This new `delayUploads` option is an alternative to the existing `deferUploads` option. With the existing `deferUploads` option, all uploads (including build creation) are deferred until the instance is stopped. With the new `delayUploads` option, an upload is not processed until the next upload is queued. So the build is not created until the first snapshot is taken, and that snapshot is not uploaded until the next snapshot is taken, and so on until the last snapshot is uploaded when the instance is stopped and the build is finalized.

Currently, this is only useful to speed up the snapshot and storybook commands since those are the only SDKs that utilize `deferUploads` and will error when no snapshots are found. In the future, this could become an opt-in feature for the exec command for the rest of our SDKs, which could error when missing snapshots or allow retrying queued snapshots.

While it wasn't necessarily needed, I felt compelled to add a mirroring test for `deferUploads` which is just as rigorous as the new test for `delayUploads`.