### PR TITLE
♻️ Adjust how direct snapshot uploads are handled

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -9,15 +9,13 @@ import {
   yieldAll
 } from './utils.js';
 
-// Logs verbose debug logs detailing various snapshot options. When `showInfo` is true, specific
-// messages will be logged as info logs rather than debug logs.
-function debugSnapshotOptions(snapshot, showInfo) {
+// Logs verbose debug logs detailing various snapshot options.
+function debugSnapshotOptions(snapshot) {
   let log = logger('core:snapshot');
 
   // log snapshot info
   log.debug('---------', snapshot.meta);
-  if (showInfo) log.info(`Snapshot found: ${snapshot.name}`, snapshot.meta);
-  else log.debug(`Received snapshot: ${snapshot.name}`, snapshot.meta);
+  log.debug(`Received snapshot: ${snapshot.name}`, snapshot.meta);
 
   // will log debug info for an object property if its value is defined
   let debugProp = (obj, prop, format = String) => {
@@ -53,9 +51,7 @@ function debugSnapshotOptions(snapshot, showInfo) {
   debugProp(snapshot, 'domSnapshot', Boolean);
 
   for (let added of (snapshot.additionalSnapshots || [])) {
-    if (showInfo) log.info(`Snapshot found: ${added.name}`, snapshot.meta);
-    else log.debug(`Additional snapshot: ${added.name}`, snapshot.meta);
-
+    log.debug(`Additional snapshot: ${added.name}`, snapshot.meta);
     debugProp(added, 'waitForTimeout');
     debugProp(added, 'waitForSelector');
     debugProp(added, 'execute');
@@ -178,7 +174,7 @@ export async function* discoverSnapshotResources(queue, options, callback) {
   let { snapshots, skipDiscovery, dryRun } = options;
 
   yield* yieldAll(snapshots.reduce((all, snapshot) => {
-    debugSnapshotOptions(snapshot, dryRun);
+    debugSnapshotOptions(snapshot);
 
     if (skipDiscovery) {
       let { additionalSnapshots, ...baseSnapshot } = snapshot;

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -302,8 +302,6 @@ export class Percy {
             config: this.config
           })
         }, snapshot => {
-          let { name, meta } = snapshot;
-          if (!this.deferUploads) this.log.info(`Snapshot taken: ${name}`, meta);
           // push each finished snapshot to the snapshots queue
           this.#snapshots.push(snapshot);
         });
@@ -314,14 +312,12 @@ export class Percy {
     }.call(this));
   }
 
-  // Uploads one or more snapshots directly to the current Percy build. A function may be provided
-  // as the second argument which will be called right before the snapshot is sent. This function is
-  // called with snapshot options and should return new snapshot options to be sent to the build.
-  upload(options, prepare) {
+  // Uploads one or more snapshots directly to the current Percy build
+  upload(options) {
     if (this.readyState !== 1) {
       throw new Error('Not running');
     } else if (Array.isArray(options)) {
-      return yieldAll(options.map(o => this.yield.upload(o, prepare)));
+      return yieldAll(options.map(o => this.yield.upload(o)));
     }
 
     // add client & environment info
@@ -331,7 +327,7 @@ export class Percy {
     // return an async generator to allow cancelation
     return (async function*() {
       try {
-        return yield* yieldTo(this.#snapshots.push(options, prepare));
+        return yield* yieldTo(this.#snapshots.push(options));
       } catch (error) {
         this.#snapshots.cancel(options);
         throw error;


### PR DESCRIPTION
## What is this?

This PR continues some of the refactor work started with #1077. In that PR, the upload command needed a new upload method, so a quick one was implemented. This PR polishes the upload command and moves some related logs around within the queues. This further isolates queue features from each other and also sets the stage for the core upload method and snapshot queue to accept alternate API requests (such as a future comparisons API).