### PR TITLE
✨Add core option to skip asset discovery

### DIFF
--- a/packages/cli-command/README.md
+++ b/packages/cli-command/README.md
@@ -171,9 +171,6 @@ option, if the environment variable `PERCY_ENABLE` is `0`, the callback _will no
 instance (and can act accordingly).
 
 - `percy` — Enables creation of a `@percy/core` instance initialized with provided options.
-  - `discoveryFlags` — When `false` prevents percy discovery flags from being accepted, but will
-    still allow other percy flags such as `--config` and `--dry-run`.
-  - `...` — All other options are passed along to the new percy instance.
 
 #### Config
 

--- a/packages/cli-command/src/command.js
+++ b/packages/cli-command/src/command.js
@@ -25,7 +25,7 @@ function withBuiltIns(definition) {
     builtInFlags.PERCY.forEach(addDedupedFlag);
 
     // maybe include percy discovery flags
-    if (def.percy.discoveryFlags !== false) {
+    if (def.percy.skipDiscovery !== true) {
       builtInFlags.DISCOVERY.forEach(addDedupedFlag);
     }
   }
@@ -67,8 +67,8 @@ async function runCommandWithContext(parsed) {
   if (def.percy) {
     let { Percy } = await import('@percy/core');
 
-    // set defaults and prune preconfiguraton options
-    let conf = del({ server: false, ...def.percy }, 'discoveryFlags');
+    // shallow merge with default options
+    let conf = { server: false, ...def.percy };
     if (pkg) conf.clientInfo ||= `${pkg.name}/${pkg.version}`;
     conf.environmentInfo ||= `node/${process.version}`;
 

--- a/packages/cli-command/test/flags.test.js
+++ b/packages/cli-command/test/flags.test.js
@@ -88,7 +88,7 @@ describe('Built-in flags:', () => {
     });
 
     it('does not show discovery flags when excluded', async () => {
-      await command('foo', { percy: { discoveryFlags: false } })(['--help']);
+      await command('foo', { percy: { skipDiscovery: true } })(['--help']);
       expect(logger.stdout).toEqual([expectedMinPercyFlags]);
       expect(logger.stdout).not.toEqual([expectedAllPercyFlags]);
     });

--- a/packages/cli-upload/src/upload.js
+++ b/packages/cli-upload/src/upload.js
@@ -48,8 +48,8 @@ export const upload = command('upload', {
   ],
 
   percy: {
-    discoveryFlags: false,
-    deferUploads: true
+    deferUploads: true,
+    skipDiscovery: true
   },
 
   config: {
@@ -76,9 +76,7 @@ export const upload = command('upload', {
 
   // the internal upload queue shares a concurrency with the snapshot queue
   percy.setConfig({ discovery: { concurrency: config.concurrency } });
-
-  // do not launch a browser when starting
-  yield* percy.yield.start({ browser: false });
+  yield* percy.yield.start();
 
   for (let filename of pathnames) {
     let file = path.parse(filename);

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -155,7 +155,7 @@ export class Percy {
 
   // Starts a local API server, a browser process, and queues creating a new Percy build which will run
   // at a later time when uploads are deferred, or run immediately when not deferred.
-  async *start(options) {
+  async *start() {
     // already starting or started
     if (this.readyState != null) return;
     this.readyState = 0;
@@ -190,9 +190,7 @@ export class Percy {
       if (!this.deferUploads) await buildTask;
 
       // maybe launch the discovery browser
-      if (!this.skipDiscovery && options?.browser !== false) {
-        yield this.browser.launch();
-      }
+      if (!this.skipDiscovery) yield this.browser.launch();
 
       // start the server after everything else is ready
       yield this.server?.listen();

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -45,7 +45,9 @@ export class Percy {
     deferUploads,
     // run without uploading anything
     skipUploads,
-    // implies `skipUploads` and also skips asset discovery
+    // run without asset discovery
+    skipDiscovery,
+    // implies `skipUploads` and `skipDiscovery`
     dryRun,
     // implies `dryRun`, silent logs, and adds extra api endpoints
     testing,
@@ -68,6 +70,7 @@ export class Percy {
     this.testing = testing ? {} : null;
     this.dryRun = !!testing || !!dryRun;
     this.skipUploads = this.dryRun || !!skipUploads;
+    this.skipDiscovery = this.dryRun || !!skipDiscovery;
     this.delayUploads = this.skipUploads || !!delayUploads;
     this.deferUploads = this.delayUploads || !!deferUploads;
     if (this.deferUploads) this.#uploads.stop();
@@ -187,7 +190,7 @@ export class Percy {
       if (!this.deferUploads) await buildTask;
 
       // maybe launch the discovery browser
-      if (!this.dryRun && options?.browser !== false) {
+      if (!this.skipDiscovery && options?.browser !== false) {
         yield this.browser.launch();
       }
 
@@ -231,8 +234,8 @@ export class Percy {
         if (close) this.#snapshots.close();
 
         yield* this.#snapshots.flush(s => {
-          // do not log a count when not closing or while dry-running
-          if (!close || this.dryRun) return;
+          // do not log a count when not closing or if asset discovery is disabled
+          if (!close || this.skipDiscovery) return;
           this.log.progress(`Processing ${s} snapshot${s !== 1 ? 's' : ''}...`, !!s);
         });
       }

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -376,6 +376,13 @@ export async function* discoverSnapshotResources(percy, snapshot, callback) {
       .map(resource => [resource.url, resource])
   ));
 
+  // when no discovery browser is available, do not attempt to discover other resources
+  if (percy.skipDiscovery && !snapshot.domSnapshot) {
+    throw new Error('Cannot capture DOM snapshot when asset discovery is disabled');
+  } else if (percy.skipDiscovery) {
+    return handleSnapshotResources(snapshot, resources, callback);
+  }
+
   // open a new browser page
   let page = yield percy.browser.page({
     enableJavaScript: snapshot.enableJavaScript ?? !snapshot.domSnapshot,


### PR DESCRIPTION
## What is this?

While asset discovery is usually necessary for taking DOM snapshots, sometimes we don't actually need to take DOM snapshots at all, such as with the `upload` command. For these circumstances, downloading a browser for asset discovery that won't ever be used is unnecessary.

For the `upload` command, we currently have a 2-part approach to skipping asset discovery. First, we utilize a `@percy/cli-command` specific option, `discoveryFlags`, to suppress asset discovery flags from being accepted. Second, we provide the `percy.start()` method with an option to skip launching a browser, which in-turn prevents the browser download completely.

For future projects, this 2-part solution isn't possible, and even now seems like a workaround for a missing feature. This PR adds that missing feature: an option to skip asset discovery altogether with a new `skipDiscovery` core option.

The new `skipDiscovery` option actually works nicely with the existing `dryRun` option. The `dryRun` option already skips asset discovery along with disabling uploads. With the new `skipDiscovery` option, some logic branches were changed from checking for `dryRun`. Now, besides a few specific places for logging, `dryRun` is equivalent to `skipDiscovery && skipUploads`.

Extra logic was added to prevent snapshot captures when asset discovery is disabled since capturing the DOM requires a browser which `skipDiscovery` specifically prevents from being launched. If any normal DOM snapshots are received, they simply bypass asset discovery completely.

This option is not currently exposed publicly in any way. Only the `upload` command and specific future SDKs will utilize this feature internally.