### PR TITLE
✨ Return comparison response in sdk-utils

### DIFF
--- a/packages/sdk-utils/src/post-comparison.js
+++ b/packages/sdk-utils/src/post-comparison.js
@@ -6,7 +6,7 @@ import request from './request.js';
 export async function postComparison(options, params) {
   let query = params ? `?${new URLSearchParams(params)}` : '';
 
-  await request.post(`/percy/comparison${query}`, options).catch(err => {
+  return await request.post(`/percy/comparison${query}`, options).catch(err => {
     if (err.response?.body?.build?.error) {
       percy.enabled = false;
     } else {


### PR DESCRIPTION
- We need this response in SDKs so that we can parse `link` from it