### PR TITLE
➖ Remove `ws` dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,6 @@
     "micromatch": "^4.0.4",
     "mime-types": "^2.1.34",
     "path-to-regexp": "^6.2.0",
-    "rimraf": "^3.0.2",
-    "ws": "^8.0.0"
+    "rimraf": "^3.0.2"
   }
 }

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -38,9 +38,6 @@
     "test:coverage": "yarn test --coverage"
   },
   "rollup": {
-    "external": [
-      "ws"
-    ],
     "output": {
       "name": "PercySDKUtils"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7626,11 +7626,6 @@ write-pkg@^4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
-ws@^8.0.0:
-  version "8.8.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
-  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
-
 ws@~8.2.3:
   version "8.2.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"


### PR DESCRIPTION
## What is this?

With the removal of the remote logger, we no longer need the `ws` dependency. This was missed by me in the original PR removing the logger.