### PR TITLE
✨ Add support for .cjs config files and snapshot files

### DIFF
--- a/packages/cli-snapshot/src/snapshot.js
+++ b/packages/cli-snapshot/src/snapshot.js
@@ -130,12 +130,12 @@ function merge(...objs) {
 async function loadSnapshotFile(file) {
   let ext = path.extname(file);
 
-  if (ext === '.js') {
+  if (/\.(c|m)?js$/.test(ext)) {
     let { default: module } = await import(path.resolve(file));
     return typeof module === 'function' ? await module() : module;
   } else if (ext === '.json') {
     return JSON.parse(fs.readFileSync(file, 'utf-8'));
-  } else if (ext.match(/\.ya?ml$/)) {
+  } else if (/\.ya?ml$/.test(ext)) {
     let { default: YAML } = await import('yaml');
     return YAML.parse(fs.readFileSync(file, 'utf-8'));
   } else {

--- a/packages/cli-snapshot/test/file.test.js
+++ b/packages/cli-snapshot/test/file.test.js
@@ -29,7 +29,7 @@ describe('percy snapshot <file>', () => {
           ]
         }], { depth: null }),
 
-        'pages-fn.js': 'module.exports = () => (' + inspect([{
+        'pages-fn.cjs': 'module.exports = () => (' + inspect([{
           name: 'JS Function Snapshot',
           url: 'http://localhost:8000'
         }], { depth: null }) + ')',
@@ -126,7 +126,7 @@ describe('percy snapshot <file>', () => {
   });
 
   it('snapshots pages from .js files that export a function', async () => {
-    await snapshot(['./pages-fn.js']);
+    await snapshot(['./pages-fn.cjs']); // .(c|m)?js
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([

--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -20,7 +20,9 @@ export const explorer = cosmiconfigSync('percy', {
     '.percy.yaml',
     '.percy.yml',
     '.percy.js',
-    'percy.config.js'
+    '.percy.cjs',
+    'percy.config.js',
+    'percy.config.cjs'
   ]
 });
 

--- a/packages/config/test/helpers.js
+++ b/packages/config/test/helpers.js
@@ -28,6 +28,9 @@ const INTERNAL_FILE_REG = new RegExp(
     '(src|dist|test|package\\.json)(\\1|$)'
 );
 
+// Used to mock javascript modules
+const JS_FILE_REG = /\.(c|m)?js$/;
+
 // Mock and spy on fs methods using an in-memory filesystem
 export async function mockfs({
   // set `true` to allow mocking files within `node_modules` (may cause dynamic import issues)
@@ -45,7 +48,7 @@ export async function mockfs({
 
   // when .js files are created, also mock the module for importing
   spyOn(vol, 'writeFileSync').and.callFake((...args) => {
-    if (args[0].endsWith('.js')) mockFileModule(...args);
+    if (JS_FILE_REG.test(args[0])) mockFileModule(...args);
     return vol.writeFileSync.and.originalFn.apply(vol, args);
   });
 


### PR DESCRIPTION
## What is this?

As the title suggests, this PR adds support for loading `.cjs` config files and snapshot files. 

This PR also adds support for `.mjs` snapshot files, but **not** config files (cosmiconfig does not support esm files).

Closes #1007 