### PR TITLE
🐛 Fix config being scrubbed from passing schemas

### DIFF
--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -207,7 +207,7 @@ export function validate(data, key = '/config') {
         set(data, path, Math.min(error.data, error.schema));
       } else if (keyword === 'required') {
         del(data, path.slice(0, -1));
-      } else {
+      } else if (!params.passingSchemas) {
         del(data, path);
       }
 

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -60,6 +60,10 @@ describe('Snapshot', () => {
       '[percy] - additionalSnapshots[0]: missing required name, prefix, or suffix',
       '[percy] - additionalSnapshots[1]: prefix & suffix are ignored when a name is provided'
     ]);
+    expect(logger.stdout).toEqual([
+      '[percy] Snapshot taken: /',
+      '[percy] Snapshot taken: nombre'
+    ]);
   });
 
   it('warns when providing conflicting options', async () => {


### PR DESCRIPTION
## What is this?

When providing additional snapshots with both a `name` and a `prefix`/`suffix`, a warning is logged that only `name` will be used. However, with the way our config validation works, any property that results in a schema error (that isn't handled by other constraints) will be scrubbed. This means that the warning is incorrect, and the additional snapshot is disregarded entirely when providing both a `name` and a `prefix`/`suffix`.

This is fixed within our validation wrapper by _not_ scrubbing properties that are failing by actually passing more than a single schema (specifically the `oneOf` schema). The property is still scrubbed when there are zero passing schemas.

Another expectation was also added to core tests to verify the desired behavior of the additional snapshot being kept.