### PR TITLE
✨ Format logger messages padded by newlines

### DIFF
--- a/packages/cli/src/update.js
+++ b/packages/cli/src/update.js
@@ -82,13 +82,9 @@ export async function checkForUpdate() {
 
     // a new version is available
     if (age !== 0) {
-      let range = `${colors.red(pkg.version)} -> ${colors.green(versions[0])}`;
-
-      log.stderr.write('\n');
-      log.warn(`${age > 0 && age < 10 ? 'A new version of @percy/cli is available!' : (
+      log.warn(`\n${age > 0 && age < 10 ? 'A new version of @percy/cli is available!' : (
         'Heads up! The current version of @percy/cli is more than 10 releases behind!'
-      )} ${range}`);
-      log.stderr.write('\n');
+      )} ${colors.red(pkg.version)} -> ${colors.green(versions[0])}\n`);
     }
   } catch (err) {
     log.debug('Unable to check for updates');

--- a/packages/cli/test/update.test.js
+++ b/packages/cli/test/update.test.js
@@ -58,7 +58,7 @@ describe('CLI update check', () => {
     await checkForUpdate();
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '', '[percy] A new version of @percy/cli is available! 1.0.0 -> 1.1.0', ''
+      '\n[percy] A new version of @percy/cli is available! 1.0.0 -> 1.1.0\n'
     ]);
   });
 
@@ -68,8 +68,8 @@ describe('CLI update check', () => {
     await checkForUpdate();
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
-      '', '[percy] Heads up! The current version of @percy/cli ' +
-        'is more than 10 releases behind! 1.0.0 -> 2.0.0', ''
+      '\n[percy] Heads up! The current version of @percy/cli ' +
+        'is more than 10 releases behind! 1.0.0 -> 2.0.0\n'
     ]);
   });
 

--- a/packages/logger/src/logger.js
+++ b/packages/logger/src/logger.js
@@ -1,5 +1,6 @@
 import { colors } from './utils.js';
 
+const LINE_PAD_REGEXP = /^(\n*)(.*?)(\n*)$/s;
 const URL_REGEXP = /https?:\/\/[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:;%_+.~#?&//=[\]]*)/i;
 const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
 
@@ -96,8 +97,8 @@ export class PercyLogger {
   // Formats messages before they are logged to stdio
   format(debug, level, message, elapsed) {
     let color = (n, m) => this.isTTY ? colors[n](m) : m;
+    let begin, end, suffix = '';
     let label = 'percy';
-    let suffix = '';
 
     if (arguments.length === 1) {
       // format(message)
@@ -107,8 +108,11 @@ export class PercyLogger {
       [level, message] = [null, level];
     }
 
+    // do not format leading or trailing newlines
+    [, begin, message, end] = message.match(LINE_PAD_REGEXP);
+
+    // include debug information
     if (this.level === 'debug') {
-      // include debug info in the label
       if (debug) label += `:${debug}`;
 
       // include elapsed time since last log
@@ -131,7 +135,7 @@ export class PercyLogger {
       message = message.replace(URL_REGEXP, color('blue', '$&'));
     }
 
-    return `[${label}] ${message}${suffix}`;
+    return `${begin}[${label}] ${message}${suffix}${end}`;
   }
 
   // True if stdout is a TTY interface

--- a/packages/logger/test/logger.test.js
+++ b/packages/logger/test/logger.test.js
@@ -168,6 +168,11 @@ describe('logger', () => {
     expect(logger.format('other', 'warn', 'elapsed', 100)).toEqual(
       `[${colors.magenta('percy:other')}] ` +
         `${colors.yellow('elapsed')} ${colors.grey('(100ms)')}`);
+
+    // does not format leading or trailing newlines
+    expect(logger.format('padded', 'debug', '\n\nnewlines\n\n', 25)).toEqual(
+      `\n\n[${colors.magenta('percy:padded')}] ` +
+        `newlines ${colors.grey('(25ms)')}\n\n`);
   });
 
   it('exposes own stdout and stderr streams', () => {


### PR DESCRIPTION
## What is this?

When adding a label to a log message, the label should be added after any leading newlines. Likewise, debug timestamps should be added before any trailing newlines. This is currently useful for the version check log, however will also be utilized for a future planned feature.