### PR TITLE
🐛 Check for execute signature before handling as function body

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -158,11 +158,14 @@ async function scrollToBottom(options, onScroll) {
   }
 }
 
+// Used to test if a string looks like a function
+const FUNC_REG = /^(async\s+)?(function\s*)?(\w+\s*)?\(.*?\)\s*(\{|=>)/is;
+
 // Serializes the provided function with percy helpers for use in evaluating browser scripts
 export function serializeFunction(fn) {
-  let fnbody = typeof fn === 'string'
-    ? `async eval() {\n${fn}\n}`
-    : fn.toString();
+  // stringify or convert a function body into a complete function
+  let fnbody = (typeof fn === 'string' && !FUNC_REG.test(fn))
+    ? `async function eval() {\n${fn}\n}` : fn.toString();
 
   // we might have a function shorthand if this fails
   /* eslint-disable-next-line no-new, no-new-func */

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -624,8 +624,9 @@ describe('Snapshot', () => {
         execute: () => document.querySelector('p').classList.add('eval-1'),
         additionalSnapshots: [
           { suffix: ' 2', execute: () => document.querySelector('p').classList.add('eval-2') },
-          { suffix: ' 3', execute: "document.querySelector('p').classList.add('eval-3')" },
-          { suffix: ' 4' }
+          { suffix: ' 3', execute: "() => document.querySelector('p').classList.add('eval-3')" },
+          { suffix: ' 4', execute: "document.querySelector('p').classList.add('eval-4')" },
+          { suffix: ' 5' }
         ]
       });
 
@@ -639,7 +640,8 @@ describe('Snapshot', () => {
       expect(dom(0)).toMatch('<p class="eval-1">Test</p>');
       expect(dom(1)).toMatch('<p class="eval-1 eval-2">Test</p>');
       expect(dom(2)).toMatch('<p class="eval-1 eval-2 eval-3">Test</p>');
-      expect(dom(3)).toMatch('<p class="eval-1 eval-2 eval-3">Test</p>');
+      expect(dom(3)).toMatch('<p class="eval-1 eval-2 eval-3 eval-4">Test</p>');
+      expect(dom(3)).toMatch('<p class="eval-1 eval-2 eval-3 eval-4">Test</p>');
     });
 
     it('can successfully snapshot a page after executing page navigation', async () => {


### PR DESCRIPTION
## What is this?

When providing a string as a value for `execute` options, it will be disregarded as unserializable if the string contains a function signature. For example, this was previously "unserializable": `"function () { ... }"`

With this PR, the provided string is checked for a function signature before being automatically given one.