### PR TITLE
♻️ Move devicePixelRatio snapshot discovery option

### DIFF
--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -28,9 +28,6 @@ export const configSchema = {
       },
       scope: {
         type: 'string'
-      },
-      devicePixelRatio: {
-        type: 'integer'
       }
     }
   },
@@ -109,6 +106,9 @@ export const configSchema = {
       userAgent: {
         type: 'string'
       },
+      devicePixelRatio: {
+        type: 'integer'
+      },
       concurrency: {
         type: 'integer',
         minimum: 1
@@ -140,7 +140,6 @@ export const snapshotSchema = {
         minHeight: { $ref: '/config/snapshot#/properties/minHeight' },
         percyCSS: { $ref: '/config/snapshot#/properties/percyCSS' },
         enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },
-        devicePixelRatio: { $ref: '/config/snapshot#/properties/devicePixelRatio' },
         discovery: {
           type: 'object',
           additionalProperties: false,
@@ -150,7 +149,8 @@ export const snapshotSchema = {
             requestHeaders: { $ref: '/config/discovery#/properties/requestHeaders' },
             authorization: { $ref: '/config/discovery#/properties/authorization' },
             disableCache: { $ref: '/config/discovery#/properties/disableCache' },
-            userAgent: { $ref: '/config/discovery#/properties/userAgent' }
+            userAgent: { $ref: '/config/discovery#/properties/userAgent' },
+            devicePixelRatio: { $ref: '/config/discovery#/properties/devicePixelRatio' }
           }
         }
       }
@@ -360,11 +360,24 @@ export function configMigration(config, util) {
     util.map('agent.assetDiscovery.requestHeaders', 'discovery.requestHeaders');
     util.map('agent.assetDiscovery.pagePoolSizeMax', 'discovery.concurrency');
     util.del('agent');
+  } else {
+    util.deprecate('snapshot.devicePixelRatio', {
+      map: 'discovery.devicePixelRatio',
+      type: 'config',
+      until: '2.0.0'
+    });
   }
 }
 
 // Snapshot option migrate function
 export function snapshotMigration(config, util, root = '') {
+  // discovery options have moved
+  util.deprecate(`${root}.devicePixelRatio`, {
+    map: `${root}.discovery.devicePixelRatio`,
+    type: 'snapshot',
+    until: '2.0.0',
+    warn: true
+  });
 }
 
 // Snapshot list options migrate function

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -410,12 +410,12 @@ export async function* discoverSnapshotResources(percy, snapshot, callback) {
     yield* triggerResourceRequests(page, snapshot);
 
     // trigger resource requests for any alternate device pixel ratio
-    if (snapshot.devicePixelRatio) {
+    if (snapshot.discovery.devicePixelRatio) {
       // wait for any existing pending resource requests first
       yield waitForDiscoveryNetworkIdle(page, snapshot.discovery);
 
       yield* triggerResourceRequests(page, snapshot, {
-        deviceScaleFactor: snapshot.devicePixelRatio,
+        deviceScaleFactor: snapshot.discovery.devicePixelRatio,
         mobile: true
       });
     }

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -650,7 +650,7 @@ describe('Discovery', () => {
       name: 'test responsive',
       url: 'http://localhost:8000',
       domSnapshot: responsiveDOM,
-      devicePixelRatio: 2,
+      discovery: { devicePixelRatio: 2 },
       widths: [400, 800]
     });
 

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -116,6 +116,17 @@ describe('Snapshot', () => {
     ]);
   });
 
+  it('warns on deprecated options', async () => {
+    await percy.snapshot([
+      { url: 'http://localhost:8000/a', devicePixelRatio: 2 }
+    ]);
+
+    expect(logger.stderr).toEqual([
+      '[percy] Warning: The snapshot option `devicePixelRatio` ' +
+        'will be removed in 2.0.0. Use `discovery.devicePixelRatio` instead.'
+    ]);
+  });
+
   it('errors if the url is invalid', async () => {
     await percy.snapshot({
       name: 'test snapshot',

--- a/packages/core/test/unit/config.test.js
+++ b/packages/core/test/unit/config.test.js
@@ -48,6 +48,23 @@ describe('Unit / Config Migration', () => {
     expect(mocked.migrate.map[2][2](false)).toEqual(true);
   });
 
+  it('migrates deprecated config', () => {
+    configMigration({
+      version: 2,
+      snapshot: {
+        devicePixelRatio: 2
+      }
+    }, mocked);
+
+    expect(mocked.migrate.deprecate).toEqual([
+      ['snapshot.devicePixelRatio', {
+        map: 'discovery.devicePixelRatio',
+        type: 'config',
+        until: '2.0.0'
+      }]
+    ]);
+  });
+
   it('does not migrate when not needed', () => {
     configMigration({
       version: 2,


### PR DESCRIPTION
## What is this?

The `devicePixelRatio` option is only used in asset discovery and was meant to be nested with related snapshot asset discovery options. This PR corrects the location of this option and adds a new deprecation notice for the old location.