### PR TITLE
✨ Expose build URL via env var (`PERCY_BUILD_URL`)

### DIFF
--- a/packages/cli-exec/src/exec.js
+++ b/packages/cli-exec/src/exec.js
@@ -69,6 +69,7 @@ export const exec = command('exec', {
   // provide SDKs with useful env vars
   env.PERCY_SERVER_ADDRESS = percy?.address();
   env.PERCY_BUILD_ID = percy?.build?.id;
+  env.PERCY_BUILD_URL = percy?.build?.url;
   env.PERCY_LOGLEVEL = log.loglevel();
 
   // run the provided command

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -194,4 +194,17 @@ describe('percy exec', () => {
       '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]);
   });
+
+  it('provides the child process with a percy build id env var', async () => {
+    await exec(['--', 'node', '--eval', (
+      'process.env.PERCY_BUILD_URL === "https://percy.io/test/test/123" || process.exit(2)'
+    )]);
+
+    expect(logger.stderr).toEqual([]);
+    expect(logger.stdout).toEqual([
+      '[percy] Percy has started!',
+      jasmine.stringMatching('\\[percy] Running "node '),
+      '[percy] Finalized build #1: https://percy.io/test/test/123'
+    ]);
+  });
 });


### PR DESCRIPTION
## What is this?

This exposes the current build URL as an env var to the current process (`PERCY_BUILD_URL`). 