### PR TITLE
✨  Check Type(app/web) Validity while creating builds

### DIFF
--- a/packages/cli-command/src/command.js
+++ b/packages/cli-command/src/command.js
@@ -62,8 +62,8 @@ function exit(exitCode, reason = '') {
 // and other common command helpers and properties.
 async function runCommandWithContext(parsed) {
   let { command, flags, args, argv, log } = parsed;
-  // include flags, args, argv, logger, exit helper, and env info
-  let context = { flags, args, argv, log, exit };
+  // include command as parentCommand, flags, args, argv, logger, exit helper, and env info
+  let context = { parentCommand: command, flags, args, argv, log, exit };
   let env = context.env = process.env;
   let pkg = command.packageInformation;
   let def = command.definition;

--- a/packages/cli-command/src/command.js
+++ b/packages/cli-command/src/command.js
@@ -62,8 +62,8 @@ function exit(exitCode, reason = '') {
 // and other common command helpers and properties.
 async function runCommandWithContext(parsed) {
   let { command, flags, args, argv, log } = parsed;
-  // include command as parentCommand, flags, args, argv, logger, exit helper, and env info
-  let context = { parentCommand: command, flags, args, argv, log, exit };
+  // include command as cliCommand, flags, args, argv, logger, exit helper, and env info
+  let context = { cliCommand: command, flags, args, argv, log, exit };
   let env = context.env = process.env;
   let pkg = command.packageInformation;
   let def = command.definition;
@@ -172,6 +172,10 @@ export function command(name, definition, callback) {
   });
 
   return runner;
+}
+
+export function getExecType(command) {
+  return command.name === 'app:exec' ? 'app' : 'web';
 }
 
 export default command;

--- a/packages/cli-command/src/index.js
+++ b/packages/cli-command/src/index.js
@@ -1,4 +1,4 @@
-export { default, command } from './command.js';
+export { default, command, getExecType } from './command.js';
 export { legacyCommand, legacyFlags as flags } from './legacy.js';
 // export common packages to avoid dependency resolution issues
 export { default as PercyConfig } from '@percy/config';

--- a/packages/cli-command/test/command.test.js
+++ b/packages/cli-command/test/command.test.js
@@ -1,5 +1,5 @@
 import { logger, dedent } from './helpers.js';
-import command from '@percy/cli-command';
+import command, { getExecType } from '@percy/cli-command';
 
 describe('Command', () => {
   beforeEach(async () => {
@@ -244,5 +244,10 @@ describe('Command', () => {
 
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([]);
+  });
+
+  it('has method that return type based on cli command', () => {
+    expect(getExecType({ name: 'exec' })).toBe('web');
+    expect(getExecType({ name: 'app:exec' })).toBe('app');
   });
 });

--- a/packages/cli-exec/src/exec.js
+++ b/packages/cli-exec/src/exec.js
@@ -1,4 +1,4 @@
-import command from '@percy/cli-command';
+import command, { getExecType } from '@percy/cli-command';
 import start from './start.js';
 import stop from './stop.js';
 import ping from './ping.js';
@@ -35,7 +35,7 @@ export const exec = command('exec', {
   percy: {
     server: true
   }
-}, async function*({ flags, argv, env, percy, log, parentCommand, exit }) {
+}, async function*({ flags, argv, env, percy, log, cliCommand, exit }) {
   let [command, ...args] = argv;
 
   // command is required
@@ -58,7 +58,7 @@ export const exec = command('exec', {
     log.warn('Percy is disabled');
   } else {
     try {
-      const execType = parentCommand.name === 'app:exec' ? 'app' : 'web';
+      const execType = getExecType(cliCommand);
       yield* percy.yield.start(execType);
     } catch (error) {
       if (error.name === 'AbortError') throw error;

--- a/packages/cli-exec/src/exec.js
+++ b/packages/cli-exec/src/exec.js
@@ -35,7 +35,7 @@ export const exec = command('exec', {
   percy: {
     server: true
   }
-}, async function*({ flags, argv, env, percy, log, exit }) {
+}, async function*({ flags, argv, env, percy, log, parentCommand, exit }) {
   let [command, ...args] = argv;
 
   // command is required
@@ -58,7 +58,8 @@ export const exec = command('exec', {
     log.warn('Percy is disabled');
   } else {
     try {
-      yield* percy.yield.start();
+      const execType = parentCommand.name === 'app:exec' ? 'app' : 'web';
+      yield* percy.yield.start(execType);
     } catch (error) {
       if (error.name === 'AbortError') throw error;
       log.warn('Skipping visual tests');

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -186,6 +186,12 @@ export class PercyClient {
     return this.get(`projects/${project}/builds?${qs}`);
   }
 
+  // Retrieve project. Requires a read access token
+  async getProject() {
+    // return this.post('projects/get-project'); // TODO: Update
+    return { type: 'app' };
+  }
+
   // Resolves when the build has finished and is no longer pending or
   // processing. By default, will time out if no update after 10 minutes.
   waitForBuild({

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -188,8 +188,7 @@ export class PercyClient {
 
   // Retrieve project. Requires a read access token
   async getProject() {
-    // return this.post('projects/get-project'); // TODO: Update
-    return { type: 'app' };
+    return this.get('projects');
   }
 
   // Resolves when the build has finished and is no longer pending or

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -217,6 +217,13 @@ describe('PercyClient', () => {
     });
   });
 
+  describe('#getProject()', () => {
+    it('gets project data', async () => {
+      api.reply('/projects', () => [200, { data: '<<project-data>>' }]);
+      await expectAsync(client.getProject()).toBeResolvedTo({ data: '<<project-data>>' });
+    });
+  });
+
   describe('#getBuild()', () => {
     it('throws when missing a build id', async () => {
       await expectAsync(client.getBuild())

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -142,7 +142,13 @@ export class Percy {
   }
 
   // Starts a local API server, a browser process, and internal queues.
-  async *start() {
+  async *start(execType) {
+    this.execType = execType;
+    let project = await this.client.getProject();
+    let projectType = project.type; // TODO: Update
+    if (projectType !== execType) {
+      throw new Error(`Invalid Project type. Please verify that the PERCY_TOKEN you are using is for a Percy ${execType} project`);
+    }
     // already starting or started
     if (this.readyState != null) return;
     this.readyState = 0;

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -145,10 +145,9 @@ export class Percy {
   async *start(execType) {
     this.execType = execType;
     let project = await this.client.getProject();
-    let projectType = project.type; // TODO: Update
-    if (projectType !== execType) {
-      throw new Error(`Invalid Project type. Please verify that the PERCY_TOKEN you are using is for a Percy ${execType} project`);
-    }
+    console.log(project);
+    let projectType = project?.data?.attributes.type;
+    if (project?.data) this.throwIfTypeInvalid(projectType);
     // already starting or started
     if (this.readyState != null) return;
     this.readyState = 0;
@@ -261,6 +260,12 @@ export class Percy {
 
     // mark instance as stopped
     this.readyState = 3;
+  }
+
+  throwIfTypeInvalid(projectType) {
+    if (projectType !== this.execType) {
+      throw new Error(`Invalid Project type. Please verify that the PERCY_TOKEN you are using is for a Percy ${this.execType} project`);
+    }
   }
 
   // Takes one or more snapshots of a page while discovering resources to upload with the resulting

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -144,10 +144,11 @@ export class Percy {
   // Starts a local API server, a browser process, and internal queues.
   async *start(execType) {
     this.execType = execType;
-    let project = await this.client.getProject();
-    console.log(project);
-    let projectType = project?.data?.attributes.type;
-    if (project?.data) this.throwIfTypeInvalid(projectType);
+    try {
+      let project = await this.client.getProject();
+      let projectType = project?.data?.attributes.type;
+      this.throwIfTypeInvalid(projectType);
+    } catch (e) {}
     // already starting or started
     if (this.readyState != null) return;
     this.readyState = 0;
@@ -264,6 +265,7 @@ export class Percy {
 
   throwIfTypeInvalid(projectType) {
     if (projectType !== this.execType) {
+      this.readyState = 2;
       throw new Error(`Invalid Project type. Please verify that the PERCY_TOKEN you are using is for a Percy ${this.execType} project`);
     }
   }

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -296,11 +296,7 @@ export function createSnapshotsQueue(percy) {
         // Fallback mechanish for Percy Token
         // For customers who don't want to expose read token to CI
         // FIXME: The created build stays in RECEIVING mode after the err
-        // TODO: Discuss if the error logic should be a separate Percy function
-        // Example: `percy.typeValidProject(data.attributes.type)`
-        if (data.attributes.type !== percy.execType) {
-          throw new Error(`Invalid Project type. Please verify that the PERCY_TOKEN you are using is for a Percy ${percy.execType} project`);
-        }
+        percy.throwIfTypeInvalid(data.attributes.type);
         let url = data.attributes['web-url'];
         let number = data.attributes['build-number'];
         Object.assign(build, { id: data.id, url, number });
@@ -324,7 +320,7 @@ export function createSnapshotsQueue(percy) {
       } else if (build?.id) {
         await percy.client.finalizeBuild(build.id);
         percy.log.info(`Finalized build #${build.number}: ${build.url}`, { build });
-      } else {̀
+      } else {
         percy.log.warn('Build not created', { build });
       }
     })

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -293,6 +293,14 @@ export function createSnapshotsQueue(percy) {
       try {
         build = percy.build = {};
         let { data } = await percy.client.createBuild();
+        // Fallback mechanish for Percy Token
+        // For customers who don't want to expose read token to CI
+        // FIXME: The created build stays in RECEIVING mode after the err
+        // TODO: Discuss if the error logic should be a separate Percy function
+        // Example: `percy.typeValidProject(data.attributes.type)`
+        if (data.attributes.type !== percy.execType) {
+          throw new Error(`Invalid Project type. Please verify that the PERCY_TOKEN you are using is for a Percy ${percy.execType} project`);
+        }
         let url = data.attributes['web-url'];
         let number = data.attributes['build-number'];
         Object.assign(build, { id: data.id, url, number });
@@ -316,7 +324,7 @@ export function createSnapshotsQueue(percy) {
       } else if (build?.id) {
         await percy.client.finalizeBuild(build.id);
         percy.log.info(`Finalized build #${build.number}: ${build.url}`, { build });
-      } else {
+      } else {̀
         percy.log.warn('Build not created', { build });
       }
     })

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -293,13 +293,11 @@ export function createSnapshotsQueue(percy) {
       try {
         build = percy.build = {};
         let { data } = await percy.client.createBuild();
-        // Fallback mechanish for Percy Token
-        // For customers who don't want to expose read token to CI
-        // FIXME: The created build stays in RECEIVING mode after the err
-        percy.throwIfTypeInvalid(data.attributes.type);
         let url = data.attributes['web-url'];
         let number = data.attributes['build-number'];
         Object.assign(build, { id: data.id, url, number });
+        // For Write-only token users
+        percy.throwIfTypeInvalid(data.attributes.type);
         // immediately run the queue if not delayed or deferred
         if (!percy.delayUploads && !percy.deferUploads) queue.run();
       } catch (err) {


### PR DESCRIPTION
### Enhancement:
Now, that we Percy supports App Percy along with Web Percy, Customers may use tokens of web project with App Percy or vice versa. CLI should be able to provide a understandable error if that's the case.

### Solution
- We get the command context from the `@percy/command` and pass it to Percy.
- Users who use Write token in the CI, for them, an empty failed build will be created in order to get the type from createBuild api.

API PR: percy/percy-api#2941
