### PR TITLE
🐛 Remove remote logger

### DIFF
--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -142,6 +142,7 @@ export class Server extends http.Server {
       super.close(resolve);
     });
   }
+
   // initial routes include cors and 404 handling
   #routes = [{
     priority: -1,

--- a/packages/core/test/unit/server.test.js
+++ b/packages/core/test/unit/server.test.js
@@ -71,39 +71,6 @@ describe('Unit / Server', () => {
     });
   });
 
-  describe('#websocket([pathname], handler)', () => {
-    async function ws(path) {
-      let res, rej, deferred;
-      let { default: WS } = await import('ws');
-      deferred = new Promise((...a) => ([res, rej] = a));
-      new WS(server.address().replace('http', 'ws') + path)
-        .once('message', v => res(v.toString()))
-        .once('error', e => rej(e));
-      return deferred;
-    }
-
-    beforeEach(async () => {
-      server.websocket('/foo', ws => ws.send('bar'));
-      await server.listen();
-    });
-
-    it('handles websocket upgrades at the specified pathname', async () => {
-      await expectAsync(ws('/foo')).toBeResolvedTo('bar');
-      await expectAsync(ws('/'))
-        .toBeRejectedWithError('Unexpected server response: 400');
-    });
-
-    it('handles websocket upgrades without a pathname', async () => {
-      server.websocket(ws => ws.send('foo'));
-      server.websocket('/bar', ws => ws.send('baz'));
-
-      await expectAsync(ws('/')).toBeResolvedTo('foo');
-      await expectAsync(ws('/foo')).toBeResolvedTo('bar');
-      await expectAsync(ws('/bar')).toBeResolvedTo('baz');
-      await expectAsync(ws('/baz')).toBeResolvedTo('foo');
-    });
-  });
-
   describe('#route([method][, pathname], handler)', () => {
     beforeEach(async () => {
       await server.listen();

--- a/packages/sdk-utils/README.md
+++ b/packages/sdk-utils/README.md
@@ -43,8 +43,7 @@ percy.domScript === fs.readFile(require.resolve('@percy/dom'))
 Returns `true` or `false` if the Percy CLI API server is running. Calls the server's `/healthcheck`
 endpoint and populates information for the [`percy`](#percy) property. The result of this function
 is cached and subsequent calls will return the first cached result. If the healthcheck fails, will
-log a message unless the CLI loglevel is `quiet` or `silent`. Upon a successful health check, a
-remote logging connection is also established.
+log a message unless the CLI loglevel is `quiet` or `silent`.
 
 ``` js
 import { isPercyEnabled } from '@percy/sdk-utils'

--- a/packages/sdk-utils/src/logger.js
+++ b/packages/sdk-utils/src/logger.js
@@ -1,5 +1,3 @@
-import percy from './percy-info.js';
-
 // Used when determining if a message should be logged
 const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
 
@@ -18,7 +16,6 @@ const loglevel = logger.loglevel = lvl => {
 // Track and send/write logs for the specified namespace and log level
 const log = logger.log = (ns, lvl, msg, meta) => {
   let err = typeof msg !== 'string' && (lvl === 'error' || lvl === 'debug');
-  meta = { remote: true, ...meta };
 
   // keep log history of full message
   let message = err ? msg.stack : msg.toString();

--- a/packages/sdk-utils/src/percy-enabled.js
+++ b/packages/sdk-utils/src/percy-enabled.js
@@ -26,10 +26,6 @@ export async function isPercyEnabled() {
       log.info('Percy is not running, disabling snapshots');
       log.debug(error);
     }
-
-    if (percy.enabled) {
-      await logger.remote();
-    }
   }
 
   return percy.enabled;

--- a/packages/sdk-utils/test/helpers.js
+++ b/packages/sdk-utils/test/helpers.js
@@ -11,7 +11,6 @@ const helpers = {
     delete process.env.PERCY_LOGLEVEL;
     delete process.env.PERCY_SERVER_ADDRESS;
     await helpers.test('reset');
-    await utils.logger.remote();
   },
 
   async test(cmd, arg) {

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -2,9 +2,34 @@ import helpers from './helpers.js';
 import utils from '@percy/sdk-utils';
 
 describe('SDK Utils', () => {
+  let err, log, stdout, stderr;
+
+  let { logger } = utils;
   let browser = process.env.__PERCY_BROWSERIFIED__;
+  let ANSI_REG = new RegExp('[\\u001B\\u009B][[\\]()#;?]*(' +
+    '(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)|' +
+    '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))', 'g');
+
+  let captureLogs = acc => msg => {
+    msg = msg.replace(/\r\n/g, '\n');
+    msg = msg.replace(ANSI_REG, '');
+    acc.push(msg.replace(/\n$/, ''));
+  };
 
   beforeEach(async () => {
+    logger.loglevel('info');
+    log = logger('test');
+    stdout = [];
+    stderr = [];
+
+    if (process.env.__PERCY_BROWSERIFIED__) {
+      spyOn(console, 'log').and.callFake(captureLogs(stdout));
+      spyOn(console, 'warn').and.callFake(captureLogs(stderr));
+      spyOn(console, 'error').and.callFake(captureLogs(stderr));
+    } else {
+      spyOn(process.stdout, 'write').and.callFake(captureLogs(stdout));
+      spyOn(process.stderr, 'write').and.callFake(captureLogs(stderr));
+    }
     await helpers.setupTest();
   });
 
@@ -73,35 +98,28 @@ describe('SDK Utils', () => {
       await helpers.test('error', '/percy/healthcheck');
       await expectAsync(isPercyEnabled()).toBeResolvedTo(false);
 
-      await expectAsync(helpers.get('logs'))
-        .toBeResolvedTo(jasmine.arrayContaining([
-          'Percy is not running, disabling snapshots'
-        ]));
+      expect(stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Percy is not running, disabling snapshots'
+      ]));
     });
 
     it('disables snapshots when the request errors', async () => {
       await helpers.test('disconnect', '/percy/healthcheck');
       await expectAsync(isPercyEnabled()).toBeResolvedTo(false);
 
-      await expectAsync(helpers.get('logs'))
-        .toBeResolvedTo(jasmine.arrayContaining([
-          'Percy is not running, disabling snapshots'
-        ]));
+      expect(stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Percy is not running, disabling snapshots'
+      ]));
+
     });
 
     it('disables snapshots when the API version is unsupported', async () => {
       await helpers.test('version', '0.1.0');
       await expectAsync(isPercyEnabled()).toBeResolvedTo(false);
 
-      await expectAsync(helpers.get('logs'))
-        .toBeResolvedTo(jasmine.arrayContaining([
-          'Unsupported Percy CLI version, disabling snapshots'
-        ]));
-    });
-
-    it('enables remote logging on success', async () => {
-      await expectAsync(isPercyEnabled()).toBeResolvedTo(true);
-      expect(utils.logger.remote.socket).toBeDefined();
+      expect(stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Unsupported Percy CLI version, disabling snapshots'
+      ]));
     });
 
     it('returns false if the build fails during a snapshot', async () => {
@@ -127,7 +145,7 @@ describe('SDK Utils', () => {
       spyOn(utils.request, 'fetch').and.callFake((...args) => {
         return utils.request.fetch.calls.count() > 2
           ? utils.request.fetch.and.originalFn(...args)
-          // eslint-disable-next-line prefer-promise-reject-errors
+        // eslint-disable-next-line prefer-promise-reject-errors
           : Promise.reject({ code: 'ETIMEDOUT' });
       });
 
@@ -202,38 +220,9 @@ describe('SDK Utils', () => {
   });
 
   describe('logger()', () => {
-    let err, log, stdout, stderr;
-    let { logger } = utils;
-
-    let ANSI_REG = new RegExp('[\\u001B\\u009B][[\\]()#;?]*(' +
-      '(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)|' +
-      '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))', 'g');
-
-    let captureLogs = acc => msg => {
-      msg = msg.replace(/\r\n/g, '\n');
-      msg = msg.replace(ANSI_REG, '');
-      acc.push(msg.replace(/\n$/, ''));
-    };
-
     beforeEach(async () => {
-      await helpers.test('remote-logging', false);
-      while (logger.remote.socket) await new Promise(r => setTimeout(r, 0));
-
       err = new Error('Test error');
       err.stack = 'Error stack';
-      logger.loglevel('info');
-      log = logger('test');
-      stdout = [];
-      stderr = [];
-
-      if (process.env.__PERCY_BROWSERIFIED__) {
-        spyOn(console, 'log').and.callFake(captureLogs(stdout));
-        spyOn(console, 'warn').and.callFake(captureLogs(stderr));
-        spyOn(console, 'error').and.callFake(captureLogs(stderr));
-      } else {
-        spyOn(process.stdout, 'write').and.callFake(captureLogs(stdout));
-        spyOn(process.stderr, 'write').and.callFake(captureLogs(stderr));
-      }
     });
 
     it('creates a minimal percy logger', async () => {
@@ -271,106 +260,6 @@ describe('SDK Utils', () => {
         ...(!browser ? ['[percy:test] Test debug log'] : []),
         '[percy:test] Error stack'
       ]);
-    });
-
-    it('can connect to a remote percy logger instance', async () => {
-      await helpers.test('remote-logging', true);
-      await logger.remote();
-
-      let socket = logger.remote.socket;
-      expect(socket).not.toBeNull();
-
-      // does not initiate new connections once connected
-      await logger.remote();
-      expect(logger.remote.socket).toBe(socket);
-
-      // does not log locally, but sends logs remotely
-      log.info('Test foo');
-      log.error(err);
-
-      expect(stderr).toEqual([]);
-      expect(stdout).toEqual([]);
-
-      await expectAsync(helpers.get('logs', l => l))
-        .toBeResolvedTo([
-          jasmine.objectContaining({
-            debug: 'test',
-            level: 'info',
-            message: 'Test foo',
-            meta: { remote: true }
-          }),
-          jasmine.objectContaining({
-            debug: 'test',
-            level: 'error',
-            message: 'Error stack',
-            meta: { remote: true },
-            error: true
-          })
-        ]);
-    });
-
-    it('sends any existing logs to the connected remote logger', async () => {
-      log.info('Test info');
-      log.warn('Test warn');
-      log.error(err);
-
-      await expectAsync(helpers.get('logs'))
-        .toBeResolvedTo([]);
-
-      expect(stdout).toHaveSize(1);
-      expect(stderr).toHaveSize(2);
-
-      await helpers.test('remote-logging', true);
-      await logger.remote();
-
-      await expectAsync(helpers.get('logs'))
-        .toBeResolvedTo(['Test info', 'Test warn', 'Error stack']);
-    });
-
-    it('sets the local loglevel to reflect the connected remote logger', async () => {
-      delete utils.logger.loglevel.lvl;
-      expect(logger.loglevel()).toEqual('info');
-
-      await helpers.test('remote-logging', true);
-      await logger.remote();
-
-      // remove logger is silent during testing mode
-      expect(utils.logger.loglevel.lvl).toEqual('silent');
-      expect(logger.loglevel()).toEqual('silent');
-    });
-
-    it('silently handles remote connection errors', async () => {
-      let addr = utils.percy.address;
-      utils.percy.address = 'http://no.localhost:9999';
-      await logger.remote().then(() => (utils.percy.address = addr));
-
-      log.info('Test remote');
-
-      expect(logger.remote.socket).toBeFalsy();
-      await expectAsync(helpers.get('logs')).toBeResolvedTo([]);
-      expect(stdout).toEqual(['[percy] Test remote']);
-      expect(stderr).toEqual([]);
-    });
-
-    it('logs debug messages for remote connection errors', async () => {
-      logger.loglevel('debug');
-
-      let addr = utils.percy.address;
-      utils.percy.address = 'http://no.localhost:9999';
-      await logger.remote().then(() => (utils.percy.address = addr));
-
-      log.info('Test remote');
-
-      expect(logger.remote.socket).toBeFalsy();
-      await expectAsync(helpers.get('logs')).toBeResolvedTo([]);
-      // node debug logs write to stderr; browser debug logs use console.log
-      expect(browser ? stdout : stderr).toEqual(jasmine.arrayContaining([
-        '[percy:utils] Unable to connect to remote logger',
-        jasmine.stringMatching(
-          // node throws a real error while browsers show console logs
-          browser ? /Socket connection (failed|timed out)/ : /ECONNREFUSED|ENOTFOUND/
-        )
-      ]));
     });
   });
 });

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -110,7 +110,6 @@ describe('SDK Utils', () => {
       expect(stdout).toEqual(jasmine.arrayContaining([
         '[percy] Percy is not running, disabling snapshots'
       ]));
-
     });
 
     it('disables snapshots when the API version is unsupported', async () => {


### PR DESCRIPTION
## What is this?

The remote logger is a nice to have to get logs from remote browsers/clients, but it's not required. We've noticed that websockets have been hanging up suites (#1065). Rather than chasing this nice to have, we're going to remove it since it's not that big of a feature to begin with. 

Will close #1065 