### PR TITLE
🐛 Update snapshot typedefs

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -38,6 +38,8 @@ interface CommonSnapshotOptions {
   minHeight?: number;
   percyCSS?: string;
   enableJavaScript?: boolean;
+  devicePixelRatio?: number;
+  scope?: string;
 }
 
 export interface SnapshotOptions extends CommonSnapshotOptions {

--- a/packages/core/types/index.test-d.ts
+++ b/packages/core/types/index.test-d.ts
@@ -15,7 +15,9 @@ const percyOptions: PercyOptions = {
     widths: [1280],
     minHeight: 1024,
     percyCSS: '.percy { color: purple; }',
-    enableJavaScript: false
+    enableJavaScript: false,
+    scope: '.percy',
+    devicePixelRatio: 2
   },
   discovery: {
     requestHeaders: { Authorization: 'foobar' },


### PR DESCRIPTION
## What is this?

We were missing `devicePixelRatio` & `scope` in the TS typedefs. This will close https://github.com/percy/percy-playwright/issues/115