### PR TITLE
✨ Serialize DOM resources

### DIFF
--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -80,10 +80,11 @@ describe('Percy', () => {
     });
 
     expect(snapshot.url).toEqual('http://localhost:8000/');
-    expect(snapshot.domSnapshot).toEqual(
-      '<!DOCTYPE html><html><head></head><body>' + (
+    expect(snapshot.domSnapshot).toEqual(jasmine.objectContaining({
+      html: '<!DOCTYPE html><html><head></head><body>' + (
         `<p>Hello there, Percy!</p>${img}`
-      ) + '</body></html>');
+      ) + '</body></html>'
+    }));
   });
 
   describe('.start()', () => {

--- a/packages/dom/src/prepare-dom.js
+++ b/packages/dom/src/prepare-dom.js
@@ -10,6 +10,8 @@ export function prepareDOM(dom) {
       elem.setAttribute('data-percy-element-id', uid());
     }
   }
+
+  return dom;
 }
 
 export default prepareDOM;

--- a/packages/dom/src/serialize-canvas.js
+++ b/packages/dom/src/serialize-canvas.js
@@ -1,5 +1,7 @@
+import { resourceFromDataURL } from './utils.js';
+
 // Serialize in-memory canvas elements into images.
-export function serializeCanvas({ dom, clone }) {
+export function serializeCanvas({ dom, clone, resources }) {
   for (let canvas of dom.querySelectorAll('canvas')) {
     // Note: the `.toDataURL` API requires WebGL canvas elements to use
     // `preserveDrawingBuffer: true`. This is because `.toDataURL` uses the
@@ -9,9 +11,15 @@ export function serializeCanvas({ dom, clone }) {
     // skip empty canvases
     if (!dataUrl || dataUrl === 'data:,') continue;
 
+    // get the element's percy id and create a resource for it
+    let percyElementId = canvas.getAttribute('data-percy-element-id');
+    let resource = resourceFromDataURL(percyElementId, dataUrl);
+    resources.add(resource);
+
     // create an image element in the cloned dom
     let img = clone.createElement('img');
-    img.src = dataUrl;
+    // use a data attribute to avoid making a real request
+    img.setAttribute('data-percy-serialized-attribute-src', resource.url);
 
     // copy canvas element attributes to the image element such as style, class,
     // or data attributes that may be targeted by CSS
@@ -25,7 +33,6 @@ export function serializeCanvas({ dom, clone }) {
     img.style.maxWidth = img.style.maxWidth || '100%';
 
     // insert the image into the cloned DOM and remove the cloned canvas element
-    let percyElementId = canvas.getAttribute('data-percy-element-id');
     let cloneEl = clone.querySelector(`[data-percy-element-id=${percyElementId}]`);
     cloneEl.parentElement.insertBefore(img, cloneEl);
     cloneEl.remove();

--- a/packages/dom/src/serialize-canvas.js
+++ b/packages/dom/src/serialize-canvas.js
@@ -1,5 +1,5 @@
 // Serialize in-memory canvas elements into images.
-export function serializeCanvas(dom, clone) {
+export function serializeCanvas({ dom, clone }) {
   for (let canvas of dom.querySelectorAll('canvas')) {
     // Note: the `.toDataURL` API requires WebGL canvas elements to use
     // `preserveDrawingBuffer: true`. This is because `.toDataURL` uses the

--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -16,7 +16,7 @@ function styleSheetsMatch(sheetA, sheetB) {
 }
 
 // Outputs in-memory CSSOM into their respective DOM nodes.
-export function serializeCSSOM(dom, clone) {
+export function serializeCSSOM({ dom, clone }) {
   for (let styleSheet of dom.styleSheets) {
     if (isCSSOM(styleSheet)) {
       let styleId = styleSheet.ownerNode.getAttribute('data-percy-element-id');

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -36,7 +36,8 @@ export function serializeDOM(options) {
     dom = document,
     // allow snake_case or camelCase
     enableJavaScript = options?.enable_javascript,
-    domTransformation = options?.dom_transformation
+    domTransformation = options?.dom_transformation,
+    stringifyResponse = options?.stringify_response
   } = options || {};
 
   // keep certain records throughout serialization
@@ -66,11 +67,15 @@ export function serializeDOM(options) {
     }
   }
 
-  return {
+  let result = {
     html: serializeHTML(ctx),
     warnings: Array.from(ctx.warnings),
     resources: Array.from(ctx.resources)
   };
+
+  return stringifyResponse
+    ? JSON.stringify(result)
+    : result;
 }
 
 export default serializeDOM;

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -24,6 +24,8 @@ function doctype(dom) {
 // Serializes and returns the cloned DOM as an HTML string
 function serializeHTML(ctx) {
   let html = ctx.clone.documentElement.outerHTML;
+  // replace serialized data attributes with real attributes
+  html = html.replace(/ data-percy-serialized-attribute-(\w+?)=/ig, ' $1=');
   // include the doctype with the html string
   return doctype(ctx.dom) + html;
 }

--- a/packages/dom/src/serialize-frames.js
+++ b/packages/dom/src/serialize-frames.js
@@ -12,7 +12,7 @@ function setBaseURI(dom) {
 }
 
 // Recursively serializes iframe documents into srcdoc attributes.
-export function serializeFrames({ dom, clone, enableJavaScript }) {
+export function serializeFrames({ dom, clone, warnings, resources, enableJavaScript }) {
   for (let frame of dom.querySelectorAll('iframe')) {
     let percyElementId = frame.getAttribute('data-percy-element-id');
     let cloneEl = clone.querySelector(`[data-percy-element-id="${percyElementId}"]`);
@@ -38,8 +38,13 @@ export function serializeFrames({ dom, clone, enableJavaScript }) {
         enableJavaScript
       });
 
-      // assign to srcdoc and remove src
-      cloneEl.setAttribute('srcdoc', serialized);
+      // append serialized warnings and resources
+      /* istanbul ignore next: warnings not implemented yet */
+      for (let w of serialized.warnings) warnings.add(w);
+      for (let r of serialized.resources) resources.add(r);
+
+      // assign serialized html to srcdoc and remove src
+      cloneEl.setAttribute('srcdoc', serialized.html);
       cloneEl.removeAttribute('src');
 
     // delete inaccessible frames built with js when js is disabled because they

--- a/packages/dom/src/serialize-frames.js
+++ b/packages/dom/src/serialize-frames.js
@@ -12,7 +12,7 @@ function setBaseURI(dom) {
 }
 
 // Recursively serializes iframe documents into srcdoc attributes.
-export function serializeFrames(dom, clone, { enableJavaScript }) {
+export function serializeFrames({ dom, clone, enableJavaScript }) {
   for (let frame of dom.querySelectorAll('iframe')) {
     let percyElementId = frame.getAttribute('data-percy-element-id');
     let cloneEl = clone.querySelector(`[data-percy-element-id="${percyElementId}"]`);

--- a/packages/dom/src/serialize-inputs.js
+++ b/packages/dom/src/serialize-inputs.js
@@ -1,5 +1,5 @@
 // Translates JavaScript properties of inputs into DOM attributes.
-export function serializeInputElements(dom, clone) {
+export function serializeInputElements({ dom, clone }) {
   for (let elem of dom.querySelectorAll('input, textarea, select')) {
     let inputId = elem.getAttribute('data-percy-element-id');
     let cloneEl = clone.querySelector(`[data-percy-element-id="${inputId}"]`);

--- a/packages/dom/src/serialize-video.js
+++ b/packages/dom/src/serialize-video.js
@@ -1,5 +1,5 @@
 // Captures the current frame of videos and sets the poster image
-export function serializeVideos(dom, clone) {
+export function serializeVideos({ dom, clone }) {
   for (let video of dom.querySelectorAll('video')) {
     // If the video already has a poster image, no work for us to do
     if (video.getAttribute('poster')) continue;

--- a/packages/dom/src/serialize-video.js
+++ b/packages/dom/src/serialize-video.js
@@ -1,7 +1,9 @@
+import { resourceFromDataURL } from './utils.js';
+
 // Captures the current frame of videos and sets the poster image
-export function serializeVideos({ dom, clone }) {
+export function serializeVideos({ dom, clone, resources }) {
   for (let video of dom.querySelectorAll('video')) {
-    // If the video already has a poster image, no work for us to do
+    // if the video already has a poster image, no work for us to do
     if (video.getAttribute('poster')) continue;
 
     let videoId = video.getAttribute('data-percy-element-id');
@@ -14,10 +16,15 @@ export function serializeVideos({ dom, clone }) {
     canvas.getContext('2d').drawImage(video, 0, 0, width, height);
     try { dataUrl = canvas.toDataURL(); } catch {}
 
-    // If the canvas produces a blank image, skip
+    // if the canvas produces a blank image, skip
     if (!dataUrl || dataUrl === 'data:,') continue;
 
-    cloneEl.setAttribute('poster', dataUrl);
+    // create a resource from the serialized data url
+    let resource = resourceFromDataURL(videoId, dataUrl);
+    resources.add(resource);
+
+    // use a data attribute to avoid making a real request
+    cloneEl.setAttribute('data-percy-serialized-attribute-poster', resource.url);
   }
 }
 

--- a/packages/dom/src/utils.js
+++ b/packages/dom/src/utils.js
@@ -1,0 +1,15 @@
+// Creates a resource object from an element's unique ID and data URL
+export function resourceFromDataURL(uid, dataURL) {
+  // split dataURL into desired parts
+  let [data, content] = dataURL.split(',');
+  let [, mimetype] = data.split(':');
+  [mimetype] = mimetype.split(';');
+
+  // build a URL for the serialized asset
+  let [, ext] = mimetype.split('/');
+  let path = `/__serialized__/${uid}.${ext}`;
+  let url = new URL(path, document.URL).toString();
+
+  // return the url, base64 content, and mimetype
+  return { url, content, mimetype };
+}

--- a/packages/dom/test/helpers.js
+++ b/packages/dom/test/helpers.js
@@ -41,6 +41,7 @@ export function replaceDoctype(name, publicId = '', systemId = '') {
 
 // parses a DOM string into a DOM object and returns a querySelectorAll shortcut
 export function parseDOM(domstring) {
+  if (domstring.html) domstring = domstring.html;
   let dom = new window.DOMParser().parseFromString(domstring, 'text/html');
   return selector => dom.querySelectorAll(selector);
 }

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -10,6 +10,11 @@ describe('serializeDOM', () => {
     });
   });
 
+  it('optionally returns a stringified response', () => {
+    expect(serializeDOM({ stringifyResponse: true }))
+      .toMatch('{"html":".*","warnings":\\[\\],"resources":\\[\\]}');
+  });
+
   it('always has a doctype', () => {
     document.removeChild(document.doctype);
     expect(serializeDOM().html).toMatch('<!DOCTYPE html>');

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -2,9 +2,17 @@ import { withExample, replaceDoctype } from './helpers';
 import serializeDOM from '@percy/dom';
 
 describe('serializeDOM', () => {
+  it('returns serialied html, warnings, and resources', () => {
+    expect(serializeDOM()).toEqual({
+      html: jasmine.any(String),
+      warnings: jasmine.any(Array),
+      resources: jasmine.any(Array)
+    });
+  });
+
   it('always has a doctype', () => {
     document.removeChild(document.doctype);
-    expect(serializeDOM()).toMatch('<!DOCTYPE html>');
+    expect(serializeDOM().html).toMatch('<!DOCTYPE html>');
   });
 
   it('copies existing doctypes', () => {
@@ -12,13 +20,13 @@ describe('serializeDOM', () => {
     let systemId = 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtdd';
 
     replaceDoctype('html', publicId);
-    expect(serializeDOM()).toMatch(`<!DOCTYPE html PUBLIC "${publicId}">`);
+    expect(serializeDOM().html).toMatch(`<!DOCTYPE html PUBLIC "${publicId}">`);
     replaceDoctype('html', '', systemId);
-    expect(serializeDOM()).toMatch(`<!DOCTYPE html SYSTEM "${systemId}">`);
+    expect(serializeDOM().html).toMatch(`<!DOCTYPE html SYSTEM "${systemId}">`);
     replaceDoctype('html', publicId, systemId);
-    expect(serializeDOM()).toMatch(`<!DOCTYPE html PUBLIC "${publicId}" "${systemId}">`);
+    expect(serializeDOM().html).toMatch(`<!DOCTYPE html PUBLIC "${publicId}" "${systemId}">`);
     replaceDoctype('html');
-    expect(serializeDOM()).toMatch('<!DOCTYPE html>');
+    expect(serializeDOM().html).toMatch('<!DOCTYPE html>');
   });
 
   describe('with `domTransformation`', () => {
@@ -28,18 +36,18 @@ describe('serializeDOM', () => {
     });
 
     it('transforms the DOM without modifying the original DOM', () => {
-      let dom = serializeDOM({
+      let { html } = serializeDOM({
         domTransformation(dom) {
           dom.querySelector('.delete-me').remove();
         }
       });
 
-      expect(dom).not.toMatch('Delete me');
+      expect(html).not.toMatch('Delete me');
       expect(document.querySelector('.delete-me').innerText).toBe('Delete me');
     });
 
     it('logs any errors and returns the serialized DOM', () => {
-      let dom = serializeDOM({
+      let { html } = serializeDOM({
         domTransformation(dom) {
           throw new Error('test error');
           // eslint-disable-next-line no-unreachable
@@ -47,7 +55,7 @@ describe('serializeDOM', () => {
         }
       });
 
-      expect(dom).toMatch('Delete me');
+      expect(html).toMatch('Delete me');
       expect(console.error)
         .toHaveBeenCalledOnceWith('Could not transform the dom:', 'test error');
     });


### PR DESCRIPTION
## What is this?

As part 2 of #1135, this PR refactors `@percy/dom` slightly to return the new `domSnapshot` options. To track warnings and resources throughout our serialize functions, a new context object is used to keep references of the DOM, the clone, and new sets for warnings and resources.

To exercise this new serialization return format, the canvas and video serialization functions were adjusted to create new resource objects (tracked by the `resources` context set). The frame serialization function was also updated to recursively merge the resulting frame warnings and resources.

While changing the code to update the src/poster attributes to the fake resource URLs, I noticed that the browser would actively make these requests immediately even though the cloned DOM is not mounted. To workaround this, those attributes are set as `data-percy-serialized-attribute-<name>="<value>"`. After the DOM clone is converted to an HTML string, all occurrences of `data-percy-serialized-attribute-` are removed so the resulting HTML string is left with real attribute names and values.

Finally, as a convenience for any SDKs that may have to serialize the new JSON response, a new serializer-only option was added, `stringifyResponse`. When true, the resulting JSON payload will be stringified before being returned.

This closes #425