### PR TITLE
🗑 Remove deprecated pre-release options

### DIFF
--- a/packages/cli-snapshot/src/config.js
+++ b/packages/cli-snapshot/src/config.js
@@ -29,19 +29,5 @@ export function configMigration(config, util) {
     util.map('staticSnapshots.snapshotFiles', 'static.include');
     util.map('staticSnapshots.ignoreFiles', 'static.exclude');
     util.del('staticSnapshots');
-  } else {
-    let notice = { type: 'config', until: '1.0.0' };
-    // static files and ignore options were renamed
-    util.deprecate('static.files', { map: 'static.include', ...notice });
-    util.deprecate('static.ignore', { map: 'static.exclude', ...notice });
-    // static and sitemap option overrides were renamed
-    util.deprecate('static.overrides', { map: 'static.options', ...notice });
-    util.deprecate('sitemap.overrides', { map: 'sitemap.options', ...notice });
-
-    for (let i in (config.static?.options || [])) {
-      let k = `static.options[${i}]`;
-      util.deprecate(`${k}.files`, { map: `${k}.include`, ...notice });
-      util.deprecate(`${k}.ignore`, { map: `${k}.exclude`, ...notice });
-    }
   }
 }

--- a/packages/cli-snapshot/src/snapshot.js
+++ b/packages/cli-snapshot/src/snapshot.js
@@ -39,17 +39,6 @@ export const snapshot = command('snapshot', {
     description: 'Rewrite static index and filepath URLs to be clean',
     percyrc: 'static.cleanUrls',
     group: 'Static'
-  }, {
-    // deprecated
-    name: 'files',
-    deprecated: ['1.0.0', '--include'],
-    percyrc: 'static.include',
-    type: 'pattern'
-  }, {
-    name: 'ignore',
-    deprecated: ['1.0.0', '--exclude'],
-    percyrc: 'static.exclude',
-    type: 'pattern'
   }],
 
   examples: [

--- a/packages/cli-snapshot/test/unit/config.test.js
+++ b/packages/cli-snapshot/test/unit/config.test.js
@@ -32,24 +32,6 @@ describe('Unit / Config Migration', () => {
     ]);
   });
 
-  it('migrates deprecated config', () => {
-    configMigration({
-      version: 2,
-      static: {
-        baseUrl: 'base-url',
-        files: '*.html',
-        ignore: '*.htm'
-      }
-    }, mocked);
-
-    expect(mocked.migrate.deprecate).toEqual([
-      ['static.files', { map: 'static.include', type: 'config', until: '1.0.0' }],
-      ['static.ignore', { map: 'static.exclude', type: 'config', until: '1.0.0' }],
-      ['static.overrides', { map: 'static.options', type: 'config', until: '1.0.0' }],
-      ['sitemap.overrides', { map: 'sitemap.options', type: 'config', until: '1.0.0' }]
-    ]);
-  });
-
   it('does not migrate when not needed', () => {
     configMigration({
       version: 2,

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -360,22 +360,11 @@ export function configMigration(config, util) {
     util.map('agent.assetDiscovery.requestHeaders', 'discovery.requestHeaders');
     util.map('agent.assetDiscovery.pagePoolSizeMax', 'discovery.concurrency');
     util.del('agent');
-  } else {
-    let notice = { type: 'config', until: '1.0.0' };
-    // snapshot discovery options have moved
-    util.deprecate('snapshot.authorization', { map: 'discovery.authorization', ...notice });
-    util.deprecate('snapshot.requestHeaders', { map: 'discovery.requestHeaders', ...notice });
   }
 }
 
 // Snapshot option migrate function
 export function snapshotMigration(config, util, root = '') {
-  let notice = { type: 'snapshot', until: '1.0.0', warn: true };
-  // discovery options have moved
-  util.deprecate(`${root}.authorization`, { map: `${root}.discovery.authorization`, ...notice });
-  util.deprecate(`${root}.requestHeaders`, { map: `${root}.discovery.requestHeaders`, ...notice });
-  // snapshots option was renamed
-  util.deprecate(`${root}.snapshots`, { map: `${root}.additionalSnapshots`, ...notice });
 }
 
 // Snapshot list options migrate function
@@ -388,10 +377,6 @@ export function snapshotListMigration(config, util) {
       }
     }
   }
-
-  // overrides option was renamed
-  let notice = { type: 'snapshot', until: '1.0.0', warn: true };
-  util.deprecate('overrides', { map: 'options', ...notice });
 
   // migrate options
   if (Array.isArray(config.options)) {

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -116,23 +116,6 @@ describe('Snapshot', () => {
     ]);
   });
 
-  it('warns on deprecated options', async () => {
-    await percy.snapshot([
-      { url: 'http://localhost:8000/a', requestHeaders: { foo: 'bar' } },
-      { url: 'http://localhost:8000/b', authorization: { username: 'foo' } },
-      { url: 'http://localhost:8000/c', snapshots: [{ name: 'foobar' }] }
-    ]);
-
-    expect(logger.stderr).toEqual([
-      '[percy] Warning: The snapshot option `requestHeaders` ' +
-        'will be removed in 1.0.0. Use `discovery.requestHeaders` instead.',
-      '[percy] Warning: The snapshot option `authorization` ' +
-        'will be removed in 1.0.0. Use `discovery.authorization` instead.',
-      '[percy] Warning: The snapshot option `snapshots` ' +
-        'will be removed in 1.0.0. Use `additionalSnapshots` instead.'
-    ]);
-  });
-
   it('errors if the url is invalid', async () => {
     await percy.snapshot({
       name: 'test snapshot',

--- a/packages/core/test/unit/config.test.js
+++ b/packages/core/test/unit/config.test.js
@@ -48,21 +48,6 @@ describe('Unit / Config Migration', () => {
     expect(mocked.migrate.map[2][2](false)).toEqual(true);
   });
 
-  it('migrates deprecated config', () => {
-    configMigration({
-      version: 2,
-      snapshot: {
-        authorization: {},
-        requestHeaders: {}
-      }
-    }, mocked);
-
-    expect(mocked.migrate.deprecate).toEqual([
-      ['snapshot.authorization', { map: 'discovery.authorization', type: 'config', until: '1.0.0' }],
-      ['snapshot.requestHeaders', { map: 'discovery.requestHeaders', type: 'config', until: '1.0.0' }]
-    ]);
-  });
-
   it('does not migrate when not needed', () => {
     configMigration({
       version: 2,


### PR DESCRIPTION
## What is this?

This PR removes options were meant to be removed with 1.0.0, but snuck past and stuck around a bit long.

The core snapshot list migration was left empty but will be reused for a future deprecation.