### PR TITLE
:sparkles: Skip github update check if `PERCY_SKIP_UPDATE_CHECK` is truthy

### DIFF
--- a/packages/cli/src/update.js
+++ b/packages/cli/src/update.js
@@ -69,7 +69,7 @@ export async function checkForUpdate() {
   let pkg = getPackageJSON(import.meta.url);
   let log = logger('cli:update');
 
-  if (process.env.PERCY_SKIP_UPDATE_CHECK === 'true') {
+  if (process.env.PERCY_SKIP_UPDATE_CHECK) {
     log.debug('Skipping update check');
     return;
   }

--- a/packages/cli/src/update.js
+++ b/packages/cli/src/update.js
@@ -69,6 +69,11 @@ export async function checkForUpdate() {
   let pkg = getPackageJSON(import.meta.url);
   let log = logger('cli:update');
 
+  if (process.env.PERCY_SKIP_UPDATE_CHECK === 'true') {
+    log.debug('Skipping update check');
+    return;
+  }
+
   try {
     // request new release information if needed
     if (!releases) {

--- a/packages/cli/test/update.test.js
+++ b/packages/cli/test/update.test.js
@@ -37,6 +37,20 @@ describe('CLI update check', () => {
     expect(ghAPI).not.toHaveBeenCalled();
   });
 
+  it('does not fetch the latest release information if PERCY_SKIP_UPDATE_CHECK is present', async () => {
+    expect(fs.existsSync('.releases')).toBe(false);
+    process.env.PERCY_SKIP_UPDATE_CHECK = 1;
+
+    logger.loglevel('debug');
+
+    await checkForUpdate();
+    expect(logger.stdout).toEqual([]);
+    expect(logger.stderr).toEqual(['[percy:cli:update] Skipping update check']);
+    expect(ghAPI).not.toHaveBeenCalled();
+
+    delete process.env.PERCY_SKIP_UPDATE_CHECK;
+  });
+
   it('fetchs the latest release information if the cache is outdated', async () => {
     ghAPI.and.returnValue([200, [{ tag_name: 'v1.0.0' }]]);
 


### PR DESCRIPTION
**Problem**

When running in CI environments, the cache file would normally be cached along with the project's dependencies. However, for some projects that do not cache dependencies, the GitHub request will always occur when the CLI runs after installation. This can sometimes cause the CLI to hang depending on rate limits or the presence of any locally defined GitHub token.

fixes #1058

**solution**

* we're exposing an environment variable that will skip this update check.

---


**Testing**

* post code changes are done

```sh
yarn lint
yarn build
```

* mock edited `node_modules/@percy/cli/.releases` file with new release `v1.14.0` in cache file(doesn't exist in github releases).

* run cli 
```sh
➜  cli git:(jigar/skip_github_update_check) ✗ export PERCY_LOGLEVEL=debug   
➜  cli git:(jigar/skip_github_update_check) ✗ export PERCY_SKIP_UPDATE_CHECK=true
➜  cli git:(jigar/skip_github_update_check) ✗ npx percy                          
[percy:cli:update] Skipping update check (0ms)
```