### PR TITLE
 🐛 fix device pixel ratio config for percy exec

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -193,7 +193,8 @@ async function* captureSnapshotResources(page, snapshot, options) {
 
     yield* captureSnapshotResources(page, snapshot, {
       deviceScaleFactor: discovery.devicePixelRatio,
-      mobile: true
+      mobile: true,
+      capture: snapshot.domSnapshot ? null : capture
     });
   }
 

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -43,6 +43,7 @@ function debugSnapshotOptions(snapshot) {
   debugProp(snapshot, 'execute.beforeSnapshot');
   debugProp(snapshot, 'discovery.allowedHostnames');
   debugProp(snapshot, 'discovery.disallowedHostnames');
+  debugProp(snapshot, 'discovery.devicePixelRatio');
   debugProp(snapshot, 'discovery.requestHeaders', JSON.stringify);
   debugProp(snapshot, 'discovery.authorization', JSON.stringify);
   debugProp(snapshot, 'discovery.disableCache');

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -133,6 +133,7 @@ async function* captureSnapshotResources(page, snapshot, options) {
     if (captureWidths) options = { ...options, width };
     let captured = await page.snapshot(options);
     captured.resources.delete(normalizeURL(captured.url));
+    capture(processSnapshotResources(captured));
     return captured;
   };
 
@@ -197,15 +198,9 @@ async function* captureSnapshotResources(page, snapshot, options) {
   }
 
   // wait for final network idle when not capturing DOM
-  if (capture) {
+  if (capture && snapshot.domSnapshot) {
     yield waitForDiscoveryNetworkIdle(page, discovery);
-    if (!snapshot.domSnapshot) {
-      // invoked through cli-snapshot
-      snapshot.resources.delete(snapshot.url);
-      capture(processSnapshotResources({ domSnapshot: baseSnapshot.domSnapshot, ...snapshot }));
-    } else {
-      capture(processSnapshotResources(snapshot));
-    }
+    capture(processSnapshotResources(snapshot));
   }
 }
 

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -110,6 +110,7 @@ function getSnapshotOptions(options, { config, meta }) {
       allowedHostnames: config.discovery.allowedHostnames,
       disallowedHostnames: config.discovery.disallowedHostnames,
       networkIdleTimeout: config.discovery.networkIdleTimeout,
+      devicePixelRatio: config.discovery.devicePixelRatio,
       requestHeaders: config.discovery.requestHeaders,
       authorization: config.discovery.authorization,
       disableCache: config.discovery.disableCache,


### PR DESCRIPTION
device-pixel-ratio setting in config was not getting passed down to asset discovery function. This fixes that