### PR TITLE
🐛 Only delay uploads when actively running

### DIFF
--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -82,10 +82,6 @@ export class Percy {
       this.#snapshots.concurrency = concurrency;
     }
 
-    if (this.delayUploads) {
-      this.#uploads.concurrency = 1;
-    }
-
     this.client = new PercyClient({ token, clientInfo, environmentInfo });
     if (server) this.server = createPercyServer(this, port);
     this.browser = new Browser(this);
@@ -450,7 +446,7 @@ export class Percy {
 
     return this.#uploads.push(`upload/${name}`, async () => {
       // when delayed, stop the queue before other uploads are processed
-      if (this.delayUploads) this.#uploads.stop();
+      if (this.readyState < 2 && this.delayUploads) this.#uploads.stop();
 
       try {
         /* istanbul ignore if: useful for other internal packages */


### PR DESCRIPTION
## What is this?

Uploads are deferred by flushing the upload queue when stopping. Uploads are delayed by running the queue before adding to it, stopping it again when an upload begins, and finally flushing when stopping. However, because the queue gets stopped when an upload begins, flushing causes the upload task to stop the flush from continuing. This causes builds with delayed snapshots to prematurely stop uploading and finalize the build before it should be.

This is fixed by only stopping the queue for delayed uploads when the instance itself is not stopping. When the instance stops, uploads should be processed accordingly with any set concurrency.

The test I added was not failing due to the mock API responding too fast to uploads, causing the queue to be drained before stopping. I found that adding a delay to the mock API had no effect, and upon investigation I found that the mock request client test helper had issues when redefining existing mocks. As implemented, mocking the API a second time would only serve to reset any captured requests since the first spy matcher always ran first. The helper was fixed by preserving spy strategies per mocked URL and discarding them when new spies are created.

This PR should fix #1006 