### PR TITLE
🐛 Add sdk-utils logger mocking test helpers

### DIFF
--- a/packages/sdk-utils/src/logger.js
+++ b/packages/sdk-utils/src/logger.js
@@ -17,11 +17,6 @@ const loglevel = logger.loglevel = lvl => {
 const log = logger.log = (ns, lvl, msg, meta) => {
   let err = typeof msg !== 'string' && (lvl === 'error' || lvl === 'debug');
 
-  // keep log history of full message
-  let message = err ? msg.stack : msg.toString();
-  let [debug, level, timestamp, error] = [ns, lvl, Date.now(), !!err];
-  (log.history ||= []).push({ debug, level, message, meta, timestamp, error });
-
   // check if the specific level is within the local loglevel range
   if (LOG_LEVELS[lvl] != null && LOG_LEVELS[lvl] >= LOG_LEVELS[loglevel()]) {
     let debug = loglevel() === 'debug';

--- a/packages/sdk-utils/src/logger.js
+++ b/packages/sdk-utils/src/logger.js
@@ -8,32 +8,34 @@ export function logger(namespace) {
   ), {});
 }
 
-// Set and/or return the local loglevel
-const loglevel = logger.loglevel = lvl => {
-  return (loglevel.lvl = lvl || loglevel.lvl || process.env.PERCY_LOGLEVEL || 'info');
-};
+Object.assign(logger, {
+  // Set and/or return the local loglevel
+  loglevel: (lvl = logger.loglevel.lvl) => {
+    return (logger.loglevel.lvl = lvl || process.env.PERCY_LOGLEVEL || 'info');
+  },
 
-// Track and send/write logs for the specified namespace and log level
-const log = logger.log = (ns, lvl, msg, meta) => {
-  let err = typeof msg !== 'string' && (lvl === 'error' || lvl === 'debug');
+  // Track and send/write logs for the specified namespace and log level
+  log: (ns, lvl, msg, meta) => {
+    let err = typeof msg !== 'string' && (lvl === 'error' || lvl === 'debug');
 
-  // check if the specific level is within the local loglevel range
-  if (LOG_LEVELS[lvl] != null && LOG_LEVELS[lvl] >= LOG_LEVELS[loglevel()]) {
-    let debug = loglevel() === 'debug';
-    let label = debug ? `percy:${ns}` : 'percy';
+    // check if the specific level is within the local loglevel range
+    if (LOG_LEVELS[lvl] != null && LOG_LEVELS[lvl] >= LOG_LEVELS[logger.loglevel()]) {
+      let debug = logger.loglevel() === 'debug';
+      let label = debug ? `percy:${ns}` : 'percy';
 
-    // colorize the label when possible for consistency with the CLI logger
-    if (!process.env.__PERCY_BROWSERIFIED__) label = `\u001b[95m${label}\u001b[39m`;
-    msg = `[${label}] ${(err && debug && msg.stack) || msg}`;
+      // colorize the label when possible for consistency with the CLI logger
+      if (!process.env.__PERCY_BROWSERIFIED__) label = `\u001b[95m${label}\u001b[39m`;
+      msg = `[${label}] ${(err && debug && msg.stack) || msg}`;
 
-    if (process.env.__PERCY_BROWSERIFIED__) {
-      // use console[warn|error|log] in browsers
-      console[['warn', 'error'].includes(lvl) ? lvl : 'log'](msg);
-    } else {
-      // use process[stdout|stderr].write in node
-      process[lvl === 'info' ? 'stdout' : 'stderr'].write(msg + '\n');
+      if (process.env.__PERCY_BROWSERIFIED__) {
+        // use console[warn|error|log] in browsers
+        console[['warn', 'error'].includes(lvl) ? lvl : 'log'](msg);
+      } else {
+        // use process[stdout|stderr].write in node
+        process[lvl === 'info' ? 'stdout' : 'stderr'].write(msg + '\n');
+      }
     }
   }
-};
+});
 
 export default logger;

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -2,34 +2,7 @@ import helpers from './helpers.js';
 import utils from '@percy/sdk-utils';
 
 describe('SDK Utils', () => {
-  let err, log, stdout, stderr;
-
-  let { logger } = utils;
-  let browser = process.env.__PERCY_BROWSERIFIED__;
-  let ANSI_REG = new RegExp('[\\u001B\\u009B][[\\]()#;?]*(' +
-    '(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)|' +
-    '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))', 'g');
-
-  let captureLogs = acc => msg => {
-    msg = msg.replace(/\r\n/g, '\n');
-    msg = msg.replace(ANSI_REG, '');
-    acc.push(msg.replace(/\n$/, ''));
-  };
-
   beforeEach(async () => {
-    logger.loglevel('info');
-    log = logger('test');
-    stdout = [];
-    stderr = [];
-
-    if (process.env.__PERCY_BROWSERIFIED__) {
-      spyOn(console, 'log').and.callFake(captureLogs(stdout));
-      spyOn(console, 'warn').and.callFake(captureLogs(stderr));
-      spyOn(console, 'error').and.callFake(captureLogs(stderr));
-    } else {
-      spyOn(process.stdout, 'write').and.callFake(captureLogs(stdout));
-      spyOn(process.stderr, 'write').and.callFake(captureLogs(stderr));
-    }
     await helpers.setupTest();
   });
 
@@ -98,7 +71,7 @@ describe('SDK Utils', () => {
       await helpers.test('error', '/percy/healthcheck');
       await expectAsync(isPercyEnabled()).toBeResolvedTo(false);
 
-      expect(stdout).toEqual(jasmine.arrayContaining([
+      expect(helpers.logger.stdout).toEqual(jasmine.arrayContaining([
         '[percy] Percy is not running, disabling snapshots'
       ]));
     });
@@ -107,7 +80,7 @@ describe('SDK Utils', () => {
       await helpers.test('disconnect', '/percy/healthcheck');
       await expectAsync(isPercyEnabled()).toBeResolvedTo(false);
 
-      expect(stdout).toEqual(jasmine.arrayContaining([
+      expect(helpers.logger.stdout).toEqual(jasmine.arrayContaining([
         '[percy] Percy is not running, disabling snapshots'
       ]));
     });
@@ -116,7 +89,7 @@ describe('SDK Utils', () => {
       await helpers.test('version', '0.1.0');
       await expectAsync(isPercyEnabled()).toBeResolvedTo(false);
 
-      expect(stdout).toEqual(jasmine.arrayContaining([
+      expect(helpers.logger.stdout).toEqual(jasmine.arrayContaining([
         '[percy] Unsupported Percy CLI version, disabling snapshots'
       ]));
     });
@@ -219,9 +192,37 @@ describe('SDK Utils', () => {
   });
 
   describe('logger()', () => {
+    let browser = process.env.__PERCY_BROWSERIFIED__;
+    let log, err, stdout, stderr;
+    let { logger } = utils;
+
+    let ANSI_REG = new RegExp('[\\u001B\\u009B][[\\]()#;?]*(' + (
+      '(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)|' +
+      '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))'
+    ), 'g');
+
+    let captureLogs = acc => msg => {
+      msg = msg.replace(/\r\n/g, '\n');
+      msg = msg.replace(ANSI_REG, '');
+      acc.push(msg.replace(/\n$/, ''));
+    };
+
     beforeEach(async () => {
+      await helpers.setupTest({ logger: false });
       err = new Error('Test error');
       err.stack = 'Error stack';
+      log = utils.logger('test');
+      stdout = [];
+      stderr = [];
+
+      if (browser) {
+        spyOn(console, 'log').and.callFake(captureLogs(stdout));
+        spyOn(console, 'warn').and.callFake(captureLogs(stderr));
+        spyOn(console, 'error').and.callFake(captureLogs(stderr));
+      } else {
+        spyOn(process.stdout, 'write').and.callFake(captureLogs(stdout));
+        spyOn(process.stderr, 'write').and.callFake(captureLogs(stderr));
+      }
     });
 
     it('creates a minimal percy logger', async () => {

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -232,6 +232,9 @@ describe('SDK Utils', () => {
       log.error({ toString: () => 'Test error object' });
       log.error(err);
 
+      // not logged because loglevel is not debug
+      log.debug('Test debug');
+
       expect(stdout).toEqual([
         '[percy] Test info'
       ]);
@@ -248,16 +251,23 @@ describe('SDK Utils', () => {
 
       log.info('Test debug info');
       log.debug('Test debug log');
+      log.debug({ stack: 'Error like' });
       log.error(err);
 
       expect(stdout).toEqual([
         '[percy:test] Test debug info',
         // browser debug logs use console.log
-        ...(browser ? ['[percy:test] Test debug log'] : [])
+        ...(browser ? [
+          '[percy:test] Test debug log',
+          '[percy:test] Error like'
+        ] : [])
       ]);
       expect(stderr).toEqual([
         // node debug logs write to stderr
-        ...(!browser ? ['[percy:test] Test debug log'] : []),
+        ...(!browser ? [
+          '[percy:test] Test debug log',
+          '[percy:test] Error like'
+        ] : []),
         '[percy:test] Error stack'
       ]);
     });


### PR DESCRIPTION
## What is this?

With #254 and the removal of remote logging, SDK tests will need to be updated to mock local logs. Rather than needing to replicate mocking code for each SDK, we can simply replace the internal log function with our own mock. This mock cannot be tested like a normal mock or spy (no calls or argument tracking). Instead, this mock very minimally mimics the original logging code, without colors, and pushes logs into appropriate arrays for testing.

I moved logger test setup code back into the logger suite so the other tests could use the new mock helper. This revealed a few lines of missing coverage that required another log be added to the two existing tests. Log history tracking was also removed since it was only used for sending to remote connections, which then prompted the linter to start failing because the `const log` variable was not being used or exported. Rather than add an ignore statement, I moved the two `logger` static methods to `Object.assign` them.