### PR TITLE
:broom: don't show prerelease versions for update in CLI

### DIFF
--- a/packages/cli/src/update.js
+++ b/packages/cli/src/update.js
@@ -82,7 +82,8 @@ export async function checkForUpdate() {
     }
 
     // check the current package version against released versions
-    let versions = releases.map(r => r.tag.substr(1));
+    // don't include prerelease - alpha/beta versions
+    let versions = releases.filter(r => !r.prerelease).map(r => r.tag.substr(1));
     let age = versions.indexOf(pkg.version);
 
     // a new version is available

--- a/packages/cli/test/update.test.js
+++ b/packages/cli/test/update.test.js
@@ -76,14 +76,22 @@ describe('CLI update check', () => {
     ]);
   });
 
+  it('does not warns when a new pre release is available', async () => {
+    mockUpdateCache([{ tag: 'v1.1.0', prerelease: true }, { tag: 'v1.0.0' }]);
+
+    await checkForUpdate();
+    expect(logger.stdout).toEqual([]);
+    expect(logger.stderr).toEqual([]);
+  });
+
   it('warns when the current version is outdated', async () => {
-    mockUpdateCache([{ tag: 'v2.0.0' }]);
+    mockUpdateCache([{ tag: 'v2.0.2', prerelease: true }, { tag: 'v2.0.1', prerelease: false }, { tag: 'v2.0.0', prerelease: true }]);
 
     await checkForUpdate();
     expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
       '\n[percy] Heads up! The current version of @percy/cli ' +
-        'is more than 10 releases behind! 1.0.0 -> 2.0.0\n'
+        'is more than 10 releases behind! 1.0.0 -> 2.0.1\n'
     ]);
   });
 


### PR DESCRIPTION
* Disallow pushing users to switch to Alpha/Beta or prerelease versions.

**behavior previously**

```sh
[percy] A new version of @percy/cli is available! 1.16.0 -> 1.19.1-alpha.0
```

**behavior henceforth**

```sh
[percy] A new version of @percy/cli is available! 1.16.0 -> 1.17.0
```