### PR TITLE
✨ Show network logs on navigation errors

### DIFF
--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -76,21 +76,24 @@ export class Network {
       timeout: Network.TIMEOUT,
       idle: timeout
     }).catch(error => {
-      // throw a better timeout error
       if (error.message.startsWith('Timeout')) {
-        let msg = 'Timed out waiting for network requests to idle.';
-
-        if (this.log.shouldLog('debug')) {
-          msg += `\n\n  ${['Active requests:',
-            ...requests.map(r => r.url)
-          ].join('\n  - ')}\n`;
-        }
-
-        throw new Error(msg);
+        this._throwTimeoutError((
+          'Timed out waiting for network requests to idle.'
+        ), filter);
       } else {
         throw error;
       }
     });
+  }
+
+  // Throw a better network timeout error
+  _throwTimeoutError(msg, filter = () => true) {
+    if (this.log.shouldLog('debug')) {
+      let reqs = Array.from(this.#requests.values()).filter(filter).map(r => r.url);
+      msg += `\n\n  ${['Active requests:', ...reqs].join('\n  - ')}\n`;
+    }
+
+    throw new Error(msg);
   }
 
   // Called when a request should be removed from various trackers

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -279,6 +279,7 @@ async function sendResponseResource(network, request, session) {
       });
     }
   } catch (error) {
+    if (session.closing && error.message.includes('close')) return;
     log.debug(`Encountered an error handling request: ${url}`, meta);
     log.debug(error);
 

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -279,7 +279,9 @@ async function sendResponseResource(network, request, session) {
       });
     }
   } catch (error) {
+    /* istanbul ignore next: too hard to test (create race condition) */
     if (session.closing && error.message.includes('close')) return;
+
     log.debug(`Encountered an error handling request: ${url}`, meta);
     log.debug(error);
 

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -88,12 +88,18 @@ export class Page {
         return handlers.every(handler => handler.finished);
       }, Page.TIMEOUT)]);
     } catch (error) {
-      // remove handlers and modify the error message
+      // remove any unused handlers
       for (let handler of handlers) handler.off();
 
-      throw Object.assign(error, {
-        message: `Navigation failed: ${error.message}`
-      });
+      // assign context to unknown errors
+      if (!error.message.startsWith('Timeout')) {
+        throw Object.assign(error, { message: `Navigation failed: ${error.message}` });
+      }
+
+      // throw a network error to show active requests
+      this.network._throwTimeoutError(
+        `Navigation failed: Timed out waiting for the page ${waitUntil} event`
+      );
     }
 
     this.log.debug('Page navigated', this.meta);

--- a/packages/core/src/session.js
+++ b/packages/core/src/session.js
@@ -22,7 +22,8 @@ export class Session extends EventEmitter {
   }
 
   async close() {
-    if (!this.browser) return;
+    if (!this.browser || this.closing) return;
+    this.closing = true;
 
     await this.browser.send('Target.closeTarget', {
       targetId: this.targetId


### PR DESCRIPTION
## What is this?

Sometimes asset discovery navigation to a snapshot fails due to hanging requests or the load event never firing on the page that's being loaded. In order to help make debugging easier, we're now logging network requests that are hanging/still active when trying to navigate.

We also now suppress not needed error messages from page clean up from in-flight requests. This is most commonly logged when asset discovery is closing and external requests haven't completed. 