### PR TITLE
✨ Accept serialized DOM resources

### DIFF
--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -287,8 +287,34 @@ export const snapshotSchema = {
       properties: {
         url: { type: 'string' },
         name: { type: 'string' },
-        domSnapshot: { type: 'string' },
-        width: { $ref: '/config/snapshot#/properties/widths/items' }
+        width: { $ref: '/config/snapshot#/properties/widths/items' },
+        domSnapshot: {
+          oneOf: [{ type: 'string' }, {
+            type: 'object',
+            required: ['html'],
+            unevaluatedProperties: false,
+            properties: {
+              html: { type: 'string' },
+              warnings: {
+                type: 'array',
+                items: { type: 'string' }
+              },
+              resources: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['url', 'content', 'mimetype'],
+                  unevaluatedProperties: false,
+                  properties: {
+                    url: { type: 'string' },
+                    content: { type: 'string' },
+                    mimetype: { type: 'string' }
+                  }
+                }
+              }
+            }
+          }]
+        }
       },
       errors: {
         unevaluatedProperties: e => (

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -263,7 +263,7 @@ async function sendResponseResource(network, request, session) {
         requestId: request.interceptId,
         errorReason: 'Aborted'
       });
-    } else if (resource && (resource.root || !disableCache)) {
+    } else if (resource && (resource.root || resource.provided || !disableCache)) {
       log.debug(resource.root ? '- Serving root resource' : '- Resource cache hit', meta);
 
       await session.send('Fetch.fulfillRequest', {
@@ -317,7 +317,7 @@ async function saveResponseResource(network, request) {
   let meta = { ...network.meta, url };
   let resource = network.intercept.getResource(url);
 
-  if (!resource || (!resource.root && disableCache)) {
+  if (!resource || (!resource.root && !resource.provided && disableCache)) {
     try {
       log.debug(`Processing resource: ${url}`, meta);
       let shouldCapture = response && hostnameMatches(allowedHostnames, url);

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -173,6 +173,12 @@ export function validateSnapshotOptions(options) {
   if (snapshots) migrated.snapshots = typeof snapshots === 'function' ? [] : snapshots;
   else if (!isSnapshot && options.snapshots) migrated.snapshots = [];
 
+  // parse json dom snapshots
+  if (schema === '/snapshot/dom' && typeof migrated.domSnapshot === 'string' &&
+      migrated.domSnapshot.startsWith('{') && migrated.domSnapshot.endsWith('}')) {
+    migrated.domSnapshot = JSON.parse(migrated.domSnapshot);
+  }
+
   // log warnings encountered during dom serialization
   let domWarnings = migrated.domSnapshot?.warnings || [];
 

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -575,13 +575,17 @@ describe('Snapshot', () => {
     }, {
       url: 'http://localhost:8000/three',
       'dom-snapshot': testDOM
+    }, {
+      url: 'http://localhost:8000/four',
+      domSnapshot: JSON.stringify({ html: testDOM })
     }]);
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
       '[percy] Snapshot taken: /one',
       '[percy] Snapshot taken: /two',
-      '[percy] Snapshot taken: /three'
+      '[percy] Snapshot taken: /three',
+      '[percy] Snapshot taken: /four'
     ]);
   });
 


### PR DESCRIPTION
## What is this?

This PR expands on how DOM snapshots are accepted to build towards addressing both serialized assets and also any future DOM serialization warnings. Primarily, this PR addresses accepting additional serialized DOM options in core that will enable `@percy/dom` to make serialized assets external rather than embedded in a follow up PR.

## Approach

The config schema for DOM snapshots was updated to allow additional `domSnapshot` options:

- `domSnapshot.html` - The HTML string of the DOM. This is equivalent to providing `domSnapshot` as a string.
- `domSnapshot.warnings` - An array of warning strings to be logged when encountered during snapshot validation.
- `domSnapshot.resources` - An array of resource objects that will be converted to proper snapshot resources:
  - `resource.url` - The complete URL of the resource including the hostname.
  - `resource.mimetype` - The specific mimetype of the resource, typically an image.
  - `resource.content` - The base64 encoded content string of the resource.

When a DOM snapshot is provided to core with serialized resources, these assets will be marked within the resource cache as to always be served and never be overwritten. The resulting snapshot uploaded will include these serialized resources.

As a convenience for any SDKs that may need to stringify JSON responses from the browser, core validation will automatically parse `domSnapshot` options that look like JSON strings.