### PR TITLE
🐛 Use a file URL when importing snapshot files

### DIFF
--- a/packages/cli-snapshot/src/snapshot.js
+++ b/packages/cli-snapshot/src/snapshot.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { pathToFileURL } from 'url';
 import command from '@percy/cli-command';
 import * as SnapshotConfig from './config.js';
 
@@ -131,7 +132,7 @@ async function loadSnapshotFile(file) {
   let ext = path.extname(file);
 
   if (/\.(c|m)?js$/.test(ext)) {
-    let { default: module } = await import(path.resolve(file));
+    let { default: module } = await import(pathToFileURL(file));
     return typeof module === 'function' ? await module() : module;
   } else if (ext === '.json') {
     return JSON.parse(fs.readFileSync(file, 'utf-8'));


### PR DESCRIPTION
## What is this?

When using the `percy snapshot` command and importing a snapshot file on Windows, the drive letter can sometimes get interpreted as a URL protocol, which causes the import to fail. By using an explicit file URL with a `file://` protocol, the import will work in all environments. This PR updates the snapshot file import to use `URL.pathToFileURL()` which will also automatically resolve the absolute path like we were doing before.

This was likely missed by our Windows CI due to mocked ES modules and the mocked filesystem. Unfortunately there isn't much to do to test for this without undoing the mocks and writing a real file when running tests in Windows.