### PR TITLE
🐛 Do not start delayed uploads when debugging

### DIFF
--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -443,12 +443,10 @@ export class Percy {
 
   // Queues a snapshot upload with the provided options
   _scheduleUpload(name, options) {
-    if (this.build?.error) {
-      throw new Error(this.build.error);
-    }
+    if (this.build?.error) throw new Error(this.build.error);
 
-    // when not dry-running, process any existing delayed uploads
-    if (!this.dryRun && this.delayUploads) this.#uploads.run();
+    // maybe process any existing delayed uploads
+    if (!this.skipUploads && this.delayUploads) this.#uploads.run();
 
     return this.#uploads.push(`upload/${name}`, async () => {
       // when delayed, stop the queue before other uploads are processed

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -218,6 +218,27 @@ describe('Snapshot', () => {
     expect(root(1)).toHaveProperty('attributes.resource-url', 'http://localhost:8000/two');
   });
 
+  it('does not upload delayed snapshots when skipping', async () => {
+    // stop and recreate a percy instance with the desired option
+    await percy.stop(true);
+    await api.mock();
+
+    percy = await Percy.start({
+      token: 'PERCY_TOKEN',
+      delayUploads: true,
+      // skip should be prioritized over delay
+      skipUploads: true
+    });
+
+    await percy.snapshot('http://localhost:8000/one');
+    await percy.snapshot('http://localhost:8000/two');
+    await percy.idle();
+
+    // not requested, ever
+    expect(api.requests['/builds']).toBeUndefined();
+    expect(api.requests['/builds/123/snapshots']).toBeUndefined();
+  });
+
   it('uploads all snapshots at the end when deferred', async () => {
     // stop and recreate a percy instance with the desired option
     await percy.stop(true);


### PR DESCRIPTION
## What is this?

This fixes a bug with the new `delayUploads` option being combined with the `--debug` flag.

Different than the `dryRun` option, the `skipUploads` option may be provided while debugging so snapshots are still processed by asset discovery without a build being created. The `dryRun` option implies `skipUploads`, so this change does not affect existing dry-run behavior.