### PR TITLE
✨ Improve logger functionality

### DIFF
--- a/packages/logger/src/logger.js
+++ b/packages/logger/src/logger.js
@@ -1,6 +1,6 @@
 import { colors } from './utils.js';
 
-const URL_REGEXP = /\bhttps?:\/\/[^\s/$.?#].[^\s]*\b/i;
+const URL_REGEXP = /https?:\/\/[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:;%_+.~#?&//=[\]]*)/i;
 const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
 
 // A PercyLogger instance retains logs in-memory for quick lookups while also writing log

--- a/packages/logger/src/logger.js
+++ b/packages/logger/src/logger.js
@@ -95,6 +95,7 @@ export class PercyLogger {
 
   // Formats messages before they are logged to stdio
   format(debug, level, message, elapsed) {
+    let color = (n, m) => this.isTTY ? colors[n](m) : m;
     let label = 'percy';
     let suffix = '';
 
@@ -112,24 +113,30 @@ export class PercyLogger {
 
       // include elapsed time since last log
       if (elapsed != null) {
-        suffix = ' ' + colors.grey(`(${elapsed}ms)`);
+        suffix = ' ' + color('grey', `(${elapsed}ms)`);
       }
     }
 
-    label = colors.magenta(label);
+    // add colors
+    label = color('magenta', label);
 
     if (level === 'error') {
       // red errors
-      message = colors.red(message);
+      message = color('red', message);
     } else if (level === 'warn') {
       // yellow warnings
-      message = colors.yellow(message);
+      message = color('yellow', message);
     } else if (level === 'info' || level === 'debug') {
       // blue info and debug URLs
-      message = message.replace(URL_REGEXP, colors.blue('$&'));
+      message = message.replace(URL_REGEXP, color('blue', '$&'));
     }
 
     return `[${label}] ${message}${suffix}`;
+  }
+
+  // True if stdout is a TTY interface
+  get isTTY() {
+    return !!this.constructor.stdout.isTTY;
   }
 
   // Replaces the current line with a log message
@@ -137,12 +144,12 @@ export class PercyLogger {
     if (!this.shouldLog(debug, 'info')) return;
     let { stdout } = this.constructor;
 
-    if (stdout.isTTY || !this._progress) {
+    if (this.isTTY || !this._progress) {
       message &&= this.format(debug, message);
-      if (stdout.isTTY) stdout.cursorTo(0);
+      if (this.isTTY) stdout.cursorTo(0);
       else message &&= message + '\n';
       if (message) stdout.write(message);
-      if (stdout.isTTY) stdout.clearLine(1);
+      if (this.isTTY) stdout.clearLine(1);
     }
 
     this._progress = !!message && { message, persist };

--- a/packages/logger/test/logger.test.js
+++ b/packages/logger/test/logger.test.js
@@ -6,7 +6,7 @@ describe('logger', () => {
   let log, inst;
 
   beforeEach(async () => {
-    await helpers.mock({ ansi: true });
+    await helpers.mock({ ansi: true, isTTY: true });
     inst = logger.instance;
     log = logger('test');
   });
@@ -281,7 +281,7 @@ describe('logger', () => {
 
     it('enables debug logging when PERCY_DEBUG is defined', async () => {
       process.env.PERCY_DEBUG = '*';
-      await helpers.mock({ ansi: true });
+      await helpers.mock({ ansi: true, isTTY: true });
 
       logger('test').debug('Debug log');
 
@@ -301,9 +301,9 @@ describe('logger', () => {
       logger('test:3').debug('Debug test 3');
 
       expect(helpers.stderr).toEqual([
-        `[${colors.magenta('percy:test')}] Debug test`,
-        `[${colors.magenta('percy:test:1')}] Debug test 1`,
-        `[${colors.magenta('percy:test:3')}] Debug test 3`
+        '[percy:test] Debug test',
+        '[percy:test:1] Debug test 1',
+        '[percy:test:3] Debug test 3'
       ]);
     });
 
@@ -331,7 +331,6 @@ describe('logger', () => {
       spyOn(logger.stdout, 'cursorTo').and.callThrough();
       spyOn(logger.stdout, 'clearLine').and.callThrough();
       spyOn(logger.stdout, 'write').and.callThrough();
-      logger.stdout.isTTY = true;
       ({ stdout } = logger);
     });
 
@@ -402,7 +401,7 @@ describe('logger', () => {
         log.progress('baz');
 
         expect(stdout.cursorTo).not.toHaveBeenCalled();
-        expect(stdout.write).toHaveBeenCalledWith(`[${colors.magenta('percy')}] foo\n`);
+        expect(stdout.write).toHaveBeenCalledWith('[percy] foo\n');
         expect(stdout.clearLine).not.toHaveBeenCalled();
       });
 
@@ -414,7 +413,7 @@ describe('logger', () => {
 
         expect(stdout.cursorTo).not.toHaveBeenCalled();
         expect(stdout.clearLine).not.toHaveBeenCalled();
-        expect(stdout.write).toHaveBeenCalledWith(`[${colors.magenta('percy')}] bar\n`);
+        expect(stdout.write).toHaveBeenCalledWith('[percy] bar\n');
       });
 
       it('ignores consecutive persistant logs after the first', () => {
@@ -425,10 +424,10 @@ describe('logger', () => {
 
         expect(stdout.cursorTo).not.toHaveBeenCalled();
         expect(stdout.write).toHaveBeenCalledTimes(3);
-        expect(stdout.write).toHaveBeenCalledWith(`[${colors.magenta('percy')}] foo\n`);
-        expect(stdout.write).toHaveBeenCalledWith(`[${colors.magenta('percy')}] bar\n`);
-        expect(stdout.write).not.toHaveBeenCalledWith(`[${colors.magenta('percy')}] baz\n`);
-        expect(stdout.write).toHaveBeenCalledWith(`[${colors.magenta('percy')}] qux\n`);
+        expect(stdout.write).toHaveBeenCalledWith('[percy] foo\n');
+        expect(stdout.write).toHaveBeenCalledWith('[percy] bar\n');
+        expect(stdout.write).not.toHaveBeenCalledWith('[percy] baz\n');
+        expect(stdout.write).toHaveBeenCalledWith('[percy] qux\n');
         expect(stdout.clearLine).not.toHaveBeenCalled();
       });
     });

--- a/packages/logger/test/logger.test.js
+++ b/packages/logger/test/logger.test.js
@@ -75,10 +75,11 @@ describe('logger', () => {
   });
 
   it('highlights info URLs blue', () => {
-    log.info('URL: https://percy.io');
+    let url = 'https://percy.io/?foo[bar]=baz&qux=quux:xyzzy;';
+    log.info(`URL: ${url}`);
 
     expect(helpers.stdout).toEqual([
-      `[${colors.magenta('percy')}] URL: ${colors.blue('https://percy.io')}`
+      `[${colors.magenta('percy')}] URL: ${colors.blue(url)}`
     ]);
   });
 


### PR DESCRIPTION
## What is this?

This PR addresses two small issues with logger and adds another small feature.

- Some URLs don't get fully colored properly in log output. This is fixed with a more verbose URL regular expression.

- In non TTY environments colors aren't always supported and produce raw ansi output. This is fixed by only using colors for TTY stdout streams.

- Depending on the SDK/integration, it can sometimes be beneficial to hook into or override some logging behavior. This is made possible for our logger by moving message formatting into the write method so we can pass along the full log payloads. With full payloads, one is able to set a custom `logger.instance.write` method to handle log output.

Thanks to @grachov for the ideas with #953 & #961.