### PR TITLE
✨ Use env sha for build:wait when there's a project with no commit

### DIFF
--- a/packages/cli-build/src/wait.js
+++ b/packages/cli-build/src/wait.js
@@ -12,7 +12,6 @@ export const wait = command('wait', {
   }, {
     name: 'project',
     description: 'Build project slug, requires \'--commit\'',
-    requires: ['commit'],
     type: 'slug',
     short: 'p'
   }, {
@@ -78,9 +77,11 @@ function logProgress({
     'total-comparisons': total,
     'total-comparisons-diff': diffs,
     'total-comparisons-finished': finished
-  }
-}, log) {
+  } = {}
+} = {}, log) {
   switch (state) {
+    case undefined:
+      return log.progress('Waiting for build...');
     case 'pending':
       return log.progress('Recieving snapshots...');
     case 'processing':
@@ -123,10 +124,10 @@ function failureMessage(type, {
 
 // Return true or false if a build is considered failing or not
 function isFailing({
-  attributes: { state, 'total-comparisons-diff': diffs }
-}, { failOnChanges }) {
+  attributes: { state, 'total-comparisons-diff': diffs } = {}
+} = {}, { failOnChanges }) {
   // not pending and not processing
-  return state !== 'pending' && state !== 'processing' &&
+  return state != null && state !== 'pending' && state !== 'processing' &&
     // not finished or finished with diffs
     (state !== 'finished' || (failOnChanges && !!diffs));
 }

--- a/packages/cli-build/test/wait.test.js
+++ b/packages/cli-build/test/wait.test.js
@@ -41,8 +41,23 @@ describe('percy build:wait', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '[percy] Error: Missing build ID or commit SHA'
+      '[percy] Error: Missing project path or build ID'
     ]);
+  });
+
+  it('logs while waiting for a matching build', async () => {
+    api
+      .reply('/projects/foo/bar/builds?filter[sha]=sha123', () => [200, { data: [] }])
+      .reply('/projects/foo/bar/builds?filter[sha]=sha123', () => [200, {
+        data: [build({ 'total-comparisons-finished': 72, state: 'finished' }).data]
+      }]);
+
+    await wait(['--project=foo/bar', '--commit=sha123', '--timeout=500', '--interval=50']);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual(jasmine.arrayContaining([
+      '[percy] Waiting for build...'
+    ]));
   });
 
   it('logs while recieving snapshots', async () => {


### PR DESCRIPTION
## What is this?

With the `build:wait` command, a project and commit can be provided to search for a build to wait on. However, sometimes the `HEAD` commit, or even local CI environment variables, can refer to a merge commit instead of the branch commit. When a build is created, we use the correct commit in most environments. However when a user provides a commit to the `build:wait` command, it might not match the commit that was used when creating the build. This causes the API to return an empty list since there are no builds associated with that commit for a project.

This PR addresses this issue in two primary ways. First, the command will log `Waiting for build...` when the API returns an empty list. This is because this command can be started before a build is actually created, and will update with the correct info once a matching build is found within the command timeout. An error will be thrown if a build is not found within the timeout. Second, rather than relying on the user to provide the correct commit, we can default to the commit found in the environment, which is the same commit that would be used when creating a new build. This default commit is only used when providing the `--project` flag without a `--commit` flag.