### PR TITLE
🐛 Improve compatibility with AMD module systems

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -84,7 +84,7 @@ const plugins = {
             `(function() {\n${indent(bundle[file].code)}}).call(window);\n`,
             // support amd & commonjs modules by referencing the global
             'if (typeof define === "function" && define.amd) {',
-            `  define([], () => window.${options.name});`,
+            `  define("${pkg.name}", [], () => window.${options.name});`,
             '} else if (typeof module === "object" && module.exports) {',
             `  module.exports = window.${options.name};`,
             '}\n'


### PR DESCRIPTION
## What is this?

Some older implementations of AMD module loading systems might throw an error when the first argument to define a module is not the name of the module itself. This PR adds the package name to the AMD section of the generated bundle output for rollup builds.