### PR TITLE
♻️ Refactor core queues

### DIFF
--- a/packages/cli-upload/src/utils.js
+++ b/packages/cli-upload/src/utils.js
@@ -1,34 +1,21 @@
 import path from 'path';
-import { sha256hash } from '@percy/client/utils';
 
-// Returns a root resource object with a sha and mimetype.
-function createRootResource(url, content) {
-  return {
-    url,
-    content,
-    sha: sha256hash(content),
-    mimetype: 'text/html',
-    root: true
-  };
-}
+import {
+  createResource,
+  createRootResource
+} from '@percy/cli-command/utils';
 
-// Returns an image resource object with a sha.
-function createImageResource(url, content, mimetype) {
-  return {
-    url,
-    content,
-    sha: sha256hash(content),
-    mimetype
-  };
-}
+export {
+  yieldAll
+} from '@percy/cli-command/utils';
 
 // Returns root resource and image resource objects based on an image's
 // filename, contents, and dimensions. The root resource is a generated DOM
 // designed to display an image at it's native size without margins or padding.
 export function createImageResources(filename, content, size) {
   let { dir, name, ext } = path.parse(filename);
-  let rootUrl = `/${encodeURIComponent(path.join(dir, name))}`;
-  let imageUrl = `/${encodeURIComponent(filename)}`;
+  let rootUrl = `http://localhost/${encodeURIComponent(path.join(dir, name))}`;
+  let imageUrl = `http://localhost/${encodeURIComponent(filename)}`;
   let mimetype = ext === '.png' ? 'image/png' : 'image/jpeg';
 
   return [
@@ -49,7 +36,7 @@ export function createImageResources(filename, content, size) {
         </body>
       </html>
     `),
-    createImageResource(imageUrl, content, mimetype)
+    createResource(imageUrl, content, mimetype)
   ];
 }
 

--- a/packages/cli-upload/test/upload.test.js
+++ b/packages/cli-upload/test/upload.test.js
@@ -94,7 +94,7 @@ describe('percy upload', () => {
               type: 'resources',
               id: jasmine.any(String),
               attributes: {
-                'resource-url': '/test-1',
+                'resource-url': 'http://localhost/test-1',
                 mimetype: 'text/html',
                 'is-root': true
               }
@@ -102,7 +102,7 @@ describe('percy upload', () => {
               type: 'resources',
               id: jasmine.any(String),
               attributes: {
-                'resource-url': '/test-1.png',
+                'resource-url': 'http://localhost/test-1.png',
                 mimetype: 'image/png',
                 'is-root': null
               }

--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -57,7 +57,7 @@ export function createPercyServer(percy, port) {
     }))
   // get or set config options
     .route(['get', 'post'], '/percy/config', async (req, res) => res.json(200, {
-      config: req.body ? await percy.setConfig(req.body) : percy.config,
+      config: req.body ? percy.set(req.body) : percy.config,
       success: true
     }))
   // responds once idle (may take a long time)

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -1,136 +1,273 @@
-import mime from 'mime-types';
 import logger from '@percy/logger';
-import { request as makeRequest } from '@percy/client/utils';
-import { normalizeURL, hostnameMatches, createResource } from './utils.js';
+import Queue from './queue.js';
+import {
+  normalizeURL,
+  hostnameMatches,
+  createRootResource,
+  createPercyCSSResource,
+  createLogResource,
+  yieldAll
+} from './utils.js';
 
-const MAX_RESOURCE_SIZE = 15 * (1024 ** 2); // 15MB
-const ALLOWED_STATUSES = [200, 201, 301, 302, 304, 307, 308];
-const ALLOWED_RESOURCES = ['Document', 'Stylesheet', 'Image', 'Media', 'Font', 'Other'];
+// Logs verbose debug logs detailing various snapshot options. When `showInfo` is true, specific
+// messages will be logged as info logs rather than debug logs.
+function debugSnapshotOptions(snapshot, showInfo) {
+  let log = logger('core:snapshot');
 
-export function createRequestHandler(network, { disableCache, disallowedHostnames, getResource }) {
-  let log = logger('core:discovery');
+  // log snapshot info
+  log.debug('---------', snapshot.meta);
+  if (showInfo) log.info(`Snapshot found: ${snapshot.name}`, snapshot.meta);
+  else log.debug(`Received snapshot: ${snapshot.name}`, snapshot.meta);
 
-  return async request => {
-    let url = request.url;
-    let meta = { ...network.meta, url };
+  // will log debug info for an object property if its value is defined
+  let debugProp = (obj, prop, format = String) => {
+    let val = prop.split('.').reduce((o, k) => o?.[k], obj);
 
-    try {
-      log.debug(`Handling request: ${url}`, meta);
-      let resource = getResource(url);
+    if (val != null) {
+      // join formatted array values with a space
+      val = [].concat(val).map(format).join(', ');
+      log.debug(`- ${prop}: ${val}`, snapshot.meta);
+    }
+  };
 
-      if (resource?.root) {
-        log.debug('- Serving root resource', meta);
-        await request.respond(resource);
-      } else if (hostnameMatches(disallowedHostnames, url)) {
-        log.debug('- Skipping disallowed hostname', meta);
-        await request.abort(true);
-      } else if (resource && !disableCache) {
-        log.debug('- Resource cache hit', meta);
-        await request.respond(resource);
+  debugProp(snapshot, 'url');
+  debugProp(snapshot, 'scope');
+  debugProp(snapshot, 'widths', v => `${v}px`);
+  debugProp(snapshot, 'minHeight', v => `${v}px`);
+  debugProp(snapshot, 'enableJavaScript');
+  debugProp(snapshot, 'deviceScaleFactor');
+  debugProp(snapshot, 'waitForTimeout');
+  debugProp(snapshot, 'waitForSelector');
+  debugProp(snapshot, 'execute.afterNavigation');
+  debugProp(snapshot, 'execute.beforeResize');
+  debugProp(snapshot, 'execute.afterResize');
+  debugProp(snapshot, 'execute.beforeSnapshot');
+  debugProp(snapshot, 'discovery.allowedHostnames');
+  debugProp(snapshot, 'discovery.disallowedHostnames');
+  debugProp(snapshot, 'discovery.requestHeaders', JSON.stringify);
+  debugProp(snapshot, 'discovery.authorization', JSON.stringify);
+  debugProp(snapshot, 'discovery.disableCache');
+  debugProp(snapshot, 'discovery.userAgent');
+  debugProp(snapshot, 'clientInfo');
+  debugProp(snapshot, 'environmentInfo');
+  debugProp(snapshot, 'domSnapshot', Boolean);
+
+  for (let added of (snapshot.additionalSnapshots || [])) {
+    if (showInfo) log.info(`Snapshot found: ${added.name}`, snapshot.meta);
+    else log.debug(`Additional snapshot: ${added.name}`, snapshot.meta);
+
+    debugProp(added, 'waitForTimeout');
+    debugProp(added, 'waitForSelector');
+    debugProp(added, 'execute');
+  }
+}
+
+// Wait for a page's asset discovery network to idle
+function waitForDiscoveryNetworkIdle(page, options) {
+  let { allowedHostnames, networkIdleTimeout } = options;
+  let filter = r => hostnameMatches(allowedHostnames, r.url);
+
+  return page.network.idle(filter, networkIdleTimeout);
+}
+
+// Calls the provided callback with additional resources
+function processSnapshotResources({ domSnapshot, resources, ...snapshot }) {
+  resources = [...(resources?.values() ?? [])];
+
+  // find or create a root resource if one does not exist
+  let root = resources.find(r => r.content === domSnapshot);
+
+  if (!root) {
+    root = createRootResource(snapshot.url, domSnapshot);
+    resources.unshift(root);
+  }
+
+  // inject Percy CSS
+  if (snapshot.percyCSS) {
+    let css = createPercyCSSResource(root.url, snapshot.percyCSS);
+    resources.push(css);
+
+    // replace root contents and associated properties
+    Object.assign(root, createRootResource(root.url, (
+      root.content.replace(/(<\/body>)(?!.*\1)/is, (
+        `<link data-percy-specific-css rel="stylesheet" href="${css.pathname}"/>`
+      ) + '$&'))));
+  }
+
+  // include associated snapshot logs matched by meta information
+  resources.push(createLogResource(logger.query(log => (
+    log.meta.snapshot?.name === snapshot.meta.snapshot.name
+  ))));
+
+  return { ...snapshot, resources };
+}
+
+// Triggers the capture of resource requests for a page by iterating over snapshot widths to resize
+// the page and calling any provided execute options.
+async function* captureSnapshotResources(page, snapshot, options) {
+  let { discovery, additionalSnapshots = [], ...baseSnapshot } = snapshot;
+  if (typeof options === 'function') options = { capture: options };
+  let { capture, deviceScaleFactor, mobile } = options;
+
+  // used to resize the using capture options
+  let resize = width => page.resize({
+    height: snapshot.minHeight,
+    deviceScaleFactor,
+    mobile,
+    width
+  });
+
+  // navigate to the url
+  yield resize(snapshot.widths[0]);
+  yield page.goto(snapshot.url);
+
+  if (snapshot.execute) {
+    // when any execute options are provided, inject snapshot options
+    /* istanbul ignore next: cannot detect coverage of injected code */
+    yield page.eval((_, s) => (window.__PERCY__.snapshot = s), snapshot);
+    yield page.evaluate(snapshot.execute.afterNavigation);
+  }
+
+  // iterate over additional snapshots for proper DOM capturing
+  for (let additionalSnapshot of [baseSnapshot, ...additionalSnapshots]) {
+    let isBaseSnapshot = additionalSnapshot === baseSnapshot;
+    let snap = { ...baseSnapshot, ...additionalSnapshot };
+
+    // iterate over widths to trigger reqeusts for the base snapshot
+    if (isBaseSnapshot) {
+      for (let i = 0; i < snap.widths.length - 1; i++) {
+        yield page.evaluate(snap.execute?.beforeResize);
+        yield waitForDiscoveryNetworkIdle(page, discovery);
+        yield resize(snap.widths[i + 1]);
+        yield page.evaluate(snap.execute?.afterResize);
+      }
+    }
+
+    if (capture && !snapshot.domSnapshot) {
+      // capture this snapshot and update the base snapshot after capture
+      let captured = yield page.snapshot(snap);
+      if (isBaseSnapshot) baseSnapshot = captured;
+
+      // remove any discovered root resource request
+      captured.resources.delete(normalizeURL(captured.url));
+      capture(processSnapshotResources(captured));
+    }
+  }
+
+  // recursively trigger resource requests for any alternate device pixel ratio
+  if (deviceScaleFactor !== discovery.devicePixelRatio) {
+    yield waitForDiscoveryNetworkIdle(page, discovery);
+
+    yield* captureSnapshotResources(page, snapshot, {
+      deviceScaleFactor: discovery.devicePixelRatio,
+      mobile: true
+    });
+  }
+
+  // wait for final network idle when not capturing DOM
+  if (capture && snapshot.domSnapshot) {
+    yield waitForDiscoveryNetworkIdle(page, discovery);
+    capture(processSnapshotResources(snapshot));
+  }
+}
+
+// Pushes all provided snapshots to a discovery queue with the provided callback, yielding to each
+// one concurrently. When skipping asset discovery, the callback is called immediately for each
+// snapshot, also processing snapshot resources when not dry-running.
+export async function* discoverSnapshotResources(queue, options, callback) {
+  let { snapshots, skipDiscovery, dryRun } = options;
+
+  yield* yieldAll(snapshots.reduce((all, snapshot) => {
+    debugSnapshotOptions(snapshot, dryRun);
+
+    if (skipDiscovery) {
+      let { additionalSnapshots, ...baseSnapshot } = snapshot;
+      additionalSnapshots = (dryRun && additionalSnapshots) || [];
+
+      for (let snap of [baseSnapshot, ...additionalSnapshots]) {
+        callback(dryRun ? snap : processSnapshotResources(snap));
+      }
+    } else {
+      all.push(queue.push(snapshot, callback));
+    }
+
+    return all;
+  }, []));
+}
+
+// Used to cache resources across core instances
+const RESOURCE_CACHE_KEY = Symbol('resource-cache');
+
+// Creates an asset discovery queue that uses the percy browser instance to create a page for each
+// snapshot which is used to intercept and capture snapshot resource requests.
+export function createDiscoveryQueue(percy) {
+  let { concurrency } = percy.config.discovery;
+  let queue = new Queue();
+  let cache;
+
+  return queue
+    .set({ concurrency })
+  // on start, launch the browser and run the queue
+    .handle('start', async () => {
+      cache = percy[RESOURCE_CACHE_KEY] = new Map();
+      await percy.browser.launch();
+      queue.run();
+    })
+  // on end, close the browser
+    .handle('end', async () => {
+      await percy.browser.close();
+    })
+  // snapshots are unique by name
+    .handle('find', ({ name }, snapshot) => (
+      snapshot.name === name
+    ))
+  // initialize the root resource for DOM snapshots
+    .handle('push', snapshot => {
+      let { url, domSnapshot } = snapshot;
+      let root = domSnapshot && createRootResource(url, domSnapshot);
+      let resources = new Map(root ? [[root.url, root]] : []);
+      return { ...snapshot, resources };
+    })
+  // discovery resources for snapshots and call the callback for each discovered snapshot
+    .handle('task', async function*(snapshot, callback) {
+      percy.log.debug(`Discovering resources: ${snapshot.name}`, snapshot.meta);
+
+      // create a new browser page
+      let page = yield percy.browser.page({
+        enableJavaScript: snapshot.enableJavaScript ?? !snapshot.domSnapshot,
+        networkIdleTimeout: snapshot.discovery.networkIdleTimeout,
+        requestHeaders: snapshot.discovery.requestHeaders,
+        authorization: snapshot.discovery.authorization,
+        userAgent: snapshot.discovery.userAgent,
+        meta: snapshot.meta,
+
+        // enable network inteception
+        intercept: {
+          enableJavaScript: snapshot.enableJavaScript,
+          disableCache: snapshot.discovery.disableCache,
+          allowedHostnames: snapshot.discovery.allowedHostnames,
+          disallowedHostnames: snapshot.discovery.disallowedHostnames,
+          getResource: u => snapshot.resources.get(u) || cache.get(u),
+          saveResource: r => snapshot.resources.set(r.url, r) && cache.set(r.url, r)
+        }
+      });
+
+      try {
+        yield* captureSnapshotResources(page, snapshot, callback);
+      } finally {
+        // always close the page when done
+        await page.close();
+      }
+    })
+    .handle('error', ({ name, meta }, error) => {
+      if (error.name === 'AbortError' && queue.readyState < 3) {
+        // only error about aborted snapshots when not closed
+        percy.log.error('Received a duplicate snapshot, ' + (
+          `the previous snapshot was aborted: ${name}`), meta);
       } else {
-        await request.continue();
+        // log all other encountered errors
+        percy.log.error(`Encountered an error taking snapshot: ${name}`, meta);
+        percy.log.error(error, meta);
       }
-    } catch (error) {
-      log.debug(`Encountered an error handling request: ${url}`, meta);
-      log.debug(error);
-
-      /* istanbul ignore next: race condition */
-      await request.abort(error)
-        .catch(e => log.debug(e, meta));
-    }
-  };
-}
-
-export function createRequestFinishedHandler(network, {
-  enableJavaScript,
-  allowedHostnames,
-  disableCache,
-  getResource,
-  saveResource
-}) {
-  let log = logger('core:discovery');
-
-  return async request => {
-    let origin = request.redirectChain[0] || request;
-    let url = normalizeURL(origin.url);
-    let meta = { ...network.meta, url };
-
-    try {
-      let resource = getResource(url);
-
-      // process and cache the response and resource
-      if (!resource?.root && (!resource || disableCache)) {
-        let headers = request.headers;
-        let response = request.response;
-        let capture = response && hostnameMatches(allowedHostnames, url);
-        let body = capture && await response.buffer();
-
-        log.debug(`Processing resource: ${url}`, meta);
-
-        /* istanbul ignore next: sanity check */
-        if (!response) {
-          return log.debug('- Skipping no response', meta);
-        } else if (!capture) {
-          return log.debug('- Skipping remote resource', meta);
-        } else if (!body.length) {
-          return log.debug('- Skipping empty response', meta);
-        } else if (body.length > MAX_RESOURCE_SIZE) {
-          return log.debug('- Skipping resource larger than 15MB', meta);
-        } else if (!ALLOWED_STATUSES.includes(response.status)) {
-          return log.debug(`- Skipping disallowed status [${response.status}]`, meta);
-        } else if (!enableJavaScript && !ALLOWED_RESOURCES.includes(request.type)) {
-          return log.debug(`- Skipping disallowed resource type [${request.type}]`, meta);
-        }
-
-        // Try to get the proper mimetype if the server or asset discovery browser is sending `text/plain`
-        let mimeType = (response.mimeType === 'text/plain' && mime.lookup(response.url)) || response.mimeType;
-
-        // font responses from the browser may not be properly encoded, so request them directly
-        if (mimeType?.includes('font')) {
-          log.debug('- Requesting asset directly');
-
-          if (!headers.Authorization && network.authorization?.username) {
-            let token = Buffer.from([
-              network.authorization.username,
-              network.authorization.password || ''
-            ].join(':')).toString('base64');
-
-            headers.Authorization = `Basic ${token}`;
-          }
-
-          body = await makeRequest(response.url, { buffer: true, headers });
-        }
-
-        resource = createResource(url, body, mimeType, {
-          status: response.status,
-          // 'Network.responseReceived' returns headers split by newlines, however
-          // `Fetch.fulfillRequest` (used for cached responses) will hang with newlines.
-          headers: Object.entries(response.headers)
-            .reduce((norm, [key, value]) => (
-              Object.assign(norm, { [key]: value.split('\n') })
-            ), {})
-        });
-
-        log.debug(`- sha: ${resource.sha}`, meta);
-        log.debug(`- mimetype: ${resource.mimetype}`, meta);
-      }
-
-      saveResource(resource);
-    } catch (error) {
-      log.debug(`Encountered an error processing resource: ${url}`, meta);
-      log.debug(error);
-    }
-  };
-}
-
-export function createRequestFailedHandler(network) {
-  let log = logger('core:discovery');
-
-  return ({ url, error }) => {
-    // do not log generic failures since the real error was most likely
-    // already logged from elsewhere
-    if (error !== 'net::ERR_FAILED') {
-      log.debug(`Request failed for ${url}: ${error}`, { ...network.meta, url });
-    }
-  };
+    });
 }

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -125,16 +125,16 @@ export class Page {
     for (let script of scripts) await this.eval(script);
   }
 
-  // Take a snapshot after waiting for any timeout, waiting for any selector, executing any scripts,
-  // and waiting for the network idle
+  // Takes a snapshot after waiting for any timeout, waiting for any selector, executing any
+  // scripts, and waiting for the network idle. Returns all other provided snapshot options along
+  // with the captured URL and DOM snapshot.
   async snapshot({
-    name,
     waitForTimeout,
     waitForSelector,
     execute,
-    meta,
-    ...options
+    ...snapshot
   }) {
+    let { name, enableJavaScript } = snapshot;
     this.log.debug(`Taking snapshot: ${name}`, this.meta);
 
     // wait for any specified timeout
@@ -171,11 +171,13 @@ export class Page {
     this.log.debug('Serialize DOM', this.meta);
 
     /* istanbul ignore next: no instrumenting injected code */
-    return await this.eval((_, options) => ({
+    let capture = await this.eval((_, options) => ({
       /* eslint-disable-next-line no-undef */
-      dom: PercyDOM.serialize(options),
+      domSnapshot: PercyDOM.serialize(options),
       url: document.URL
-    }), options);
+    }), { enableJavaScript });
+
+    return { ...snapshot, ...capture };
   }
 
   // Initialize newly attached pages and iframes with page options

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -107,7 +107,7 @@ export class Percy {
   }
 
   // Set client & environment info, and override loaded config options
-  setConfig({ clientInfo, environmentInfo, ...config }) {
+  set({ clientInfo, environmentInfo, ...config }) {
     this.client.addClientInfo(clientInfo);
     this.client.addEnvironmentInfo(environmentInfo);
 

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -1,7 +1,6 @@
 import PercyClient from '@percy/client';
 import PercyConfig from '@percy/config';
 import logger from '@percy/logger';
-import Queue from './queue.js';
 import Browser from './browser.js';
 
 import {
@@ -10,24 +9,27 @@ import {
 } from './api.js';
 import {
   gatherSnapshots,
-  validateSnapshotOptions,
-  discoverSnapshotResources
+  createSnapshotsQueue,
+  validateSnapshotOptions
 } from './snapshot.js';
+import {
+  discoverSnapshotResources,
+  createDiscoveryQueue
+} from './discovery.js';
 import {
   generatePromise,
   yieldAll
 } from './utils.js';
 
-// A Percy instance will create a new build when started, handle snapshot
-// creation, asset discovery, and resource uploads, and will finalize the build
-// when stopped. Snapshots are processed concurrently and the build is not
-// finalized until all snapshots have been handled.
+// A Percy instance will create a new build when started, handle snapshot creation, asset discovery,
+// and resource uploads, and will finalize the build when stopped. Snapshots are processed
+// concurrently and the build is not finalized until all snapshots have been handled.
 export class Percy {
   log = logger('core');
   readyState = null;
 
-  #uploads = new Queue();
-  #snapshots = new Queue();
+  #discovery = null;
+  #snapshots = null;
 
   // Static shortcut to create and start an instance in one call
   static async start(options) {
@@ -64,6 +66,11 @@ export class Percy {
     // options which will become accessible via the `.config` property
     ...options
   } = {}) {
+    this.config = PercyConfig.load({
+      overrides: options,
+      path: config
+    });
+
     if (testing) loglevel = 'silent';
     if (loglevel) this.loglevel(loglevel);
 
@@ -72,23 +79,14 @@ export class Percy {
     this.skipUploads = this.dryRun || !!skipUploads;
     this.skipDiscovery = this.dryRun || !!skipDiscovery;
     this.delayUploads = this.skipUploads || !!delayUploads;
-    this.deferUploads = this.delayUploads || !!deferUploads;
-    if (this.deferUploads) this.#uploads.stop();
-
-    this.config = PercyConfig.load({
-      overrides: options,
-      path: config
-    });
-
-    if (this.config.discovery.concurrency) {
-      let { concurrency } = this.config.discovery;
-      this.#uploads.concurrency = concurrency;
-      this.#snapshots.concurrency = concurrency;
-    }
+    this.deferUploads = this.skipUploads || !!deferUploads;
 
     this.client = new PercyClient({ token, clientInfo, environmentInfo });
     if (server) this.server = createPercyServer(this, port);
     this.browser = new Browser(this);
+
+    this.#discovery = createDiscoveryQueue(this);
+    this.#snapshots = createSnapshotsQueue(this);
 
     // generator methods are wrapped to autorun and return promises
     for (let m of ['start', 'stop', 'flush', 'idle', 'snapshot']) {
@@ -131,88 +129,40 @@ export class Percy {
       return Array.isArray(next) && [path, next];
     });
 
-    // adjust concurrency if necessary
-    if (this.config.discovery.concurrency) {
-      let { concurrency } = this.config.discovery;
-      this.#uploads.concurrency = concurrency;
-      this.#snapshots.concurrency = concurrency;
-    }
+    // adjust queue concurrency
+    let { concurrency } = this.config.discovery;
+    this.#discovery.set({ concurrency });
+    this.#snapshots.set({ concurrency });
 
     return this.config;
   }
 
-  // Resolves once snapshot and upload queues are idle
-  async *idle() {
-    yield* this.#snapshots.idle();
-    yield* this.#uploads.idle();
-  }
-
-  // Immediately stops all queues, preventing any more tasks from running
-  close() {
-    this.#snapshots.close(true);
-    this.#uploads.close(true);
-  }
-
-  // Starts a local API server, a browser process, and queues creating a new Percy build which will run
-  // at a later time when uploads are deferred, or run immediately when not deferred.
+  // Starts a local API server, a browser process, and internal queues.
   async *start() {
     // already starting or started
     if (this.readyState != null) return;
     this.readyState = 0;
 
-    // create a percy build as the first immediately queued task
-    let buildTask = this.#uploads.push('build/create', () => {
-      // pause other queued tasks until after the build is created
-      this.#uploads.stop();
-      this.build = {};
-
-      return this.client.createBuild()
-        .then(({ data: { id, attributes } }) => {
-          let url = attributes['web-url'];
-          let number = attributes['build-number'];
-          Object.assign(this.build, { id, url, number });
-          if (!this.delayUploads) this.#uploads.run();
-        });
-    }, 0);
-
-    // handle deferred build errors
-    if (this.deferUploads) {
-      buildTask.catch(err => {
-        this.build = { error: 'Failed to create build' };
-        this.log.error(this.build.error);
-        this.log.error(err);
-        this.close();
-      });
-    }
-
     try {
-      // when not deferred, wait until the build is created first
-      if (!this.deferUploads) await buildTask;
-
-      // maybe launch the discovery browser
-      if (!this.skipDiscovery) yield this.browser.launch();
-
-      // start the server after everything else is ready
-      yield this.server?.listen();
-
-      // mark instance as started
+      // start the snapshots queue immediately when not delayed or deferred
+      if (!this.delayUploads && !this.deferUploads) yield this.#snapshots.start();
+      // do not start the discovery queue when not needed
+      if (!this.skipDiscovery) yield this.#discovery.start();
+      // start a local API server for SDK communication
+      if (this.server) yield this.server.listen();
+      // log and mark this instance as started
       this.log.info('Percy has started!');
       this.readyState = 1;
     } catch (error) {
-      // on error, close any running server and browser
+      // on error, close any running server and end queues
       await this.server?.close();
-      await this.browser.close();
+      await this.#discovery.end();
+      await this.#snapshots.end();
 
-      // mark instance as closed
-      this.readyState = 3;
+      // mark this instance as closed unless aborting
+      this.readyState = error.name !== 'AbortError' ? 3 : null;
 
-      // when uploads are deferred, cancel build creation on abort
-      if (this.deferUploads && error.name === 'AbortError') {
-        this.#uploads.cancel('build/create');
-        this.readyState = null;
-      }
-
-      // throw an easier-to-understand error when the port is taken
+      // throw an easier-to-understand error when the port is in use
       if (error.code === 'EADDRINUSE') {
         throw new Error('Percy is already running or the port is in use');
       } else {
@@ -221,52 +171,32 @@ export class Percy {
     }
   }
 
+  // Resolves once snapshot and upload queues are idle
+  async *idle() {
+    yield* this.#discovery.idle();
+    yield* this.#snapshots.idle();
+  }
+
   // Wait for currently queued snapshots then run and wait for resulting uploads
-  async *flush(close) {
-    try {
-      // wait until the next event loop for synchronous snapshots
-      yield new Promise(r => setImmediate(r));
+  async *flush(callback) {
+    if (!this.readyState || this.readyState > 2) return;
 
-      // close the snapshot queue and wait for it to empty
-      if (this.#snapshots.size) {
-        if (close) this.#snapshots.close();
+    // wait until the next event loop for synchronous snapshots
+    yield new Promise(r => setImmediate(r));
 
-        yield* this.#snapshots.flush(s => {
-          // do not log a count when not closing or if asset discovery is disabled
-          if (!close || this.skipDiscovery) return;
-          this.log.progress(`Processing ${s} snapshot${s !== 1 ? 's' : ''}...`, !!s);
-        });
-      }
+    // flush and log progress for discovery before snapshots
+    if (!this.skipDiscovery && this.#discovery.size) {
+      yield* this.#discovery.flush(size => callback?.('Processing', size));
+    }
 
-      // run, close, and wait for the upload queue to empty
-      if (!this.skipUploads && this.#uploads.size) {
-        if (close) this.#uploads.close();
-
-        // prevent creating an empty build when deferred
-        if (!this.deferUploads || !this.#uploads.has('build/create') || this.#uploads.size > 1) {
-          if (this.build && !this.build.id) yield* this.#uploads.idle();
-
-          yield* this.#uploads.flush(s => {
-            // do not log a count when not closing or while creating a build
-            if (!close || this.#uploads.has('build/create')) return;
-            this.log.progress(`Uploading ${s} snapshot${s !== 1 ? 's' : ''}...`, !!s);
-          });
-        }
-      }
-    } catch (error) {
-      // reopen closed queues when aborted
-      /* istanbul ignore else: all errors bubble */
-      if (close && error.name === 'AbortError') {
-        this.#snapshots.open();
-        this.#uploads.open();
-      }
-
-      throw error;
+    // flush and log progress for snapshot uploads
+    if (!this.skipUploads && this.#snapshots.size) {
+      yield* this.#snapshots.flush(size => callback?.('Uploading', size));
     }
   }
 
-  // Stops the local API server and browser once snapshots have completed and finalizes the Percy
-  // build. Does nothing if not running. When `force` is true, any queued tasks are cleared.
+  // Stops the local API server and closes the browser and internal queues once snapshots have
+  // completed. Does nothing if not running. When `force` is true, any queued snapshots are cleared.
   async *stop(force) {
     // not started, but the browser was launched
     if (!this.readyState && this.browser.isConnected()) {
@@ -277,7 +207,10 @@ export class Percy {
     if (!this.readyState || this.readyState > 2) return;
 
     // close queues asap
-    if (force) this.close();
+    if (force) {
+      this.#discovery.close(true);
+      this.#snapshots.close(true);
+    }
 
     // already stopping
     if (this.readyState === 2) return;
@@ -286,9 +219,15 @@ export class Percy {
     // log when force stopping
     if (force) this.log.info('Stopping percy...');
 
+    // used to log snapshot count information
+    let info = (state, size) => `${state} ` +
+      `${size} snapshot${size !== 1 ? 's' : ''}`;
+
     try {
-      // process uploads and close queues
-      yield* this.yield.flush(true);
+      // flush discovery and snapshot queues
+      yield* this.yield.flush((state, size) => {
+        this.log.progress(`${info(state, size)}...`, !!size);
+      });
     } catch (error) {
       // reset ready state when aborted
       /* istanbul ignore else: all errors bubble */
@@ -297,70 +236,22 @@ export class Percy {
     }
 
     // if dry-running, log the total number of snapshots
-    if (this.dryRun && this.#uploads.size) {
-      let total = this.#uploads.size - 1; // subtract the build task
-      this.log.info(`Found ${total} snapshot${total !== 1 ? 's' : ''}`);
+    if (this.dryRun && this.#snapshots.size) {
+      this.log.info(info('Found', this.#snapshots.size));
     }
 
-    // close any running server and browser
+    // close server and end queues
     await this.server?.close();
-    await this.browser.close();
-
-    // finalize and log build info
-    let meta = { build: this.build };
-
-    if (this.build?.failed) {
-      // do not finalize failed builds
-      this.log.warn(`Build #${this.build.number} failed: ${this.build.url}`, meta);
-    } else if (this.build?.id) {
-      // finalize the build
-      await this.client.finalizeBuild(this.build.id);
-      this.log.info(`Finalized build #${this.build.number}: ${this.build.url}`, meta);
-    } else {
-      // no build was ever created (likely failed while deferred)
-      this.log.warn('Build not created', meta);
-    }
+    await this.#discovery.end();
+    await this.#snapshots.end();
 
     // mark instance as stopped
     this.readyState = 3;
   }
 
-  // Deprecated capture method
-  capture(options) {
-    this.log.deprecated('The #capture() method will be ' + (
-      'removed in 1.0.0. Use #snapshot() instead.'));
-    return this.snapshot(options);
-  }
-
-  // Takes one or more snapshots of a page while discovering resources to upload with the
-  // snapshot. Once asset discovery has completed, the queued snapshot will resolve and an upload
-  // task will be queued separately. Accepts several different syntaxes for taking snapshots using
-  // various methods.
-  //
-  // snapshot(url|{url}|[...url|{url}])
-  // - requires fully qualified resolvable urls
-  // - snapshot options may be provided with the object syntax
-  //
-  // snapshot({snapshots:[...url|{url}]})
-  // - optional `baseUrl` prepended to snapshot urls
-  // - optional `options` apply to all or specific snapshots
-  //
-  // snapshot(sitemap|{sitemap})
-  // - required to be a fully qualified resolvable url ending in `.xml`
-  // - optional `include`/`exclude` to filter snapshots
-  // - optional `options` apply to all or specific snapshots
-  //
-  // snapshot({serve})
-  // - server address is prepended to snapshot urls
-  // - optional `baseUrl` used when serving pages
-  // - optional `rewrites`/`cleanUrls` to control snapshot urls
-  // - optional `include`/`exclude` to filter snapshots
-  // - optional `snapshots`, with fallback to built-in sitemap.xml
-  // - optional `options` apply to all or specific snapshots
-  //
-  // All available syntaxes will eventually push snapshots to the snapshot queue without the need to
-  // await on this method directly. This method resolves after the snapshot upload is queued, but
-  // does not await on the upload to complete.
+  // Takes one or more snapshots of a page while discovering resources to upload with the resulting
+  // snapshots. Once asset discovery has completed for the provided snapshots, the queued task will
+  // resolve and an upload task will be queued separately.
   snapshot(options) {
     if (this.readyState !== 1) {
       throw new Error('Not running');
@@ -370,8 +261,11 @@ export class Percy {
       return yieldAll(options.map(o => this.yield.snapshot(o)));
     }
 
+    // accept a url for a sitemap or snapshot
     if (typeof options === 'string') {
-      options = options.endsWith('.xml') ? { sitemap: options } : { url: options };
+      options = options.endsWith('.xml')
+        ? { sitemap: options }
+        : { url: options };
     }
 
     // validate options and add client & environment info
@@ -379,102 +273,44 @@ export class Percy {
     this.client.addClientInfo(options.clientInfo);
     this.client.addEnvironmentInfo(options.environmentInfo);
 
+    // without a discovery browser, capture is not possible
+    if (this.skipDiscovery && !this.dryRun && !options.domSnapshot) {
+      throw new Error('Cannot capture DOM snapshots when asset discovery is disabled');
+    }
+
     // return an async generator to allow cancelation
     return (async function*() {
-      let server = 'serve' in options ? (
-        await createStaticServer(options).listen()
-      ) : null;
+      let server;
 
       try {
-        if (server) {
-          // automatically set specific static server options
-          options.baseUrl = new URL(options.baseUrl || '', server.address()).href;
-          if (!options.snapshots) options.sitemap = new URL('sitemap.xml', options.baseUrl).href;
+        if ('serve' in options) {
+          // create and start a static server
+          let { baseUrl, snapshots } = options;
+          server = yield createStaticServer(options).listen();
+          baseUrl = options.baseUrl = new URL(baseUrl || '', server.address()).href;
+          if (!snapshots) options.sitemap = new URL('sitemap.xml', baseUrl).href;
         }
 
-        // gather snapshots from options
-        let snapshots = yield* gatherSnapshots(this, options);
+        // gather snapshots and discover snapshot resources
+        yield* discoverSnapshotResources(this.#discovery, {
+          skipDiscovery: this.skipDiscovery,
+          dryRun: this.dryRun,
 
-        try {
-          // use a try-catch to cancel snapshots that haven't started when the error occurred
-          yield* yieldAll(snapshots.map(s => this._takeSnapshot(s)));
-        } catch (error) {
-          // cancel queued snapshots that may not have started
-          snapshots.map(s => this._cancelSnapshot(s));
-          throw error;
-        }
+          snapshots: yield* gatherSnapshots(options, {
+            meta: { build: this.build },
+            config: this.config
+          })
+        }, snapshot => {
+          let { name, meta } = snapshot;
+          if (!this.deferUploads) this.log.info(`Snapshot taken: ${name}`, meta);
+          // push each finished snapshot to the snapshots queue
+          this.#snapshots.push(snapshot);
+        });
       } finally {
+        // always close any created server
         await server?.close();
       }
     }.call(this));
-  }
-
-  // Cancel any pending snapshot or snapshot uploads
-  _cancelSnapshot(snapshot) {
-    this.#snapshots.cancel(`snapshot/${snapshot.name}`);
-
-    for (let { name } of [snapshot, ...(snapshot.additionalSnapshots || [])]) {
-      this.#uploads.cancel(`upload/${name}`);
-    }
-  }
-
-  // Resolves after asset discovery has finished and uploads have been queued
-  _takeSnapshot(snapshot) {
-    // cancel any existing snapshot with the same name
-    this._cancelSnapshot(snapshot);
-
-    return this.#snapshots.push(`snapshot/${snapshot.name}`, async function*() {
-      try {
-        yield* discoverSnapshotResources(this, snapshot, (snap, resources) => {
-          if (!this.dryRun) this.log.info(`Snapshot taken: ${snap.name}`, snap.meta);
-          this._scheduleUpload(snap.name, { ...snap, resources });
-        });
-      } catch (error) {
-        if (error.name === 'AbortError') {
-          this.log.error('Received a duplicate snapshot name, ' + (
-            `the previous snapshot was aborted: ${snapshot.name}`), snapshot.meta);
-        } else {
-          this.log.error(`Encountered an error taking snapshot: ${snapshot.name}`, snapshot.meta);
-          this.log.error(error, snapshot.meta);
-        }
-      }
-    }.bind(this));
-  }
-
-  // Queues a snapshot upload with the provided options
-  _scheduleUpload(name, options) {
-    if (this.build?.error) throw new Error(this.build.error);
-
-    // maybe process any existing delayed uploads
-    if (!this.skipUploads && this.delayUploads && (
-      !this.build || this.build.id
-    )) this.#uploads.run();
-
-    return this.#uploads.push(`upload/${name}`, async () => {
-      // when delayed, stop the queue before other uploads are processed
-      if (this.readyState < 2 && this.delayUploads) this.#uploads.stop();
-
-      try {
-        /* istanbul ignore if: useful for other internal packages */
-        if (typeof options === 'function') options = await options();
-        await this.client.sendSnapshot(this.build.id, options);
-      } catch (error) {
-        let failed = error.response?.statusCode === 422 && (
-          error.response.body.errors.find(e => (
-            e.source?.pointer === '/data/attributes/build'
-          )));
-
-        this.log.error(`Encountered an error uploading snapshot: ${name}`, options.meta);
-        this.log.error(failed?.detail ?? error, options.meta);
-
-        // build failed at some point, stop accepting snapshots
-        if (failed) {
-          this.build.error = failed.detail;
-          this.build.failed = true;
-          this.close();
-        }
-      }
-    });
   }
 }
 

--- a/packages/core/src/queue.js
+++ b/packages/core/src/queue.js
@@ -4,140 +4,288 @@ import {
   AbortController
 } from './utils.js';
 
+// Assigns a deffered promise and resolve & reject functions to an object
+function deferred(obj) {
+  return Object.assign(obj, {
+    deferred: new Promise((resolve, reject) => {
+      Object.assign(obj, { resolve, reject });
+    })
+  });
+}
+
+// Returns the position of a needle within a haystack, or undefined if not found
+function positionOf(haystack, needle, i = 1) {
+  for (let item of haystack) {
+    if (item !== needle) i++;
+    else return i;
+  }
+}
+
+// Thrown when attempting to push to a closed queue
+class QueueClosedError extends Error {
+  name = this.constructor.name;
+}
+
+// A queue instance keeps a list of arbitrary items to process concurrently,
+// configured and controlled by various methods
 export class Queue {
-  running = true;
-  closed = false;
+  // item concurrency
+  concurrency = 10;
 
-  #queued = new Map();
-  #pending = new Map();
-
-  constructor(concurrency = 10) {
-    this.concurrency = concurrency;
+  // Configure queue properties
+  set({ concurrency }) {
+    if (concurrency) this.concurrency = concurrency;
+    return this;
   }
 
-  push(id, generator, priority) {
-    /* istanbul ignore next: race condition paranoia */
-    if (this.closed && !id.startsWith('@@/')) return;
+  // Configure queue handlers
+  #handlers = {};
 
-    this.cancel(id);
-
-    let task = { id, generator, priority };
-    task.promise = new Promise((resolve, reject) => {
-      Object.assign(task, { resolve, reject });
-      this.#queued.set(id, task);
-      this._dequeue();
-    });
-
-    return task.promise;
+  handle(event, handler) {
+    this.#handlers[event] = handler;
+    return this;
   }
 
-  cancel(id) {
-    this.#pending.get(id)?.ctrl?.abort();
-    this.#pending.delete(id);
-    this.#queued.delete(id);
-  }
+  // internal queues
+  #queued = new Set();
+  #pending = new Set();
 
-  has(id) {
-    return this.#queued.has(id) ||
-      this.#pending.has(id);
-  }
-
-  clear() {
-    this.#queued.clear();
-    return this.size;
-  }
-
+  // Queue size is total queued and pending items
   get size() {
     return this.#queued.size + this.#pending.size;
   }
 
+  // Pushes an item into the queue, additional args are passed to any configured task handler.
+  push(item, ...args) {
+    let task = deferred({ item });
+
+    // attach any configured error handler
+    task.deferred = task.deferred.catch(e => {
+      if (!this.#handlers.error) throw e;
+      return this.#handlers.error(item, e);
+    });
+
+    // when closed, reject with a queue closed error
+    if (this.readyState > 2) {
+      task.reject(new QueueClosedError());
+      return task.deferred;
+    }
+
+    // call or set up other handlers
+    let exists = this.cancel(item);
+    task.item = item = this.#handlers.push
+      ? this.#handlers.push(item, exists) : item;
+    task.handler = () => this.#handlers.task
+      ? this.#handlers.task(item, ...args) : item;
+    task.ctrl = new AbortController();
+
+    // queue this task & maybe dequeue the next task
+    this.#queued.add(task);
+    this.#dequeue();
+
+    // return the deferred task promise
+    return task.deferred;
+  }
+
+  // Maybe processes the next queued item task.
+  #dequeue() {
+    if (!this.#queued.size || this.readyState < 2) return;
+    if (this.#pending.size >= this.concurrency) return;
+    let [task] = this.#queued;
+    return this.#process(task);
+  }
+
+  // Cancels and aborts a specific item task.
+  cancel(item) {
+    let task = this.#find(item);
+    task?.ctrl.abort();
+
+    let queued = this.#queued.delete(task);
+    let pending = this.#pending.delete(task);
+
+    // reject queued tasks that are not pending
+    if (task && queued && !pending) {
+      task.reject(task.ctrl.signal.reason);
+    }
+
+    // return the cancelled item
+    return task?.item;
+  }
+
+  // Returns an item task matching the provided subject.
+  #find(subject) {
+    let find = this.#handlers.find
+    // use any configured find handler to match items
+      ? ({ item }) => this.#handlers.find(subject, item)
+      : ({ item }) => subject === item;
+
+    return (
+      // look at queued then pending items
+      [...this.#queued].find(find) ??
+      [...this.#pending].find(find)
+    );
+  }
+
+  // keep track of start and end tasks
+  #start = null;
+  #end = null;
+
+  // Initialize a starting task or return an existing one.
+  start() {
+    this.#start ??= deferred({ readyState: 1 });
+    this.#start.handler ??= this.#end
+    // wait for any ending task to complete first
+      ? () => this.#end.promise.then(this.#handlers.start)
+      : this.#handlers.start;
+    return this.#process(this.#start).deferred;
+  }
+
+  // intialize an ending task or return an existing one
+  end() {
+    this.#end ??= deferred({ readyState: 0 });
+    this.#end.handler ??= this.#start
+    // wait for any starting task to complete first
+      ? () => this.#start.promise.then(this.#handlers.end)
+      : this.#handlers.end;
+    return this.#process(this.#end).deferred;
+  }
+
+  // represents various queue states such as ready, running, or closed
+  readyState = 0;
+
+  // run the queue, starting it if necessary, and start dequeuing tasks
   run() {
-    this.running = true;
-
-    while (this.running && this.#queued.size && (
-      this.#pending.size < this.concurrency
-    )) this._dequeue();
-
+    if (!this.#start) this.start();
+    // when starting, state is updated afterwards
+    if (this.readyState === 0) this.#start.readyState = 2;
+    if (this.readyState === 1) this.readyState = 2;
+    while (this.#dequeue()) this.#dequeue();
     return this;
   }
 
+  // stop a running queue
   stop() {
-    this.running = false;
+    if (this.readyState === 2) this.readyState = 1;
     return this;
   }
 
-  open() {
-    this.closed = false;
-    return this;
-  }
-
+  // close a running queue, optionally aborting it
   close(abort) {
-    if (abort) this.stop().clear();
-    this.closed = true;
+    // when starting, state is updated afterwards
+    if (this.#start?.pending) this.#start.readyState = 3;
+    if (this.readyState < 3) this.readyState = 3;
+    if (abort) this.clear();
     return this;
   }
 
+  // clear and abort any queued tasks
+  clear() {
+    let tasks = [...this.#queued];
+    this.#queued.clear();
+
+    for (let task of tasks) {
+      task.ctrl.abort();
+      task.reject(task.ctrl.signal.reason);
+    }
+  }
+
+  // process a single item task when started
+  process(item) {
+    let task = this.#find(item);
+    if (this.readyState) this.#process(task);
+    return task?.deferred;
+  }
+
+  // processes tasks using a generator promise, allowing task handlers to be cancelable
+  #process(task) {
+    if (!task || task.promise) return task;
+
+    let queued = this.#queued.has(task);
+    // remove queued tasks from the queue
+    if (queued) this.#queued.delete(task);
+    // clear queued tasks when ending
+    if (task === this.#end) this.clear();
+    // add queued tasks to pending queue
+    if (queued) this.#pending.add(task);
+    // stop the queue when necessary
+    if (task.stop) this.stop();
+    // mark task as pending
+    task.pending = true;
+
+    // handle the task using a generator promise
+    task.promise = generatePromise(task.handler, task.ctrl?.signal, (err, val) => {
+      // clean up pending tasks that have not been aborted
+      if (queued && !task.ctrl.signal.aborted) this.#pending.delete(task);
+      // update queue state when necessary
+      if (task.readyState != null) this.readyState = task.readyState;
+      // clean up internal tasks after ending
+      if (!this.readyState) this.#start = this.#end = null;
+      // resolve or reject the deferred task promise
+      task[err ? 'reject' : 'resolve'](err ?? val);
+      // keep dequeuing when running
+      if (this.readyState === 2) this.run();
+      // mark pending task done
+      task.pending = false;
+    });
+
+    return task;
+  }
+
+  // returns a generator that yeilds until started and no longer pending, calling the
+  // callback every 10ms during checks with the current number of pending tasks
   idle(callback) {
     return yieldFor(() => {
       callback?.(this.#pending.size);
-      return !this.#pending.size;
+      let starting = this.#start?.pending === true;
+      return !starting && !this.#pending.size;
     }, { idle: 10 });
   }
 
-  empty(callback) {
-    return yieldFor(() => {
-      callback?.(this.size);
-      return !this.size;
-    }, { idle: 10 });
+  // process items up to the latest queued item, starting the queue if necessary;
+  // returns a generator that yields until the flushed item has finished processing
+  flush(callback) {
+    let interrupt = (
+      // check for existing interrupts
+      [...this.#pending].find(t => t.stop) ??
+      [...this.#queued].find(t => t.stop)
+    );
+
+    // get the latest queued or pending task to track
+    let flush = [...this.#queued].pop() ?? [...this.#pending].pop();
+    // determine if the queue should be stopped after flushing
+    if (flush) flush.stop = interrupt?.stop ?? this.readyState < 2;
+    // remove the old interrupt to avoid stopping early
+    if (interrupt) delete interrupt.stop;
+    // start the queue if not started
+    if (!this.#start) this.start();
+    // run the queue if stopped
+    if (flush?.stop) this.run();
+
+    // will yield with the callback until done flushing
+    return this.#until(flush, callback);
   }
 
-  async *flush(callback) {
-    let stopped = !this.running;
-
-    this.run().push('@@/flush', () => {
-      if (stopped) this.stop();
-    });
-
+  // Repeatedly yields, calling the callback with the position of the task within the queue
+  async *#until(task, callback) {
     try {
-      yield* this.idle(pend => {
-        let left = [...this.#queued.keys()].indexOf('@@/flush');
-        if (!~left && !this.#pending.has('@@/flush')) left = 0;
-        callback?.(pend + left);
-      });
-    } catch (error) {
-      if (stopped) this.stop();
-      this.cancel('@@/flush');
-      throw error;
+      yield* yieldFor(() => {
+        if (this.#start?.pending) return false;
+        let queued, pending = this.#pending.size;
+        // calculate the position within queued when not pending
+        if (task && task.pending == null) queued = positionOf(this.#queued, task);
+        // calculate the position within pending when not stopping
+        if (!task?.stop && task?.pending != null) pending = positionOf(this.#pending, task);
+        // call the callback and return true when not queued or pending
+        let position = (queued ?? 0) + (pending ?? 0);
+        callback?.(position);
+        return !position;
+      }, { idle: 10 });
+    } catch (err) {
+      // reset flushed tasks on error
+      if (task.stop) this.stop();
+      delete task.stop;
+      throw err;
     }
-  }
-
-  next() {
-    let next;
-
-    for (let [id, task] of this.#queued) {
-      if (!next || (task.priority != null && next.priority == null) ||
-          task.priority < next.priority) next = task;
-      if (id === '@@/flush') break;
-    }
-
-    return next;
-  }
-
-  _dequeue() {
-    if (!this.running) return;
-    if (this.#pending.size >= this.concurrency) return;
-    let task = this.next();
-    if (!task) return;
-
-    this.#queued.delete(task.id);
-    this.#pending.set(task.id, task);
-
-    let ctrl = task.ctrl = new AbortController();
-    return generatePromise(task.generator, ctrl.signal, (err, val) => {
-      if (!ctrl.signal.aborted) this.#pending.delete(task.id);
-      task[err ? 'reject' : 'resolve'](err ?? val);
-      return this._dequeue();
-    });
   }
 }
 

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -274,11 +274,10 @@ export function createSnapshotsQueue(percy) {
     .handle('find', ({ name }, snapshot) => (
       snapshot.name === name
     ))
-  // when pushed, maybe flush old snapshots or possibly merge with existing snapshots
+  // when pushed, maybe flush old snapshots
     .handle('push', (snapshot, existing) => {
       // immediately flush when uploads are delayed but not skipped
       if (percy.delayUploads && !percy.skipUploads) queue.flush();
-
       return snapshot;
     })
   // send snapshots to be uploaded to the build

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -1,21 +1,16 @@
 import logger from '@percy/logger';
 import PercyConfig from '@percy/config';
 import micromatch from 'micromatch';
-
-import {
-  configSchema
-} from './config.js';
+import { configSchema } from './config.js';
+import Queue from './queue.js';
 import {
   request,
   hostnameMatches,
-  createRootResource,
-  createPercyCSSResource,
-  createLogResource,
   yieldTo
 } from './utils.js';
 
 // Throw a better error message for missing or invalid urls
-export function validURL(url, base) {
+function validURL(url, base) {
   if (!url) {
     throw new Error('Missing required URL for snapshot');
   }
@@ -32,7 +27,7 @@ const RE_REGEXP = /^\/(.+)\/(\w+)?$/;
 
 // Returns true or false if a snapshot matches the provided include and exclude predicates. A
 // predicate can be an array of predicates, a regular expression, a glob pattern, or a function.
-export function snapshotMatches(snapshot, include, exclude) {
+function snapshotMatches(snapshot, include, exclude) {
   // support an options object as the second argument
   if (include?.include || include?.exclude) ({ include, exclude } = include);
 
@@ -74,15 +69,15 @@ export function snapshotMatches(snapshot, include, exclude) {
 }
 
 // Accepts an array of snapshots to filter and map with matching options.
-export function mapSnapshotOptions(percy, snapshots, config) {
+function mapSnapshotOptions(snapshots, context) {
   if (!snapshots?.length) return [];
 
   // reduce options into a single function
-  let applyOptions = [].concat(config?.options || [])
+  let applyOptions = [].concat(context?.options || [])
     .reduceRight((next, { include, exclude, ...opts }) => snap => next(
       // assign additional options to included snaphots
       snapshotMatches(snap, include, exclude) ? Object.assign(snap, opts) : snap
-    ), s => getSnapshotConfig(percy, s));
+    ), snap => getSnapshotOptions(snap, context));
 
   // reduce snapshots with overrides
   return snapshots.reduce((acc, snapshot) => {
@@ -90,12 +85,12 @@ export function mapSnapshotOptions(percy, snapshots, config) {
     if (typeof snapshot === 'string') snapshot = { url: snapshot };
 
     // normalize the snapshot url and use it for the default name
-    let url = validURL(snapshot.url, config?.baseUrl);
+    let url = validURL(snapshot.url, context?.baseUrl);
     snapshot.name ||= `${url.pathname}${url.search}${url.hash}`;
     snapshot.url = url.href;
 
     // use the snapshot when matching include/exclude
-    if (snapshotMatches(snapshot, config)) {
+    if (snapshotMatches(snapshot, context)) {
       acc.push(applyOptions(snapshot));
     }
 
@@ -103,23 +98,45 @@ export function mapSnapshotOptions(percy, snapshots, config) {
   }, []);
 }
 
-// Returns an array of derived snapshot options
-export async function* gatherSnapshots(percy, options) {
-  let { baseUrl, snapshots } = options;
+// Return snapshot options merged with defaults and global config.
+function getSnapshotOptions(options, { config, meta }) {
+  return PercyConfig.merge([{
+    widths: configSchema.snapshot.properties.widths.default,
+    discovery: { allowedHostnames: [validURL(options.url).hostname] },
+    meta: { ...meta, snapshot: { name: options.name } }
+  }, config.snapshot, {
+    // only specific discovery options are used per-snapshot
+    discovery: {
+      allowedHostnames: config.discovery.allowedHostnames,
+      disallowedHostnames: config.discovery.disallowedHostnames,
+      networkIdleTimeout: config.discovery.networkIdleTimeout,
+      requestHeaders: config.discovery.requestHeaders,
+      authorization: config.discovery.authorization,
+      disableCache: config.discovery.disableCache,
+      userAgent: config.discovery.userAgent
+    }
+  }, options], (path, prev, next) => {
+    switch (path.map(k => k.toString()).join('.')) {
+      case 'widths': // dedup, sort, and override widths when not empty
+        return [path, !next?.length ? prev : [...new Set(next)].sort((a, b) => a - b)];
+      case 'percyCSS': // concatenate percy css
+        return [path, [prev, next].filter(Boolean).join('\n')];
+      case 'execute': // shorthand for execute.beforeSnapshot
+        return (Array.isArray(next) || typeof next !== 'object')
+          ? [path.concat('beforeSnapshot'), next] : [path];
+      case 'discovery.disallowedHostnames': // prevent disallowing the root hostname
+        return [path, !next?.length ? prev : (
+          (prev ?? []).concat(next).filter(h => !hostnameMatches(h, options.url))
+        )];
+    }
 
-  if ('url' in options) snapshots = [options];
-  if ('sitemap' in options) snapshots = yield getSitemapSnapshots(options);
-
-  // validate evaluated snapshots
-  if (typeof snapshots === 'function') {
-    snapshots = yield* yieldTo(snapshots(baseUrl));
-    snapshots = validateSnapshotOptions({ baseUrl, snapshots }).snapshots;
-  }
-
-  // map snapshots with snapshot options
-  snapshots = mapSnapshotOptions(percy, snapshots, options);
-  if (!snapshots.length) throw new Error('No snapshots found');
-  return snapshots;
+    // ensure additional snapshots have complete names
+    if (path[0] === 'additionalSnapshots' && path.length === 2) {
+      let { prefix = '', suffix = '', ...n } = next;
+      next = { name: `${prefix}${options.name}${suffix}`, ...n };
+      return [path, next];
+    }
+  });
 }
 
 // Validates and migrates snapshot options against the correct schema based on provided
@@ -172,7 +189,7 @@ export function validateSnapshotOptions(options) {
 
 // Fetches a sitemap and parses it into a list of URLs for taking snapshots. Duplicate URLs,
 // including a trailing slash, are removed from the resulting list.
-export async function getSitemapSnapshots(options) {
+async function getSitemapSnapshots(options) {
   return request(options.sitemap, (body, res) => {
     // validate sitemap content-type
     let [contentType] = res.headers['content-type'].split(';');
@@ -193,254 +210,100 @@ export async function getSitemapSnapshots(options) {
   });
 }
 
-// Return snapshot options merged with defaults and global options.
-export function getSnapshotConfig(percy, options) {
-  return PercyConfig.merge([{
-    widths: configSchema.snapshot.properties.widths.default,
-    discovery: { allowedHostnames: [validURL(options.url).hostname] },
-    meta: { snapshot: { name: options.name }, build: percy.build }
-  }, percy.config.snapshot, {
-    // only specific discovery options are used per-snapshot
-    discovery: {
-      allowedHostnames: percy.config.discovery.allowedHostnames,
-      disallowedHostnames: percy.config.discovery.disallowedHostnames,
-      networkIdleTimeout: percy.config.discovery.networkIdleTimeout,
-      requestHeaders: percy.config.discovery.requestHeaders,
-      authorization: percy.config.discovery.authorization,
-      disableCache: percy.config.discovery.disableCache,
-      userAgent: percy.config.discovery.userAgent
-    }
-  }, options], (path, prev, next) => {
-    switch (path.map(k => k.toString()).join('.')) {
-      case 'widths': // dedup, sort, and override widths when not empty
-        return [path, !next?.length ? prev : Array.from(new Set(next)).sort((a, b) => a - b)];
-      case 'percyCSS': // concatenate percy css
-        return [path, [prev, next].filter(Boolean).join('\n')];
-      case 'execute': // shorthand for execute.beforeSnapshot
-        return (Array.isArray(next) || typeof next !== 'object')
-          ? [path.concat('beforeSnapshot'), next] : [path];
-      case 'discovery.disallowedHostnames': // prevent disallowing the root hostname
-        return [path, !next?.length ? prev : (
-          (prev ?? []).concat(next).filter(h => !hostnameMatches(h, options.url))
-        )];
-    }
+// Returns an array of derived snapshot options
+export async function* gatherSnapshots(options, context) {
+  let { baseUrl, snapshots } = options;
 
-    // ensure additional snapshots have complete names
-    if (path[0] === 'additionalSnapshots' && path.length === 2) {
-      let { prefix = '', suffix = '', ...n } = next;
-      next = { name: `${prefix}${options.name}${suffix}`, ...n };
-      return [path, next];
-    }
-  });
-}
+  if ('url' in options) [snapshots, options] = [[options], {}];
+  if ('sitemap' in options) snapshots = yield getSitemapSnapshots(options);
 
-// Returns a complete and valid snapshot config object and logs verbose debug logs detailing various
-// snapshot options. When `showInfo` is true, specific messages will be logged as info logs rather
-// than debug logs.
-function debugSnapshotConfig(snapshot, showInfo) {
-  let log = logger('core:snapshot');
-
-  // log snapshot info
-  log.debug('---------', snapshot.meta);
-  if (showInfo) log.info(`Snapshot found: ${snapshot.name}`, snapshot.meta);
-  else log.debug(`Handling snapshot: ${snapshot.name}`, snapshot.meta);
-
-  // will log debug info for an object property if its value is defined
-  let debugProp = (obj, prop, format = String) => {
-    let val = prop.split('.').reduce((o, k) => o?.[k], obj);
-
-    if (val != null) {
-      // join formatted array values with a space
-      val = [].concat(val).map(format).join(', ');
-      log.debug(`- ${prop}: ${val}`, snapshot.meta);
-    }
-  };
-
-  debugProp(snapshot, 'url');
-  debugProp(snapshot, 'scope');
-  debugProp(snapshot, 'widths', v => `${v}px`);
-  debugProp(snapshot, 'minHeight', v => `${v}px`);
-  debugProp(snapshot, 'enableJavaScript');
-  debugProp(snapshot, 'deviceScaleFactor');
-  debugProp(snapshot, 'waitForTimeout');
-  debugProp(snapshot, 'waitForSelector');
-  debugProp(snapshot, 'execute.afterNavigation');
-  debugProp(snapshot, 'execute.beforeResize');
-  debugProp(snapshot, 'execute.afterResize');
-  debugProp(snapshot, 'execute.beforeSnapshot');
-  debugProp(snapshot, 'discovery.allowedHostnames');
-  debugProp(snapshot, 'discovery.disallowedHostnames');
-  debugProp(snapshot, 'discovery.requestHeaders', JSON.stringify);
-  debugProp(snapshot, 'discovery.authorization', JSON.stringify);
-  debugProp(snapshot, 'discovery.disableCache');
-  debugProp(snapshot, 'discovery.userAgent');
-  debugProp(snapshot, 'clientInfo');
-  debugProp(snapshot, 'environmentInfo');
-  debugProp(snapshot, 'domSnapshot', Boolean);
-
-  for (let added of (snapshot.additionalSnapshots || [])) {
-    if (showInfo) log.info(`Snapshot found: ${added.name}`, snapshot.meta);
-    else log.debug(`Additional snapshot: ${added.name}`, snapshot.meta);
-
-    debugProp(added, 'waitForTimeout');
-    debugProp(added, 'waitForSelector');
-    debugProp(added, 'execute');
-  }
-}
-
-// Calls the provided callback with additional resources
-function handleSnapshotResources(snapshot, map, callback) {
-  let resources = [...map.values()];
-
-  // sort the root resource first
-  let [root] = resources.splice(resources.findIndex(r => r.root), 1);
-  resources.unshift(root);
-
-  // inject Percy CSS
-  if (snapshot.percyCSS) {
-    let css = createPercyCSSResource(root.url, snapshot.percyCSS);
-    resources.push(css);
-
-    // replace root contents and associated properties
-    Object.assign(root, createRootResource(root.url, (
-      root.content.replace(/(<\/body>)(?!.*\1)/is, (
-        `<link data-percy-specific-css rel="stylesheet" href="${css.pathname}"/>`
-      ) + '$&'))));
+  // validate evaluated snapshots
+  if (typeof snapshots === 'function') {
+    snapshots = yield* yieldTo(snapshots(baseUrl));
+    snapshots = validateSnapshotOptions({ baseUrl, snapshots }).snapshots;
   }
 
-  // include associated snapshot logs matched by meta information
-  resources.push(createLogResource(logger.query(log => (
-    log.meta.snapshot?.name === snapshot.meta.snapshot.name
-  ))));
+  // map snapshots with snapshot options
+  snapshots = mapSnapshotOptions(snapshots, { ...options, ...context });
+  if (!snapshots.length) throw new Error('No snapshots found');
 
-  return callback(snapshot, resources);
+  return snapshots;
 }
 
-// Wait for a page's asset discovery network to idle
-function waitForDiscoveryNetworkIdle(page, options) {
-  let { allowedHostnames, networkIdleTimeout } = options;
-  let filter = r => hostnameMatches(allowedHostnames, r.url);
+// Creates a snapshots queue that manages a Percy build and uploads snapshots.
+export function createSnapshotsQueue(percy) {
+  let { concurrency } = percy.config.discovery;
+  let queue = new Queue();
+  let build;
 
-  return page.network.idle(filter, networkIdleTimeout);
-}
-
-// Used to cache resources across core instances
-const RESOURCE_CACHE_KEY = Symbol('resource-cache');
-
-// Trigger resource requests for a page by iterating over snapshot widths and calling any provided
-// execute options. Additional resize options may be provided to capture resources mobile resources
-function* triggerResourceRequests(page, snapshot, options) {
-  // copy widths to prevent mutation later
-  let [initialWidth, ...widths] = snapshot.widths;
-
-  // set the initial page size
-  yield page.resize({
-    width: initialWidth,
-    height: snapshot.minHeight,
-    ...options
-  });
-
-  // navigate to the url
-  yield page.goto(snapshot.url);
-
-  if (snapshot.execute) {
-    // when any execute options are provided, inject snapshot options
-    /* istanbul ignore next: cannot detect coverage of injected code */
-    yield page.eval((_, s) => (window.__PERCY__.snapshot = s), snapshot);
-    yield page.evaluate(snapshot.execute.afterNavigation);
-  }
-
-  // trigger resize events for other widths
-  for (let width of widths) {
-    yield page.evaluate(snapshot.execute?.beforeResize);
-    yield waitForDiscoveryNetworkIdle(page, snapshot.discovery);
-    yield page.resize({ width, height: snapshot.minHeight, ...options });
-    yield page.evaluate(snapshot.execute?.afterResize);
-  }
-}
-
-// Discovers resources for a snapshot using a browser page to intercept requests. The callback
-// function will be called with the snapshot name (for additional snapshots) and an array of
-// discovered resources. When additional snapshots are provided, the callback will be called once
-// for each snapshot.
-export async function* discoverSnapshotResources(percy, snapshot, callback) {
-  debugSnapshotConfig(snapshot, percy.dryRun);
-
-  // when dry-running, invoke the callback for each snapshot and immediately return
-  let allSnapshots = [snapshot, ...(snapshot.additionalSnapshots || [])];
-  if (percy.dryRun) return allSnapshots.map(s => callback(s));
-
-  // keep a global resource cache across snapshots
-  let cache = percy[RESOURCE_CACHE_KEY] ||= new Map();
-
-  // preload the root resource for existing dom snapshots
-  let resources = new Map(snapshot.domSnapshot && (
-    [createRootResource(snapshot.url, snapshot.domSnapshot)]
-      .map(resource => [resource.url, resource])
-  ));
-
-  // when no discovery browser is available, do not attempt to discover other resources
-  if (percy.skipDiscovery && !snapshot.domSnapshot) {
-    throw new Error('Cannot capture DOM snapshot when asset discovery is disabled');
-  } else if (percy.skipDiscovery) {
-    return handleSnapshotResources(snapshot, resources, callback);
-  }
-
-  // open a new browser page
-  let page = yield percy.browser.page({
-    enableJavaScript: snapshot.enableJavaScript ?? !snapshot.domSnapshot,
-    networkIdleTimeout: snapshot.discovery.networkIdleTimeout,
-    requestHeaders: snapshot.discovery.requestHeaders,
-    authorization: snapshot.discovery.authorization,
-    userAgent: snapshot.discovery.userAgent,
-    meta: snapshot.meta,
-
-    // enable network inteception
-    intercept: {
-      enableJavaScript: snapshot.enableJavaScript,
-      disableCache: snapshot.discovery.disableCache,
-      allowedHostnames: snapshot.discovery.allowedHostnames,
-      disallowedHostnames: snapshot.discovery.disallowedHostnames,
-      getResource: u => resources.get(u) || cache.get(u),
-      saveResource: r => resources.set(r.url, r) && cache.set(r.url, r)
-    }
-  });
-
-  try {
-    yield* triggerResourceRequests(page, snapshot);
-
-    // trigger resource requests for any alternate device pixel ratio
-    if (snapshot.discovery.devicePixelRatio) {
-      // wait for any existing pending resource requests first
-      yield waitForDiscoveryNetworkIdle(page, snapshot.discovery);
-
-      yield* triggerResourceRequests(page, snapshot, {
-        deviceScaleFactor: snapshot.discovery.devicePixelRatio,
-        mobile: true
-      });
-    }
-
-    if (snapshot.domSnapshot) {
-      // ensure discovery has finished and handle resources
-      yield waitForDiscoveryNetworkIdle(page, snapshot.discovery);
-      handleSnapshotResources(snapshot, resources, callback);
-    } else {
-      let { enableJavaScript } = snapshot;
-
-      // capture snapshots sequentially
-      for (let snap of allSnapshots) {
-        // will wait for timeouts, selectors, and additional network activity
-        let { url, dom } = yield page.snapshot({ enableJavaScript, ...snap });
-        let root = createRootResource(url, dom);
-        // use the normalized root url to prevent duplicates
-        resources.set(root.url, root);
-        // shallow merge with root snapshot options
-        handleSnapshotResources({ ...snapshot, ...snap }, resources, callback);
-        // remove the previously captured dom snapshot
-        resources.delete(root.url);
+  return queue
+    .set({ concurrency })
+  // on start, create a new Percy build
+    .handle('start', async () => {
+      try {
+        build = percy.build = {};
+        let { data } = await percy.client.createBuild();
+        let url = data.attributes['web-url'];
+        let number = data.attributes['build-number'];
+        Object.assign(build, { id: data.id, url, number });
+        // immediately run the queue if not delayed or deferred
+        if (!percy.delayUploads && !percy.deferUploads) queue.run();
+      } catch (err) {
+        // immediately throw the error if not delayed or deferred
+        if (!percy.delayUploads && !percy.deferUploads) throw err;
+        Object.assign(build, { error: 'Failed to create build' });
+        percy.log.error(build.error);
+        percy.log.error(err);
+        queue.close(true);
       }
-    }
-  } finally {
-    await page.close();
-  }
+    })
+  // on end, maybe finalize the build and log about build info
+    .handle('end', async () => {
+      if (!percy.readyState) return;
+
+      if (build?.failed) {
+        percy.log.warn(`Build #${build.number} failed: ${build.url}`, { build });
+      } else if (build?.id) {
+        await percy.client.finalizeBuild(build.id);
+        percy.log.info(`Finalized build #${build.number}: ${build.url}`, { build });
+      } else {
+        percy.log.warn('Build not created', { build });
+      }
+    })
+  // snapshots are unique by name alone
+    .handle('find', ({ name }, snapshot) => (
+      snapshot.name === name
+    ))
+  // when pushed, maybe flush old snapshots or possibly merge with existing snapshots
+    .handle('push', (snapshot, existing) => {
+      // immediately flush when uploads are delayed but not skipped
+      if (percy.delayUploads && !percy.skipUploads) queue.flush();
+
+      return snapshot;
+    })
+  // send snapshots to be uploaded to the build
+    .handle('task', async function*(snapshot, prepare) {
+      snapshot = yield* yieldTo(prepare?.(snapshot) ?? snapshot);
+      return yield percy.client.sendSnapshot(build.id, snapshot);
+    })
+  // handle possible build errors returned by the API
+    .handle('error', ({ name, meta }, error) => {
+      if (error.name === 'QueueClosedError') return { error };
+      if (error.name === 'AbortError') return { error };
+
+      let failed = error.response?.statusCode === 422 && (
+        error.response.body.errors.find(e => (
+          e.source?.pointer === '/data/attributes/build'
+        )));
+
+      if (failed) {
+        build.error = error.message = failed.detail;
+        build.failed = true;
+        queue.close(true);
+      }
+
+      percy.log.error(`Encountered an error uploading snapshot: ${name}`, meta);
+      percy.log.error(error, meta);
+      return { error };
+    });
 }

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -529,9 +529,9 @@ describe('Discovery', () => {
       `[percy:core:discovery] - sha: ${sha256hash(pixel)}`,
       '[percy:core:discovery] - mimetype: image/gif',
       '[percy:core:page] Page navigated',
-      '[percy:core:network] Wait for 100ms idle',
+      '[percy:core:discovery] Wait for 100ms idle',
       '[percy:core:page] Resize page to 1200x1024 @1x',
-      '[percy:core:network] Wait for 100ms idle',
+      '[percy:core:discovery] Wait for 100ms idle',
       '[percy:core:page] Page closed'
     ]));
   });
@@ -728,14 +728,19 @@ describe('Discovery', () => {
     });
 
     logger.reset();
-    await percy.snapshot([{
+
+    await percy.snapshot({
       name: 'Snapshot with DOM',
       url: 'http://localhost:8000',
       domSnapshot: testDOM
-    }, {
+    });
+
+    expect(() => percy.snapshot({
       name: 'Snapshot without DOM',
       url: 'http://localhost:8000'
-    }]);
+    })).toThrowError(
+      'Cannot capture DOM snapshots when asset discovery is disabled'
+    );
 
     await percy.idle();
     expect(server.requests).toEqual([]);
@@ -746,12 +751,9 @@ describe('Discovery', () => {
       'http://localhost:8000/'
     ]);
 
+    expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
       '[percy] Snapshot taken: Snapshot with DOM'
-    ]);
-    expect(logger.stderr).toEqual([
-      '[percy] Encountered an error taking snapshot: Snapshot without DOM',
-      '[percy] Error: Cannot capture DOM snapshot when asset discovery is disabled'
     ]);
   });
 

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -98,7 +98,7 @@ describe('Discovery', () => {
   });
 
   it('waits for discovery network idle timeout', async () => {
-    percy.setConfig({ discovery: { networkIdleTimeout: 400 } });
+    percy.set({ discovery: { networkIdleTimeout: 400 } });
 
     server.reply('/', () => [200, 'text/html', dedent`
       <html><body><script>

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -139,9 +139,9 @@ describe('Percy', () => {
     });
   });
 
-  describe('#setConfig(config)', () => {
+  describe('#set(config)', () => {
     it('adds client and environment information', () => {
-      expect(percy.setConfig({
+      expect(percy.set({
         clientInfo: 'client/info',
         environmentInfo: 'env/info'
       })).toEqual(percy.config);
@@ -151,7 +151,7 @@ describe('Percy', () => {
     });
 
     it('merges existing and provided config options', () => {
-      expect(percy.setConfig({
+      expect(percy.set({
         snapshot: { widths: [1000] }
       })).toEqual({
         ...percy.config,
@@ -163,7 +163,7 @@ describe('Percy', () => {
     });
 
     it('warns and ignores invalid config options', () => {
-      expect(percy.setConfig({
+      expect(percy.set({
         snapshot: { widths: 1000 },
         foo: 'bar'
       })).toEqual(percy.config);

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -72,17 +72,18 @@ describe('Percy', () => {
     // navigate to a page and capture a snapshot outside of core
     await page.goto('http://localhost:8000');
 
-    let { url, dom } = await page.snapshot({
+    let snapshot = await page.snapshot({
       execute() {
         let p = document.querySelector('p');
         p.textContent = p.textContent.replace('Hello', 'Hello there,');
       }
     });
 
-    expect(url).toEqual('http://localhost:8000/');
-    expect(dom).toEqual('<!DOCTYPE html><html><head></head><body>' + (
-      `<p>Hello there, Percy!</p>${img}`
-    ) + '</body></html>');
+    expect(snapshot.url).toEqual('http://localhost:8000/');
+    expect(snapshot.domSnapshot).toEqual(
+      '<!DOCTYPE html><html><head></head><body>' + (
+        `<p>Hello there, Percy!</p>${img}`
+      ) + '</body></html>');
   });
 
   describe('.start()', () => {
@@ -369,8 +370,7 @@ describe('Percy', () => {
       })).toThrowError('Failed to create build');
 
       expect(logger.stdout).toEqual([
-        '[percy] Percy has started!',
-        '[percy] Snapshot taken: Snapshot 1'
+        '[percy] Percy has started!'
       ]);
       expect(logger.stderr).toEqual([
         '[percy] Failed to create build',
@@ -599,7 +599,7 @@ describe('Percy', () => {
       ]));
       expect(logger.stderr).toEqual([
         '[percy] Encountered an error uploading snapshot: test snapshot',
-        '[percy] Build has failed',
+        '[percy] Error: Build has failed',
         '[percy] Build #1 failed: https://percy.io/test/test/123'
       ]);
     });
@@ -608,7 +608,6 @@ describe('Percy', () => {
   describe('#idle()', () => {
     beforeEach(async () => {
       await percy.start();
-      logger.reset();
     });
 
     it('resolves after snapshots idle', async () => {
@@ -620,23 +619,8 @@ describe('Percy', () => {
       });
 
       expect(api.requests['/builds/123/snapshots']).toBeUndefined();
-
       await percy.idle();
-
       expect(api.requests['/builds/123/snapshots']).toHaveSize(1);
-    });
-  });
-
-  describe('#capture()', () => {
-    it('is deprecated', async () => {
-      spyOn(percy, 'snapshot').and.resolveTo('fin');
-      await expectAsync(percy.capture()).toBeResolvedTo('fin');
-      expect(percy.snapshot).toHaveBeenCalledTimes(1);
-
-      expect(logger.stderr).toEqual([
-        '[percy] Warning: The #capture() method will be ' +
-          'removed in 1.0.0. Use #snapshot() instead.'
-      ]);
     });
   });
 });

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -1011,7 +1011,7 @@ describe('Snapshot', () => {
     });
 
     it('creates a resource for per-snapshot percy-css', async () => {
-      percy.setConfig({ snapshot: { percyCSS: '' } });
+      percy.set({ snapshot: { percyCSS: '' } });
 
       await percy.snapshot({
         name: 'test snapshot',

--- a/packages/core/test/unit/queue.test.js
+++ b/packages/core/test/unit/queue.test.js
@@ -1,220 +1,451 @@
-import { generatePromise, AbortController, waitForTimeout } from '../../src/utils.js';
+import { AbortController, generatePromise, waitForTimeout } from '../../src/utils.js';
 import Queue from '../../src/queue.js';
-
-function task(timeout = 0, cb) {
-  return async function t() {
-    t.running = true;
-    await waitForTimeout(timeout);
-    let v = cb && (await cb());
-    t.running = false;
-    return v;
-  };
-}
 
 describe('Unit / Tasks Queue', () => {
   let q;
 
   beforeEach(() => {
-    q = new Queue(2);
+    q = new Queue();
   });
 
-  it('has a default concurrency', () => {
-    expect(new Queue()).toHaveProperty('concurrency', 10);
+  it('has a customizable concurrency', () => {
+    expect(q.concurrency).toBe(10);
+    q.set({ concurrency: 2 });
+    expect(q.concurrency).toBe(2);
   });
 
-  it('can set a specific concurrency', () => {
-    expect(q).toHaveProperty('concurrency', 2);
+  it('can push items to the queue', () => {
+    expect(q.size).toBe(0);
+    q.push(1);
+    q.push('item #2');
+    expect(q.size).toBe(2);
+    q.push({ value: 'item #3' });
+    expect(q.size).toBe(3);
   });
 
-  describe('#push()', () => {
-    it('runs each task concurrently within the limit', () => {
-      let tasks = Array(4).fill().map(() => task(100));
-      tasks.forEach((t, i) => q.push(i, t));
+  it('can cancel existing queued items', async () => {
+    let p1 = q.push('item #1');
+    let p2 = q.push('item #2');
+    expect(q.size).toBe(2);
 
-      expect(tasks[0]).toHaveProperty('running', true);
-      expect(tasks[1]).toHaveProperty('running', true);
-      expect(tasks[2]).not.toHaveProperty('running');
-      expect(tasks[3]).not.toHaveProperty('running');
-    });
+    await expectAsync(p1).toBePending();
+    await expectAsync(p2).toBePending();
 
-    it('resolves or rejects when the task completes', async () => {
-      let n = 0;
-      q.push(0, task(50, () => n++));
+    q.cancel('item #2');
+    expect(q.size).toBe(1);
+    await expectAsync(p1).toBePending();
+    await expectAsync(p2).toBeRejectedWithError('This operation was aborted');
 
-      expect(n).toBe(0);
-      await expectAsync(q.push(1, task(100, () => n++))).toBeResolvedTo(1);
-      expect(n).toBe(2);
-
-      await expectAsync(q.push(2, () => {
-        throw new Error('some error');
-      })).toBeRejectedWithError('some error');
-    });
-
-    it('can run tasks according to priority', async () => {
-      let done = [];
-
-      for (let i = 0; i < 4; i++) {
-        q.push(i, task(100, () => done.push(i)));
-      }
-
-      await Promise.all([
-        q.push(4, task(100, () => done.push(4)), 10),
-        q.push(5, task(100, () => done.push(5)), 10),
-        q.push(6, task(100, () => done.push(6)), 5)
-      ]);
-
-      expect(done).toEqual([0, 1, 6, 4, 5]);
-      await generatePromise(q.idle());
-      expect(done).toEqual([0, 1, 6, 4, 5, 2, 3]);
-    });
+    let p1$2 = q.push('item #1');
+    expect(q.size).toBe(1);
+    expect(p1).not.toBe(p1$2);
+    await expectAsync(p1).toBeRejectedWithError('This operation was aborted');
+    await expectAsync(p1$2).toBePending();
   });
 
-  describe('#size', () => {
-    it('returns the number of all incomplete tasks', async () => {
-      let tasks = Array(10).fill().map((_, i) => q.push(i, task(100)));
+  it('can add a find handler to cancel similar items', async () => {
+    let find = jasmine.createSpy('find', (a, b) => a.key === b.key);
+    q.handle('find', find.and.callThrough());
 
-      expect(q.size).toBe(10);
-      await tasks[1]; // wait for the first set of tasks to complete
-      expect(q.size).toBe(8);
-    });
+    let p0 = q.push({ key: 0, value: '' });
+    expect(find).not.toHaveBeenCalledWith();
+    expect(q.size).toBe(1);
+
+    let itemFoo = { key: 1, value: 'foo' };
+    let promiseFoo = q.push(itemFoo);
+    expect(q.size).toBe(2);
+
+    expect(find).toHaveBeenCalledWith(itemFoo, jasmine.anything());
+    await expectAsync(promiseFoo).toBePending();
+    await expectAsync(p0).toBePending();
+
+    let itemBar = { key: 1, value: 'bar' };
+    let promiseBar = q.push(itemBar);
+    expect(q.size).toBe(2);
+
+    expect(find).toHaveBeenCalledWith(itemBar, itemFoo);
+    await expectAsync(promiseBar).toBePending();
+    await expectAsync(p0).toBePending();
+
+    await expectAsync(promiseFoo)
+      .toBeRejectedWithError('This operation was aborted');
   });
 
-  describe('#idle()', () => {
-    it('finishes when running tasks settle', async () => {
-      let tasks = Array(5).fill().map(() => task(100));
-      tasks.forEach((t, i) => q.push(i, t));
+  it('can add a push handler to transform pushed items', async () => {
+    let push = jasmine.createSpy('push', i => (i.pushed = true, i));
+    q.handle('find', (a, b) => a.key === b.key);
+    q.handle('push', push.and.callThrough());
 
-      q.push('err', task(50, () => {
-        // a rejected task should not interrupt #idle()
-        throw new Error('test error');
-      })).catch(() => {}); // we're catching the promise, not the task
+    let itemFoo = { key: 1, value: 'foo' };
+    let promiseFoo = q.push(itemFoo);
 
-      q.push('stop', () => q.stop());
-      let more = Array(3).fill().map(() => task(50));
-      more.forEach((t, i) => q.push(`more/${i}`, t));
+    expect(push).toHaveBeenCalledWith(itemFoo, undefined);
+    expect(itemFoo).toHaveProperty('pushed', true);
+    await expectAsync(promiseFoo).toBePending();
 
-      await expectAsync(generatePromise(q.idle())).toBeResolved();
-      tasks.forEach(t => expect(t).toHaveProperty('running', false));
-      more.forEach(t => expect(t).not.toHaveProperty('running'));
+    let itemBar = { key: 1, value: 'bar' };
+    let promiseBar = q.push(itemBar);
 
-      await expectAsync(generatePromise(q.run().idle())).toBeResolved();
-      more.forEach(t => expect(t).toHaveProperty('running', false));
-    });
+    expect(push).toHaveBeenCalledWith(itemBar, itemFoo);
+    expect(itemBar).toHaveProperty('pushed', true);
+    await expectAsync(promiseBar).toBePending();
+
+    await expectAsync(promiseFoo)
+      .toBeRejectedWithError('This operation was aborted');
   });
 
-  describe('#empty()', () => {
-    it('finishes when all tasks are settled', async () => {
-      let tasks = Array(5).fill().map(() => task(50));
-      tasks.forEach((t, i) => q.push(i, t));
+  it('can process any queued item once started', async () => {
+    let p1 = q.push('item #1');
+    let p2 = q.push('item #2');
+    expect(q.size).toBe(2);
 
-      q.push('stop', () => q.stop());
-      let more = Array(3).fill().map(() => task(50));
-      more.forEach((t, i) => q.push(`more/${i}`, t));
+    await expectAsync(p1).toBePending();
+    await expectAsync(p2).toBePending();
 
-      let empty = generatePromise(q.empty());
+    let p2$2 = q.process('item #2');
+    expect(q.size).toBe(2);
+    expect(p2$2).toBe(p2);
 
-      await expectAsync(empty).toBePending();
-      await generatePromise(q.idle());
-      await expectAsync(empty).toBePending();
+    await expectAsync(p1).toBePending();
+    await expectAsync(p2).toBePending();
 
-      tasks.forEach(t => expect(t).toHaveProperty('running', false));
-      more.forEach(t => expect(t).not.toHaveProperty('running'));
-      expect(q.running).toBe(false);
+    await q.start();
+    expect(q.size).toBe(2);
+    await q.process('item #2');
+    expect(q.size).toBe(1);
 
-      q.run();
-
-      expect(q.running).toBe(true);
-      await expectAsync(empty).toBePending();
-      await generatePromise(q.idle());
-      await expectAsync(empty).toBeResolved();
-
-      more.forEach(t => expect(t).toHaveProperty('running', false));
-    });
+    await expectAsync(p1).toBePending();
+    await expectAsync(p2).toBeResolved();
   });
 
-  describe('#cancel()', () => {
-    it('can cancel a pending task', async () => {
-      let task = async function*() {
-        task.step = yield 'foo';
-        task.step = yield waitForTimeout(100, 'bar');
-        task.step = yield waitForTimeout(500, 'baz');
-        task.step = yield 'qux';
-      };
+  it('can add a start handler that is called when starting', async () => {
+    let start = jasmine.createSpy('start');
+    q.handle('start', start);
 
-      let p = q.push('t', task);
-      await waitForTimeout(200);
-      q.cancel('t');
-
-      expect(task.step).toBe('bar');
-      await generatePromise(q.idle());
-      await expectAsync(p).toBeRejected();
-    });
+    expect(start).not.toHaveBeenCalled();
+    await q.start();
+    await q.start();
+    expect(start).toHaveBeenCalled();
   });
 
-  describe('#clear()', () => {
-    it('removes tasks from the queue', async () => {
-      let tasks = Array(10).fill().map(() => task(100));
-      let promises = tasks.map((t, i) => q.push(i, t));
-      q.clear();
+  it('can add a task handler for processing queued items', async () => {
+    let task = jasmine.createSpy('task');
+    q.handle('task', task);
+    q.push('item #1');
+    q.push('item #2');
 
-      // the first set of tasks is already running, the queue length will return
-      // 2 unless we wait for them to settle
-      await promises[1];
+    await q.start();
+    expect(task).not.toHaveBeenCalled();
 
-      expect(q.size).toBe(0);
-      expect(tasks[2]).not.toHaveProperty('running');
-    });
+    await q.process('item #2');
+    expect(task).toHaveBeenCalledWith('item #2');
   });
 
-  describe('#flush()', () => {
-    it('resolves when the queue idles', async () => {
-      let tasks = Array(5).fill().map(() => task(50));
-      tasks.forEach((t, i) => q.push(i, t));
+  it('can add an error handler to handle task errors', async () => {
+    let err = new Error('testing');
+    let error = jasmine.createSpy('error');
+    q.handle('task', () => Promise.reject(err));
+    q.handle('error', error);
 
-      await generatePromise(q.flush());
-      tasks.forEach(t => expect(t).toHaveProperty('running', false));
-    });
+    let p1 = q.push('item #1');
+    q.run();
 
-    it('automatically runs and stops the queue', async () => {
-      q.stop();
+    await expectAsync(p1).toBeResolved();
+    expect(error).toHaveBeenCalledWith('item #1', err);
 
-      let tasks = Array(5).fill().map(() => task(50));
-      tasks.forEach((t, i) => q.push(i, t));
-      q.push('stop', () => q.stop());
+    q.stop();
+    let p2 = q.push('item #2');
+    q.cancel('item #2');
 
-      let more = Array(5).fill().map(() => task(50));
-      more.forEach((t, i) => q.push(`more/${i}`, t));
+    await expectAsync(p2).toBeResolved();
+    expect(error).toHaveBeenCalledWith('item #2', (
+      jasmine.objectContaining({
+        name: 'AbortError',
+        message: 'This operation was aborted'
+      })
+    ));
+  });
 
-      expect(q.running).toBe(false);
-      await generatePromise(q.flush());
-      tasks.forEach(t => expect(t).toHaveProperty('running', false));
-      more.forEach(t => expect(t).not.toHaveProperty('running'));
+  it('can start running queued items sequentially', async () => {
+    let start = jasmine.createSpy('start');
+    let task = jasmine.createSpy('task');
+    q.handle('start', start);
+    q.handle('task', task);
 
-      expect(q.running).toBe(false);
-      await generatePromise(q.flush());
-      tasks.forEach(t => expect(t).toHaveProperty('running', false));
-    });
+    let promises = Promise.all([
+      q.push('item #1', 'foo'),
+      q.push('item #2', 'bar'),
+      q.push('item #3', 'baz')
+    ]);
 
-    it('stops the running queue when canceled', async () => {
-      q.stop();
+    expect(q.size).toBe(3);
+    q.run();
 
-      let tasks = Array(5).fill().map(() => task(50));
-      tasks.forEach((t, i) => q.push(i, t));
+    await expectAsync(promises).toBeResolved();
+    expect(q.size).toBe(0);
 
-      expect(q.running).toBe(false);
+    expect(start).toHaveBeenCalledBefore(task);
+    expect(task.calls.allArgs()).toEqual([
+      ['item #1', 'foo'],
+      ['item #2', 'bar'],
+      ['item #3', 'baz']
+    ]);
+  });
 
-      let ctrl = new AbortController();
-      let flushed = generatePromise(q.flush(), ctrl.signal);
-      expect(tasks[0]).toHaveProperty('running', true);
-      expect(q.running).toBe(true);
-      ctrl.abort();
+  it('can run as many queued items as concurrency allows', async () => {
+    q.handle('task', item => waitForTimeout(item.timeout, item.value));
+    q.set({ concurrency: 3 });
 
-      await expectAsync(flushed).toBeRejected();
-      await generatePromise(q.idle());
+    let p1 = Promise.all([
+      q.push({ value: 1, timeout: 100 }),
+      q.push({ value: 2, timeout: 100 }),
+      q.push({ value: 3, timeout: 100 })
+    ]).then(() => q.stop());
 
-      expect(tasks[0]).toHaveProperty('running', false);
-      expect(tasks[2]).not.toHaveProperty('running');
-      expect(q.running).toBe(false);
-    });
+    let p2 = Promise.all([
+      q.push({ value: 4, timeout: 100 }),
+      q.push({ value: 4, timeout: 100 }),
+      q.push({ value: 6, timeout: 100 })
+    ]);
+
+    expect(q.size).toBe(6);
+    q.run();
+
+    await expectAsync(p1).toBeResolved();
+    await expectAsync(p2).toBePending();
+    expect(q.size).toBe(3);
+  });
+
+  it('can prevent items from being accepted when closed', async () => {
+    let push = jasmine.createSpy('push');
+    let task = jasmine.createSpy('task');
+    q.handle('push', push);
+    q.handle('task', task);
+
+    let p1 = q.push('item #1');
+    let p2 = q.push('item #2');
+    expect(push).toHaveBeenCalledTimes(2);
+    expect(task).not.toHaveBeenCalled();
+    expect(q.size).toBe(2);
+
+    q.close();
+    let p3 = q.push('item #3');
+    expect(push).toHaveBeenCalledTimes(2);
+    expect(task).not.toHaveBeenCalled();
+    expect(q.size).toBe(2);
+
+    await expectAsync(p1).toBePending();
+    await expectAsync(p2).toBePending();
+    await expectAsync(p3).toBeRejectedWith(
+      jasmine.objectContaining({ name: 'QueueClosedError' })
+    );
+  });
+
+  it('can clear queued items when closing', async () => {
+    let p1 = q.push('item #1');
+    let p2 = q.push('item #2');
+    expect(q.size).toBe(2);
+
+    q.close(true);
+    expect(q.size).toBe(0);
+
+    await expectAsync(p1)
+      .toBeRejectedWithError('This operation was aborted');
+    await expectAsync(p2)
+      .toBeRejectedWithError('This operation was aborted');
+  });
+
+  it('can add an end handler that is called when ending', async () => {
+    let end = jasmine.createSpy('end');
+    q.handle('end', end);
+
+    let p1 = q.push('item #1');
+    let p2 = q.push('item #2');
+    q.close();
+
+    expect(end).not.toHaveBeenCalled();
+    await expectAsync(p1).toBePending();
+    await expectAsync(p2).toBePending();
+
+    await q.end();
+    expect(end).toHaveBeenCalled();
+
+    await expectAsync(p1)
+      .toBeRejectedWithError('This operation was aborted');
+    await expectAsync(p2)
+      .toBeRejectedWithError('This operation was aborted');
+  });
+
+  it('waits for the start handler when ending early', async () => {
+    let resolve, deferred = new Promise(r => (resolve = r));
+    let start = jasmine.createSpy('start', () => deferred);
+    q.handle('start', start.and.callThrough());
+    q.start();
+
+    let promise = q.end();
+    await expectAsync(promise).toBePending();
+
+    resolve();
+    await expectAsync(promise).toBeResolved();
+  });
+
+  it('waits for the end handler when starting', async () => {
+    let resolve, deferred = new Promise(r => (resolve = r));
+    let end = jasmine.createSpy('end', () => deferred);
+    q.handle('end', end.and.callThrough());
+    q.end();
+
+    let promise = q.start();
+    await expectAsync(promise).toBePending();
+
+    resolve();
+    await expectAsync(promise).toBeResolved();
+  });
+
+  it('waits until started before running queued items', async () => {
+    let resolve, deferred = new Promise(r => (resolve = r));
+    let start = jasmine.createSpy('start', () => deferred);
+    q.handle('start', start.and.callThrough());
+    q.start();
+
+    let promises = Promise.all([
+      q.push('item #1'),
+      q.push('item #2'),
+      q.push('item #3')
+    ]);
+
+    q.run();
+    await expectAsync(promises).toBePending();
+
+    resolve();
+    await expectAsync(promises).toBeResolved();
+  });
+
+  it('can run or close while starting', async () => {
+    expect(q.readyState).toBe(0);
+    await q.start();
+    expect(q.readyState).toBe(1);
+
+    await q.end();
+    expect(q.readyState).toBe(0);
+    q.handle('start', () => q.run());
+    await q.start();
+    expect(q.readyState).toBe(2);
+
+    await q.end();
+    expect(q.readyState).toBe(0);
+    q.handle('start', () => q.close());
+    await q.start();
+    expect(q.readyState).toBe(3);
+  });
+
+  it('does nothing when stopping if not started or closed', async () => {
+    expect(q.readyState).toBe(0);
+    expect(q.stop().readyState).toBe(0);
+    await q.start();
+    expect(q.readyState).toBe(1);
+    expect(q.run().readyState).toBe(2);
+    expect(q.stop().readyState).toBe(1);
+    expect(q.close().readyState).toBe(3);
+    expect(q.stop().readyState).toBe(3);
+  });
+
+  it('does nothing when closing if already closed', () => {
+    expect(q.readyState).toBe(0);
+    expect(q.close().readyState).toBe(3);
+    expect(q.close().readyState).toBe(3);
+  });
+
+  it('can wait until pending items idle', async () => {
+    let resolve1, deferred1 = new Promise(r => (resolve1 = r));
+    let resolve2, deferred2 = new Promise(r => (resolve2 = r));
+    q.push(deferred1);
+    q.push(deferred2);
+    await q.start();
+    q.run();
+
+    let idle = jasmine.createSpy('idle');
+    let promise = generatePromise(q.idle(idle));
+    await expectAsync(promise).toBePending();
+    expect(idle).toHaveBeenCalledWith(2);
+
+    resolve1();
+    await waitForTimeout(10);
+    expect(idle.calls.count()).toBeGreaterThan(1);
+    expect(idle).toHaveBeenCalledWith(1);
+
+    await expectAsync(promise).toBePending();
+
+    resolve2();
+    await waitForTimeout(10);
+    expect(idle.calls.count()).toBeGreaterThan(2);
+    expect(idle).toHaveBeenCalledWith(0);
+
+    await expectAsync(promise).toBeResolved();
+  });
+
+  it('can flush currently queued items', async () => {
+    let resolve, deferred = new Promise(r => (resolve = r));
+
+    q.push('item #1');
+    q.push('item #2');
+    q.push('item #3');
+    q.push(deferred);
+
+    expect(q.size).toBe(4);
+
+    let promise = generatePromise(q.flush());
+    await expectAsync(promise).toBePending();
+
+    q.push('item #5');
+    q.push('item #6');
+
+    expect(q.size).toBe(3);
+
+    resolve();
+    await expectAsync(promise).toBeResolved();
+
+    expect(q.size).toBe(2);
+  });
+
+  it('can flush twice without interruption', async () => {
+    let resolve1, deferred1 = new Promise(r => (resolve1 = r));
+    let resolve2, deferred2 = new Promise(r => (resolve2 = r));
+
+    q.push(deferred1);
+    let p1 = generatePromise(q.flush());
+    await expectAsync(p1).toBePending();
+
+    q.push(deferred2);
+    let p2 = generatePromise(q.flush());
+    await expectAsync(p2).toBePending();
+
+    resolve1();
+    await expectAsync(p1).toBeResolved();
+    await expectAsync(p2).toBePending();
+
+    resolve2();
+    await expectAsync(p2).toBeResolved();
+  });
+
+  it('cancels the flush when aborted', async () => {
+    let resolve, deferred = new Promise(r => (resolve = r));
+    let p1 = q.push(deferred);
+    let p2 = q.push('flush');
+
+    q.set({ concurrency: 1 });
+    let ctrl = new AbortController();
+    let flush = generatePromise(q.flush(), ctrl.signal);
+    await expectAsync(flush).toBePending();
+    await expectAsync(p1).toBePending();
+    await expectAsync(p2).toBePending();
+
+    ctrl.abort();
+    await expectAsync(flush)
+      .toBeRejectedWithError('This operation was aborted');
+
+    resolve();
+    await expectAsync(p1).toBeResolved();
+    await expectAsync(p2).toBePending();
   });
 });


### PR DESCRIPTION
## What is this?

This PR refactors the queues in `@percy/core` to allow greater encapsulation and functionality. Queue specific tasks were grouped together and as a result caused other parts of core to be slightly refactored.

### new Queue

The queue class previously allowed arbitrary task functions to be queued together and run concurrently. All discovery related queued tasks did the same thing, but with different snapshots. Likewise with the upload queue, with the exception of deferred build creation.

The new queue class allows queuing arbitrary _items_ and processes them concurrently using configured handlers. The discovery queue is configured to first launch a browser before processing items (discovering resources). The snapshots queue is configured to create and finalize a build around processing items (uploading snapshots). These new queues also allow configuring push handlers which will (in the future) let use merge queued items before being processed.

### Core changes

Almost everything that dealt with the queue had to be updated to accommodate new queue features, including a few logs. Build handling was moved from the core class to the snapshot queue, as was browser launching to the discovery queue. Since the logical place for the new snapshot queue code to live would be in `snapshot.js`, it also ended up next to the new discovery queue, which meant that this file grew pretty exponentially. To break this file up, the discovery queue and related functions were moved to `discovery.js`. The existing network intercept code from that file was then moved and integrated directly into `network.js`.

### Discovery changes

We previously used a combination of two helper functions to create a new browser page, discover snapshot resources for widths and pixel ratios, and then optionally capture DOM snapshots. Page creation was removed from these helpers to be handled directly by the queue, and the remaining code was merged into a single helper. After triggering asset requests from resizing the page, the DOM is optionally captured before additional resources are discovery for other pixel ratios. In the future, we can easily add additional DOM capture points during page resizing.

### Upload command changes

The upload command used a private method, `_scheduleUpload()` to push a function into the internal upload queue which would upload snapshot based on images from the filesystem. Without this private method, the upload method would no longer function properly or be able to dry-run quickly. To solve this, a new `upload()` method was added to core specifically for the upload command. It utilizes additional queued item arguments to provide a processing function which is yielded to during task processing, before the snapshot is uploaded. In the future, this method may adapt to other APIs which can utilize the snapshot queue.

### Other changes

A couple internal methods were also changed slightly in response to some of the refactoring. First, the browser page method `snapshot()` was updated to return the provided payload minus any capture specific options. The returned payload previously only included `dom`, but now includes `domSnapshot` to match what is expected by other helper functions. The core class `setConfig()` method is now simply `set()` (inspired by queue's matching method) which better reflects it's ability to set more than only configuration options (currently also client and env info). 