### PR TITLE
🐛 Improve aborting during bulk snapshots

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@ extends: standard
 plugins:
   - babel
 rules:
+  one-var: off
   prefer-const: off
   no-extra-parens: off
   no-unused-expressions: off

--- a/packages/cli-exec/src/start.js
+++ b/packages/cli-exec/src/start.js
@@ -14,15 +14,14 @@ export const start = command('start', {
   }
 }, async function*({ percy, exit }) {
   if (!percy) exit(0, 'Percy is disabled');
+  let { yieldFor } = await import('@percy/cli-command/utils');
 
   // start percy
   yield* percy.yield.start();
 
   try {
     // run until stopped or terminated
-    while (percy.readyState < 3) {
-      yield new Promise(r => setImmediate(r));
-    }
+    yield* yieldFor(() => percy.readyState >= 3);
   } catch (error) {
     await percy.stop(true);
     throw error;

--- a/packages/cli-snapshot/test/directory.test.js
+++ b/packages/cli-snapshot/test/directory.test.js
@@ -45,7 +45,7 @@ describe('percy snapshot <directory>', () => {
       '[percy] Snapshot taken: /test-1.html',
       '[percy] Snapshot taken: /test-2.html',
       '[percy] Snapshot taken: /test-3.html',
-      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots'),
+      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots?'),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]));
   });
@@ -60,7 +60,7 @@ describe('percy snapshot <directory>', () => {
       '[percy] Snapshot taken: /base/test-2.html',
       '[percy] Snapshot taken: /base/test-3.html',
       '[percy] Snapshot taken: /base/test-index/index.html',
-      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots'),
+      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots?'),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]));
   });

--- a/packages/cli-snapshot/test/file.test.js
+++ b/packages/cli-snapshot/test/file.test.js
@@ -120,7 +120,7 @@ describe('percy snapshot <file>', () => {
       '[percy] Snapshot taken: JS Snapshot',
       '[percy] Snapshot taken: JS Snapshot 2',
       '[percy] Snapshot taken: Other JS Snapshot',
-      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots'),
+      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots?'),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]);
   });
@@ -146,7 +146,7 @@ describe('percy snapshot <file>', () => {
       '[percy] Snapshot taken: /',
       '[percy] Snapshot taken: /one',
       '[percy] Snapshot taken: /two',
-      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots'),
+      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots?'),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]));
   });
@@ -171,7 +171,7 @@ describe('percy snapshot <file>', () => {
       '[percy] Snapshot taken: Snapshot #42',
       '[percy] Snapshot taken: Snapshot #62',
       '[percy] Snapshot taken: Snapshot #82',
-      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots'),
+      jasmine.stringMatching('\\[percy\\] Uploading \\d snapshots?'),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]));
   });

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -10,7 +10,8 @@ import {
   hostnameMatches,
   createRootResource,
   createPercyCSSResource,
-  createLogResource
+  createLogResource,
+  yieldTo
 } from './utils.js';
 
 // Throw a better error message for missing or invalid urls
@@ -103,17 +104,16 @@ export function mapSnapshotOptions(percy, snapshots, config) {
 }
 
 // Returns an array of derived snapshot options
-export async function gatherSnapshots(percy, options) {
+export async function* gatherSnapshots(percy, options) {
   let { baseUrl, snapshots } = options;
 
   if ('url' in options) snapshots = [options];
-  if ('sitemap' in options) snapshots = await getSitemapSnapshots(options);
+  if ('sitemap' in options) snapshots = yield getSitemapSnapshots(options);
 
   // validate evaluated snapshots
   if (typeof snapshots === 'function') {
-    ({ snapshots } = validateSnapshotOptions({
-      baseUrl, snapshots: await snapshots(baseUrl)
-    }));
+    snapshots = yield* yieldTo(snapshots(baseUrl));
+    snapshots = validateSnapshotOptions({ baseUrl, snapshots }).snapshots;
   }
 
   // map snapshots with snapshot options

--- a/packages/core/test/unit/utils.test.js
+++ b/packages/core/test/unit/utils.test.js
@@ -161,7 +161,6 @@ describe('Unit / Utils', () => {
       resolve(6);
 
       await expectAsync(promise).toBeResolved();
-      //console.log('promise resolved');
       await expectAsync(gen.next()).toBeResolvedTo(
         { done: true, value: [2, 4, null, 3, 6] });
     });


### PR DESCRIPTION
## What is this?

Currently, when taking bulk snapshots by either providing an array of snapshots or a snapshots function, a few aspects of the process cannot be aborted as expected, and instead get aborted after running asynchronously.

This PR adds a few core generator utils to create generators from promises (`yieldTo`) and handle running generators concurrently (`yieldAll`). The `yieldTo` util was also made to handle other values besides promises so `yieldAll` can behave similarly to `Promise.all` while still yielding to each generator.

With the help of these additional utils, bulk snapshots processing can now better handle aborting (by using generators instead of promises). A couple of other places were also adapted with these utils, as well as unit tests were added.