### PR TITLE
✨ Expose deferred uploads

### DIFF
--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -86,6 +86,10 @@ export function createPercyServer(percy, port) {
       if (!req.url.searchParams.has('async')) await snapshot;
       return res.json(200, { success: true });
     })
+  // flushes one or more snapshots from the internal queue
+    .route('post', '/percy/flush', async (req, res) => res.json(200, {
+      success: await percy.flush(req.body).then(() => true)
+    }))
   // stops percy at the end of the current event loop
     .route('/percy/stop', (req, res) => {
       setImmediate(() => percy.stop());

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -1,5 +1,14 @@
 // Common config options used in Percy commands
 export const configSchema = {
+  percy: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      deferUploads: {
+        type: 'boolean'
+      }
+    }
+  },
   snapshot: {
     type: 'object',
     additionalProperties: false,

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -55,7 +55,7 @@ export class Percy {
     // implies `dryRun`, silent logs, and adds extra api endpoints
     testing,
     // configuration filepath
-    config,
+    config: configFile,
     // provided to @percy/client
     token,
     clientInfo = '',
@@ -67,10 +67,13 @@ export class Percy {
     // options which will become accessible via the `.config` property
     ...options
   } = {}) {
-    this.config = PercyConfig.load({
+    let { percy, ...config } = PercyConfig.load({
       overrides: options,
-      path: config
+      path: configFile
     });
+
+    deferUploads ??= percy?.deferUploads;
+    this.config = config;
 
     if (testing) loglevel = 'silent';
     if (loglevel) this.loglevel(loglevel);

--- a/packages/core/src/queue.js
+++ b/packages/core/src/queue.js
@@ -192,7 +192,8 @@ export class Queue {
   // process a single item task when started
   process(item) {
     let task = this.#find(item);
-    if (this.readyState) this.#process(task);
+    if (task && !this.#start) this.start();
+    this.#start?.promise.then(() => this.#process(task));
     return task?.deferred;
   }
 

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -115,6 +115,20 @@ describe('API Server', () => {
     ].join(' ')]);
   });
 
+  it('has a /flush endpoint that calls #flush()', async () => {
+    spyOn(percy, 'flush').and.resolveTo();
+    await percy.start();
+
+    await expectAsync(request('/percy/flush', {
+      body: { name: 'Snapshot name' },
+      method: 'post'
+    })).toBeResolvedTo({ success: true });
+
+    expect(percy.flush).toHaveBeenCalledWith({
+      name: 'Snapshot name'
+    });
+  });
+
   it('has a /stop endpoint that calls #stop()', async () => {
     spyOn(percy, 'stop').and.resolveTo();
     await percy.start();

--- a/packages/sdk-utils/src/flush-snapshots.js
+++ b/packages/sdk-utils/src/flush-snapshots.js
@@ -1,0 +1,17 @@
+import percy from './percy-info.js';
+import request from './request.js';
+
+// Posts to the local Percy server one or more snapshots to flush. Given no arguments, all snapshots
+// will be flushed. Does nothing when Percy is not enabled.
+export async function flushSnapshots(options) {
+  if (percy.enabled) {
+    // accept one or more snapshot names
+    options &&= [].concat(options).map(o => (
+      typeof o === 'string' ? { name: o } : o
+    ));
+
+    await request.post('/percy/flush', options);
+  }
+}
+
+export default flushSnapshots;

--- a/packages/sdk-utils/src/index.js
+++ b/packages/sdk-utils/src/index.js
@@ -5,6 +5,7 @@ import isPercyEnabled from './percy-enabled.js';
 import waitForPercyIdle from './percy-idle.js';
 import fetchPercyDOM from './percy-dom.js';
 import postSnapshot from './post-snapshot.js';
+import flushSnapshots from './flush-snapshots.js';
 
 export {
   logger,
@@ -13,7 +14,8 @@ export {
   isPercyEnabled,
   waitForPercyIdle,
   fetchPercyDOM,
-  postSnapshot
+  postSnapshot,
+  flushSnapshots
 };
 
 // export the namespace by default

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -191,6 +191,29 @@ describe('SDK Utils', () => {
     });
   });
 
+  describe('flushSnapshots([options])', () => {
+    let { flushSnapshots } = utils;
+
+    it('does nothing when percy is not enabled', async () => {
+      await expectAsync(flushSnapshots()).toBeResolved();
+      await expectAsync(helpers.get('requests')).toBeResolvedTo({});
+    });
+
+    it('posts options to the CLI API flush endpoint', async () => {
+      utils.percy.enabled = true;
+
+      await expectAsync(flushSnapshots()).toBeResolved();
+      await expectAsync(flushSnapshots({ name: 'foo' })).toBeResolved();
+      await expectAsync(flushSnapshots(['bar', 'baz'])).toBeResolved();
+
+      await expectAsync(helpers.get('requests')).toBeResolvedTo([
+        { url: '/percy/flush', method: 'POST' },
+        { url: '/percy/flush', method: 'POST', body: [{ name: 'foo' }] },
+        { url: '/percy/flush', method: 'POST', body: [{ name: 'bar' }, { name: 'baz' }] }
+      ]);
+    });
+  });
+
   describe('logger()', () => {
     let browser = process.env.__PERCY_BROWSERIFIED__;
     let log, err, stdout, stderr;


### PR DESCRIPTION
## What is this?

For some time, our internal queues have been able to be deferred so snapshots are only processed and uploaded after asset discovery has completely finished for all snapshots. This was only ever utilized in a couple of SDKs which specifically did not create empty builds when no snapshots were found (storybook and the upload command). With the recent refactor around our internal queues, deferred items can now be cancelled or merged with existing deferred items to allow better encapsulation and greater control over internal queues.

This PR not only exposes the `deferUploads` option via a new config file entry, but also exposes a new core endpoint to flush deferred snapshots. The core flush method was also updated to accept one or more specific snapshots to flush rather than flush all snapshots. Finally, an sdk-utils helper was added which posts to this new core endpoint and can accept one or more snapshot names rather than a snapshot options object.