### PR TITLE
🐛 Fix multi-dom capture when using the snapshot command

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -136,7 +136,8 @@ async function* captureSnapshotResources(page, snapshot, options) {
   for (let additionalSnapshot of [baseSnapshot, ...additionalSnapshots]) {
     let isBaseSnapshot = additionalSnapshot === baseSnapshot;
     let snap = { ...baseSnapshot, ...additionalSnapshot };
-    let width, { widths, execute } = snap;
+    let { widths, execute } = snap;
+    let [width] = widths;
 
     // iterate over widths to trigger reqeusts and capture other widths
     if (isBaseSnapshot || captureWidths) {

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -317,7 +317,7 @@ export function createSnapshotsQueue(percy) {
       if (percy.dryRun) percy.log.info(`Snapshot found: ${name}`, meta);
 
       // immediately flush when uploads are delayed but not skipped
-      if (percy.delayUploads && !percy.skipUploads) queue.flush();
+      if (percy.delayUploads && !percy.deferUploads) queue.flush();
       // overwrite any existing snapshot when not deferred or when resources is a function
       if (!percy.deferUploads || typeof snapshot.resources === 'function') return snapshot;
       // merge snapshot options when uploads are deferred

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -365,6 +365,7 @@ describe('Snapshot', () => {
     // stop and recreate a percy instance with the desired option
     await percy.stop(true);
     await api.mock();
+    logger.reset();
 
     testDOM = `
       <p id="test"></p>
@@ -379,7 +380,10 @@ describe('Snapshot', () => {
 
     percy = await Percy.start({
       token: 'PERCY_TOKEN',
-      deferUploads: true
+      deferUploads: true,
+      loglevel: 'debug',
+      // delay should do nothing
+      delayUploads: true
     });
 
     percy.snapshot({
@@ -396,6 +400,15 @@ describe('Snapshot', () => {
     expect(api.requests['/builds/123/snapshots']).toBeUndefined();
 
     await percy.stop();
+
+    expect(logger.stderr).toEqual(jasmine.arrayContaining([
+      '[percy:core:page] Taking snapshot: Snapshot 0 @600px',
+      '[percy:core:page] Taking snapshot: Snapshot 0 @1000px',
+      '[percy:core:page] Taking snapshot: Snapshot 0 @1600px',
+      '[percy:core:page] Taking snapshot: Snapshot 1 @600px',
+      '[percy:core:page] Taking snapshot: Snapshot 1 @1000px',
+      '[percy:core:page] Taking snapshot: Snapshot 1 @1600px'
+    ]));
 
     // snapshots uploaded after stopping
     expect(api.requests['/builds/123/snapshots']).toHaveSize(2);


### PR DESCRIPTION
## What is this?

While testing multi-dom support with the snapshot command, I noticed two issues that this PR fixes.

1. When both `delayUploads` and `deferUploads` are `true`, the snapshot queue acts delayed but not deferred. This is fixed by checking for `!deferUploads` before automatically flushing the queue.

2. When the first snapshot is taken at the initial width, it is missing it's singular `width`. This happened because `width` was undefined for the first loop, and fixed by setting it to the first width.

One test was updated to test for both of these issues. First `delayUploads` was added to ensure it does not affect `deferUploads`. Second, debug logging was added to test for a specific snapshot log to verify each singular width.