### PR TITLE
🐛 Fix cli-snapshot warning for top-level references option

### DIFF
--- a/packages/cli-snapshot/src/snapshot.js
+++ b/packages/cli-snapshot/src/snapshot.js
@@ -81,8 +81,8 @@ export const snapshot = command('snapshot', {
     if (file) {
       // load snapshots file
       let snapshots = yield loadSnapshotFile(file);
-      // accept a config object instead of an array of snapshots
-      let config = Array.isArray(snapshots) ? { snapshots } : snapshots;
+      // remove any references and accept an array of snapshots instead of an config object
+      let { references, ...config } = Array.isArray(snapshots) ? { snapshots } : snapshots;
       options = merge(config, { baseUrl, include, exclude });
     } else if (serve) {
       // serve and snapshot a static directory

--- a/packages/cli-snapshot/test/file.test.js
+++ b/packages/cli-snapshot/test/file.test.js
@@ -224,4 +224,24 @@ describe('percy snapshot <file>', () => {
       '[percy] Error: No snapshots found'
     ]);
   });
+
+  it('allows a top-level references object for .yaml references', async () => {
+    fs.writeFileSync('references.yaml', [
+      'references:',
+      '  ref: &ref Reference Snapshot',
+      'snapshots:',
+      '  - url: http://localhost:8000/',
+      '    name: *ref'
+    ].join('\n'));
+
+    await snapshot(['./references.yaml']);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      '[percy] Percy has started!',
+      '[percy] Snapshot taken: Reference Snapshot',
+      '[percy] Uploading 1 snapshot...',
+      '[percy] Finalized build #1: https://percy.io/test/test/123'
+    ]);
+  });
 });


### PR DESCRIPTION
## What is this?

When using the `percy snapshot` command with a snapshots file, we previously were relaxed about top-level options so YAML files could make use of references and anchors. Since moving some `cli-snapshot` features into `core`, top-level options became more strict as other types of files can now be provided (such as sitemap/static server options).

While references still work, they now inadvertently produce a validation warning (#898). This PR removes this warning for the `references` property specifically by removing that property from the config object before passing it along to the snapshot method. While we previously allowed any name for references, going forward they should be kept to the `references` property, otherwise the validation warning will be logged.

Fixes #898 