### PR TITLE
✨ Config schema and validation improvements

### DIFF
--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -152,7 +152,7 @@ function a(word) {
 }
 
 // Default errors anywhere within these keywords can be confusing
-const HIDE_NESTED_KEYWORDS = ['oneOf', 'anyOf', 'allOf', 'not'];
+const HIDE_NESTED_KEYWORDS = ['oneOf', 'anyOf', 'allOf', 'if', 'then', 'else', 'not'];
 
 function shouldHideError(key, path, error) {
   let { parentSchema, keyword, schemaPath } = error;

--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -130,10 +130,17 @@ export function addSchema(schemas) {
   ajv.removeSchema('/config');
 
   for (let [key, schema] of entries(schemas)) {
-    let $id = `/config/${key}`;
-    if (ajv.getSchema($id)) ajv.removeSchema($id);
-    assign(config.properties, { [key]: { $ref: $id } });
-    ajv.addSchema(schema, $id);
+    if (key === '$config') {
+      assign(config, (
+        typeof schema === 'function'
+          ? schema(config) : schema
+      ));
+    } else {
+      let $id = `/config/${key}`;
+      if (ajv.getSchema($id)) ajv.removeSchema($id);
+      assign(config.properties, { [key]: { $ref: $id } });
+      ajv.addSchema(schema, $id);
+    }
   }
 
   return ajv.addSchema(config, '/config');

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -147,6 +147,31 @@ describe('PercyConfig', () => {
         message: 'must be a string, received a number'
       }]);
     });
+
+    it('can manipulate other attributes of the config schema', () => {
+      PercyConfig.addSchema([{
+        $config: {
+          properties: {
+            test: { const: 'foo' }
+          }
+        }
+      }, {
+        $config: c => ({
+          properties: {
+            test: {
+              oneOf: [c.properties.test, { const: 'bar' }],
+              errors: { oneOf: 'invalid' }
+            }
+          }
+        })
+      }]);
+
+      expect(PercyConfig.validate({ test: 'foo' })).toBeUndefined();
+      expect(PercyConfig.validate({ test: 'bar' })).toBeUndefined();
+      expect(PercyConfig.validate({ test: 'baz' })).toEqual([
+        { path: 'test', message: 'invalid' }
+      ]);
+    });
   });
 
   describe('.getDefaults()', () => {

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -377,6 +377,99 @@ describe('PercyConfig', () => {
         message: 'disallowed property'
       }]);
     });
+
+    it('handles complex conditional schemas', () => {
+      PercyConfig.addSchema({
+        $id: '/test/complex',
+        $ref: '/test/complex#/$defs/complete',
+        $defs: {
+          condition: {
+            isTrue: {
+              required: ['condition'],
+              properties: { condition: { const: true } }
+            },
+            isNotFalse: {
+              not: {
+                required: ['condition'],
+                properties: { condition: { const: false } }
+              }
+            },
+            disallowBar: {
+              disallowed: ['bar'],
+              error: 'disallowed with condition enabled'
+            }
+          },
+          common: {
+            type: 'object',
+            if: { $ref: '/test/complex#/$defs/condition/isTrue' },
+            then: { $ref: '/test/complex#/$defs/condition/disallowBar' },
+            properties: {
+              foo: { type: 'string' },
+              bar: { type: 'string' },
+              condition: { type: 'boolean' }
+            }
+          },
+          item: {
+            type: 'object',
+            $ref: '/test/complex#/$defs/common',
+            unevaluatedProperties: false,
+            properties: {
+              name: { type: 'string' }
+            }
+          },
+          complete: {
+            type: 'object',
+            unevaluatedProperties: false,
+            $ref: '/test/complex#/$defs/common',
+            properties: {
+              items: {
+                type: 'array',
+                items: { $ref: '/test/complex#/$defs/item' }
+              }
+            },
+            allOf: [{
+              if: { $ref: '/test/complex#/$defs/condition/isTrue' },
+              then: {
+                properties: {
+                  items: {
+                    type: 'array',
+                    items: {
+                      $ref: '/test/complex#/$defs/item',
+                      if: { $ref: '/test/complex#/$defs/condition/isNotFalse' },
+                      then: { $ref: '/test/complex#/$defs/condition/disallowBar' }
+                    }
+                  }
+                }
+              }
+            }]
+          }
+        }
+      });
+
+      expect(PercyConfig.validate({
+        condition: true,
+        foo: 'top foo',
+        bar: 'top bar',
+        items: [{
+          name: 'item 1',
+          foo: 'item 1 foo'
+        }, {
+          name: 'item 2',
+          foo: 'item 2 foo',
+          bar: 'item 2 bar'
+        }, {
+          name: 'item 3',
+          bar: 'item 3 bar',
+          condition: false
+        }]
+      }, '/test/complex')).toEqual([{
+        path: 'bar',
+        message: 'disallowed with condition enabled'
+      }, {
+        path: 'items[1].bar',
+        message: 'disallowed with condition enabled'
+      }]);
+    });
   });
 
   describe('.migrate()', () => {


### PR DESCRIPTION
## What is this?

While adjusting the config schema for Storybook, there's a requirement to conditionally validate some properties. Specifically, when JavaScript is enabled, DOM capture options cannot be used. While this can be partially achieved with the current `@percy/config` package, this PR makes some adjustments to not only make it easier, but to also add the ability for more broad config validations.

First, we currently suppress confusing validation warnings from `allOf`, `oneOf`, `anyOf`, and `not`. This is because the default validation warnings are _always_ generated even if that schema is not the best match. For example, if `anyOf` is used to accept both a number or an array of numbers, the default warnings would show at least one failure since both cannot be true, but the whole schema is valid since only one needs to be true. For conditional properties like `if`, `then`, and `else`, similar default warnings are generated unless they are suppressed.

Second, Storybook capture options could not be disallowed in a `.percy.yml` config file when `snapshot.enableJavaScript` is true. This is because the current way to manipulate the config file schema is by adding individual object properties with no method available for the properties to introspect each other. To help with this, this PR adds a new `$config` keyword used when registering a config file. This keyword can be used to manipulate the entire config file schema without restriction. This should be used sparingly since it has the potential to remove or replace the config file schema completely.

With these two changes to config schemas, the Storybook SDK will be able to specify a schema in which capture options are only accepted as long as JavaScript is not enabled.