### PR TITLE
🐛 Fix static server base-url issue

### DIFF
--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -141,9 +141,12 @@ export function validateSnapshotOptions(options) {
     clientInfo, environmentInfo, snapshots, ...migrated
   } = PercyConfig.migrate(options, schema);
 
+  // maintain a trailing slash for base URLs to normalize them
+  if (migrated.baseUrl?.endsWith('/') === false) migrated.baseUrl += '/';
+  let baseUrl = schema === '/snapshot/server' ? 'http://localhost/' : migrated.baseUrl;
+
   // gather info for validating individual snapshot URLs
   let isSnapshot = schema === '/snapshot/dom' || schema === '/snapshot';
-  let baseUrl = schema === '/snapshot/server' ? 'http://localhost' : options.baseUrl;
   let snaps = isSnapshot ? [migrated] : Array.isArray(snapshots) ? snapshots : [];
   for (let snap of snaps) validURL(typeof snap === 'string' ? snap : snap.url, baseUrl);
 

--- a/packages/core/test/snapshot-multiple.test.js
+++ b/packages/core/test/snapshot-multiple.test.js
@@ -328,6 +328,22 @@ describe('Snapshot multiple', () => {
       ]));
     });
 
+    it('can supply a base-url to serve files at', async () => {
+      await percy.snapshot({
+        serve: './public',
+        baseUrl: '/foo/bar',
+        cleanUrls: true
+      });
+
+      expect(logger.stderr).toEqual([]);
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Snapshot taken: /foo/bar',
+        '[percy] Snapshot taken: /foo/bar/about',
+        '[percy] Snapshot taken: /foo/bar/blog/foo',
+        '[percy] Snapshot taken: /foo/bar/blog/bar'
+      ]));
+    });
+
     it('closes the server when aborted', async () => {
       let ctrl = new AbortController();
 


### PR DESCRIPTION
## What is this?

The base-url option for static servers wasn't working correctly for two reasons. First, is the assumed sitemap URL was being constructed in a way that would leave off trailing paths from URLs, like how relative links work. Second, when creating a static server, the generated sitemap was only being served at the server root, not at the base-url root.

The first part of the issue is fixed by ensuring that any provided base-url has a trailing forward slash so when the URL is constructed, it treats the base-url as the path root. The second part is fixed by adjusting static server creation to host the generated sitemap at the correct path under the base-url.