### PR TITLE
[WIP] Add screenshot endpoint for native apps

### DIFF
--- a/packages/cli-app/src/app.js
+++ b/packages/cli-app/src/app.js
@@ -2,7 +2,7 @@ import command from '@percy/cli-command';
 import exec from './exec.js';
 
 export const app = command('app', {
-  description: 'Create Percy builds for native app snapshots',
+  description: 'Create Percy builds for native app screenshots',
   hidden: 'This command is still in development and may not work as expected',
   commands: [exec]
 });

--- a/packages/cli-app/src/exec.js
+++ b/packages/cli-app/src/exec.js
@@ -10,7 +10,8 @@ export const start = command('start', {
 
   percy: {
     server: true,
-    skipDiscovery: true
+    skipDiscovery: true,
+    isApp: true,
   }
 }, ExecPlugin.start.callback);
 
@@ -25,7 +26,8 @@ export const exec = command('exec', {
 
   percy: {
     server: true,
-    skipDiscovery: true
+    skipDiscovery: true,
+    isApp: true,
   }
 }, ExecPlugin.default.callback);
 

--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -128,9 +128,12 @@ export function createPercyServer(percy, port) {
       let wrapper = '(window.PercyAgent = class { snapshot(n, o) { return PercyDOM.serialize(o); } });';
       return res.send(200, 'applicaton/javascript', content.concat(wrapper));
     })
-  // post one or more snapshots
+  // post one or more screenshot
     .route('post', '/percy/screenshot', async (req, res) => {
-      // TODO
+      let screenshot = percy.screenshot(req.body);
+      if (!req.url.searchParams.has('async')) await screenshot;
+      // Call Rails EP to mark seesion as Percy Session
+      return res.json(200, { success: true });
     })
   // stops percy at the end of the current event loop
     .route('/percy/stop', (req, res) => {

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -73,7 +73,7 @@ export class Percy {
     this.dryRun = !!testing || !!dryRun;
     this.skipUploads = this.dryRun || !!skipUploads;
     this.skipDiscovery = this.dryRun || !!skipDiscovery;
-    this.isApp = !!isApp;
+    this.isApp = isApp;
     this.delayUploads = this.skipUploads || !!delayUploads;
     this.deferUploads = this.delayUploads || !!deferUploads;
     if (this.deferUploads) this.#uploads.stop();

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -48,6 +48,8 @@ export class Percy {
     // run without asset discovery
     skipDiscovery,
     // implies `skipUploads` and `skipDiscovery`
+    isApp = false,
+    // true is server is running for native app
     dryRun,
     // implies `dryRun`, silent logs, and adds extra api endpoints
     testing,
@@ -71,6 +73,7 @@ export class Percy {
     this.dryRun = !!testing || !!dryRun;
     this.skipUploads = this.dryRun || !!skipUploads;
     this.skipDiscovery = this.dryRun || !!skipDiscovery;
+    this.isApp = !!isApp;
     this.delayUploads = this.skipUploads || !!delayUploads;
     this.deferUploads = this.delayUploads || !!deferUploads;
     if (this.deferUploads) this.#uploads.stop();

--- a/packages/sdk-utils/src/post-screenshot.js
+++ b/packages/sdk-utils/src/post-screenshot.js
@@ -1,0 +1,18 @@
+import percy from './percy-info.js';
+import request from './request.js';
+
+// Post screenshot data to the screenshot endpoint. If the screenshot endpoint responds with a closed
+// error message, signal that Percy has been disabled.
+export async function postScreenshot(options, params) {
+  let query = params ? `?${new URLSearchParams(params)}` : '';
+
+  await request.post(`/percy/screenshot${query}`, options).catch(err => {
+    if (err.response?.body?.build?.error) {
+      percy.enabled = false;
+    } else {
+      throw err;
+    }
+  });
+}
+
+export default postScreenshot;


### PR DESCRIPTION
Jira task: https://browserstack.atlassian.net/browse/PAPP-27

1. add isApp config in app:exec
2. Update route depending on if percy server is for web/ app
3. Add `/percy/screenshot` endpoint for native apps
4. Add screenshot fn in client.js to post to API & call rails endpoint for AA intergration.