### PR TITLE
✨ Add snake_case normalization to config utils

### DIFF
--- a/packages/config/src/utils/normalize.js
+++ b/packages/config/src/utils/normalize.js
@@ -29,12 +29,21 @@ export function kebabcase(str) {
     .match(WORD_REG).join('-').toLowerCase();
 }
 
+// Coverts kebab-case and camelCased strings to snake_case.
+export function snakecase(str) {
+  if (typeof str !== 'string') return str;
+
+  return Array.from(CAMELCASE_MAP)
+    .reduce((str, [word, camel]) => str.replace(camel, `_${word}`), str)
+    .match(WORD_REG).join('_').toLowerCase();
+}
+
 // Removes undefined empty values and renames kebab-case properties to camelCase. Optionally
 // allows deep merging with options.overrides, converting keys to kebab-case with options.kebab,
 // and normalizing against a schema with options.schema.
 export function normalize(object, options) {
   if (typeof options === 'string') options = { schema: options };
-  let keycase = options?.kebab ? kebabcase : camelcase;
+  let keycase = options?.kebab ? kebabcase : options?.snake ? snakecase : camelcase;
 
   return merge([object, options?.overrides], (path, value) => {
     let schemas = getSchema(options?.schema, path.map(camelcase));

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -1127,6 +1127,22 @@ describe('PercyConfig', () => {
       });
     });
 
+    it('can convert keys to snake_case', () => {
+      expect(PercyConfig.normalize({
+        'foo-bar': 'baz',
+        foo: { bar_baz: 'qux' },
+        fooBar_baz: ['qux'],
+        percyCSS: '',
+        enableJavaScript: false
+      }, { snake: true })).toEqual({
+        foo_bar: 'baz',
+        foo: { bar_baz: 'qux' },
+        foo_bar_baz: ['qux'],
+        percy_css: '',
+        enable_javascript: false
+      });
+    });
+
     it('skips normalizing properties of class instances', () => {
       expect(PercyConfig.normalize({
         inst: new (class { 'don_t-doThis' = 'plz' })(),


### PR DESCRIPTION
## What is this?

Our `normalize` config utility allows transforming object keys to a different casing while removing empty values from the provided object. Currently, it supports transforming object keys from any casing into either camelCase or kebab-case. This PR adds the ability to transform keys into snake_case by copying the kebab-case functionality and replacing `-` with `_`.