### PR TITLE
✨ Add comparisons API for future SDK usage

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -7,6 +7,7 @@ builds. Can also be used to query for a project's builds using a read access tok
 - [Usage](#usage)
 - [Create a build](#create-a-build)
 - [Create, upload, and finalize snapshots](#create-upload-and-finalize-snapshots)
+- [Create, upload, and finalize comparisons](#create-upload-and-finalize-comparisons)
 - [Finalize a build](#finalize-a-build)
 - [Query for a build*](#query-for-a-build)
 - [Query for a project's builds*](#query-for-a-projects-builds)
@@ -59,7 +60,39 @@ await client.sendSnapshot(buildId, snapshotOptions)
   - `mimetype` — Resource mimetype (**required**)
   - `content` — Resource content (**required**)
   - `sha` — Resource content sha
-  - `root` — Boolean indicating a root resource
+  - `root` — Boolean indicating a root resource## Create, upload, and finalize snapshots
+
+## Create, upload, and finalize comparisons
+
+This method combines the work of creating a snapshot, creating an associated comparison, uploading
+associated comparison tiles, and finally finalizing the comparison.
+
+``` js
+await client.sendComparison(buildId, comparisonOptions)
+```
+
+#### Options
+
+- `name` — Snapshot name (**required**)
+- `clientInfo` — Additional client info
+- `environmentInfo` — Additional environment info
+- `externalDebugUrl` — External debug URL
+- `tag` — Tagged information about this comparison
+  - `name` — The tag name for this comparison, e.g. "iPhone 14 Pro" (**required**)
+  - `osName` - OS name for the comparison tag; e.g. "iOS"
+  - `osVersion` - OS version for the comparison tag; e.g. "16"
+  - `width` - The width for this type of comparison
+  - `height` - The height for this type of comparison
+  - `orientation` - Either "portrait" or "landscape"
+- `tiles` — Array of comparison tiles
+  - `sha` — Tile file contents SHA-256 hash
+  - `filepath` — Tile filepath in the filesystem (required when missing `content`)
+  - `content` — Tile contents as a string or buffer (required when missing `filepath`)
+  - `statusBarHeight` — Height of any status bar in this tile
+  - `navBarHeight` — Height of any nav bar in this tile
+  - `headerHeight` — Height of any header area in this tile
+  - `footerHeight` — Height of any footer area in this tile
+  - `fullscreen` — Boolean indicating this is a fullscreen tile
 
 ## Finalize a build
 

--- a/packages/client/test/helpers.js
+++ b/packages/client/test/helpers.js
@@ -120,6 +120,14 @@ export const api = {
           }
         }
       }
+    }],
+
+    '/snapshots/4567/comparisons': ({ body }) => [201, {
+      data: {
+        id: '891011',
+        attributes: body.attributes,
+        relationships: body.relationships
+      }
     }]
   },
 

--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -2,10 +2,18 @@ import fs from 'fs';
 import path from 'path';
 import { createRequire } from 'module';
 import logger from '@percy/logger';
+import { normalize } from '@percy/config/utils';
 import { getPackageJSON, Server } from './utils.js';
 
 // need require.resolve until import.meta.resolve can be transpiled
 export const PERCY_DOM = createRequire(import.meta.url).resolve('@percy/dom');
+
+// Returns a URL encoded string of nested query params
+function encodeURLSearchParams(subj, prefix) {
+  return typeof subj === 'object' ? Object.entries(subj).map(([key, value]) => (
+    encodeURLSearchParams(value, prefix ? `${prefix}[${key}]` : key)
+  )).join('&') : `${prefix}=${encodeURIComponent(subj)}`;
+}
 
 // Create a Percy CLI API server instance
 export function createPercyServer(percy, port) {
@@ -90,7 +98,18 @@ export function createPercyServer(percy, port) {
     .route('post', '/percy/comparison', async (req, res) => {
       let upload = percy.upload(req.body);
       if (req.url.searchParams.has('await')) await upload;
-      return res.json(200, { success: true });
+
+      // generate and include one or more redirect links to comparisons
+      let link = ({ name, tag }) => [
+        percy.client.apiUrl, '/comparisons/redirect?',
+        encodeURLSearchParams(normalize({
+          buildId: percy.build?.id, snapshot: { name }, tag
+        }, { snake: true }))
+      ].join('');
+
+      return res.json(200, Object.assign({ success: true }, req.body ? (
+        Array.isArray(req.body) ? { links: req.body.map(link) } : { link: link(req.body) }
+      ) : {}));
     })
   // flushes one or more snapshots from the internal queue
     .route('post', '/percy/flush', async (req, res) => res.json(200, {

--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -80,10 +80,16 @@ export function createPercyServer(percy, port) {
       let wrapper = '(window.PercyAgent = class { snapshot(n, o) { return PercyDOM.serialize(o); } });';
       return res.send(200, 'applicaton/javascript', content.concat(wrapper));
     })
-  // post one or more snapshots
+  // post one or more snapshots, optionally async
     .route('post', '/percy/snapshot', async (req, res) => {
       let snapshot = percy.snapshot(req.body);
       if (!req.url.searchParams.has('async')) await snapshot;
+      return res.json(200, { success: true });
+    })
+  // post one or more comparisons, optionally waiting
+    .route('post', '/percy/comparison', async (req, res) => {
+      let upload = percy.upload(req.body);
+      if (req.url.searchParams.has('await')) await upload;
       return res.json(200, { success: true });
     })
   // flushes one or more snapshots from the internal queue

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -19,7 +19,7 @@ export const configSchema = {
         items: {
           type: 'integer',
           maximum: 2000,
-          minimum: 10
+          minimum: 120
         }
       },
       minHeight: {
@@ -353,10 +353,81 @@ export const snapshotSchema = {
   }
 };
 
+// Comparison upload options
+export const comparisonSchema = {
+  type: 'object',
+  $id: '/comparison',
+  required: ['name', 'tag'],
+  additionalProperties: false,
+  properties: {
+    name: { type: 'string' },
+    externalDebugUrl: { type: 'string' },
+    tag: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['name'],
+      properties: {
+        name: { type: 'string' },
+        osName: { type: 'string' },
+        osVersion: { type: 'string' },
+        width: {
+          type: 'integer',
+          maximum: 2000,
+          minimum: 120
+        },
+        height: {
+          type: 'integer',
+          maximum: 2000,
+          minimum: 10
+        },
+        orientation: {
+          type: 'string',
+          enum: ['portrait', 'landscape']
+        }
+      }
+    },
+    tiles: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          filepath: {
+            type: 'string'
+          },
+          content: {
+            type: 'string'
+          },
+          statusBarHeight: {
+            type: 'integer',
+            minimum: 0
+          },
+          navBarHeight: {
+            type: 'integer',
+            minimum: 0
+          },
+          headerHeight: {
+            type: 'integer',
+            minimum: 0
+          },
+          footerHeight: {
+            type: 'integer',
+            minimum: 0
+          },
+          fullscreen: {
+            type: 'boolean'
+          }
+        }
+      }
+    }
+  }
+};
+
 // Grouped schemas for easier registration
 export const schemas = [
   configSchema,
-  snapshotSchema
+  snapshotSchema,
+  comparisonSchema
 ];
 
 // Config migrate function

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -377,7 +377,6 @@ export const comparisonSchema = {
         },
         height: {
           type: 'integer',
-          maximum: 2000,
           minimum: 10
         },
         orientation: {

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -327,6 +327,23 @@ export class Percy {
       return yieldAll(options.map(o => this.yield.upload(o)));
     }
 
+    // validate comparison uploads and warn about any errors
+    if ('tag' in options || 'tiles' in options) {
+      // throw when missing required snapshot or tag name
+      if (!options.name) throw new Error('Missing required snapshot name');
+      if (!options.tag?.name) throw new Error('Missing required tag name for comparison');
+
+      // normalize, migrate, and remove certain properties from validating
+      options = PercyConfig.migrate(options, '/comparison');
+      let { clientInfo, environmentInfo, ...comparison } = options;
+      let errors = PercyConfig.validate(comparison, '/comparison');
+
+      if (errors) {
+        this.log.warn('Invalid upload options:');
+        for (let e of errors) this.log.warn(`- ${e.path}: ${e.message}`);
+      }
+    }
+
     // add client & environment info
     this.client.addClientInfo(options.clientInfo);
     this.client.addEnvironmentInfo(options.environmentInfo);

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -333,7 +333,8 @@ export function createSnapshotsQueue(percy) {
         : resources;
 
       // upload the snapshot and log when deferred
-      let response = yield percy.client.sendSnapshot(build.id, snapshot);
+      let send = 'tag' in snapshot ? 'sendComparison' : 'sendSnapshot';
+      let response = yield percy.client[send](build.id, snapshot);
       if (percy.deferUploads) percy.log.info(`Snapshot uploaded: ${name}`, meta);
 
       return { ...snapshot, response };

--- a/packages/sdk-utils/src/index.js
+++ b/packages/sdk-utils/src/index.js
@@ -5,6 +5,7 @@ import isPercyEnabled from './percy-enabled.js';
 import waitForPercyIdle from './percy-idle.js';
 import fetchPercyDOM from './percy-dom.js';
 import postSnapshot from './post-snapshot.js';
+import postComparison from './post-comparison.js';
 import flushSnapshots from './flush-snapshots.js';
 
 export {
@@ -15,6 +16,7 @@ export {
   waitForPercyIdle,
   fetchPercyDOM,
   postSnapshot,
+  postComparison,
   flushSnapshots
 };
 

--- a/packages/sdk-utils/src/post-comparison.js
+++ b/packages/sdk-utils/src/post-comparison.js
@@ -3,10 +3,10 @@ import request from './request.js';
 
 // Post snapshot data to the CLI snapshot endpoint. If the endpoint responds with a build error,
 // indicate that Percy has been disabled.
-export async function postSnapshot(options, params) {
+export async function postComparison(options, params) {
   let query = params ? `?${new URLSearchParams(params)}` : '';
 
-  await request.post(`/percy/snapshot${query}`, options).catch(err => {
+  await request.post(`/percy/comparison${query}`, options).catch(err => {
     if (err.response?.body?.build?.error) {
       percy.enabled = false;
     } else {
@@ -15,4 +15,4 @@ export async function postSnapshot(options, params) {
   });
 }
 
-export default postSnapshot;
+export default postComparison;


### PR DESCRIPTION
## What is this?

Soon, the Percy API will be able to accept specific snapshot comparisons to upload and associate with a build. This PR adds methods to `@percy/client` and `@percy/core` to enable SDKs to communicate with this upcoming API.

### Client

Comparison methods added to client mirror other snapshot methods already present, with a few changes. For example, comparison creation and finalization is similar to snapshot creation and finalization, but with different endpoints and payloads. Likewise for snapshot resources and comparison tiles. The only major difference between the two APIs, is the comparisons flow includes creating a parent snapshot first, but not finalizing it.

Other small changes were made such as repurposing the build ID validation function to validate any type of ID, and using `fs.promises` to read resources and tiles from the filesystem.

### Core queue

With recent work refactoring and isolating the internal queue responsibilities, adding comparison uploads to the existing queue was actually a very small change. When a snapshot payload includes a `tag` it is assumed to be a comparison and `client.sendComparison()` is used in place of `client.sendSnapshot()`

### Core API

Also with the recent refactor work came the addition of the core `percy.upload()` method used by the upload command. Thanks to this method, a new `/percy/comparisons` endpoint can utilize it to facilitate comparison uploads. Now when the method detects the presence of a `tag` or `tiles` property, it will validate all options against a newly added comparison schema, and throw an error when missing the required snapshot name or comparison tag name. This new endpoint also returns a generated link to the comparison redirect API which will redirect to the comparison's web-url when available. 

### SDK utils

A new comparison posting utility function was added to mirror the snapshot posting utility function. These two functions, including their tests, are nearly identical with the only differences being the endpoint used by the function and payload used for the tests. Any JavaScript SDKs that would use the new comparison API should use this new utility function.