### PR TITLE
🐛 Use then instead of finally for promises with the yieldTo util

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -100,7 +100,7 @@ export class AbortError extends Error {
 // An async generator that yields after every event loop until the promise settles
 export async function* yieldTo(subject) {
   let pending = typeof subject?.finally === 'function';
-  if (pending) subject = subject.finally(() => (pending = false));
+  if (pending) subject.then(() => (pending = false), () => (pending = false));
   /* eslint-disable-next-line no-unmodified-loop-condition */
   while (pending) yield new Promise(r => setImmediate(r));
   return isGenerator(subject) ? yield* subject : await subject;


### PR DESCRIPTION
## What is this?

Some versions of V8 complain about promise rejections if there is no detected catch handler. Even though we await on these promises and allow them to reject asynchronously, the error can still surface as "PromiseRejectionHandledWarning: Promise rejection was handled asynchronously."

This is fixed by using then with a catch handler instead of a single finally. The promise reference no longer needs to be updated since it would cause issues to be swallowed.