### PR TITLE
👷  update request method for verify tiles, remove warnings banner for app:exec

### DIFF
--- a/packages/cli-app/src/app.js
+++ b/packages/cli-app/src/app.js
@@ -3,7 +3,7 @@ import exec from './exec.js';
 
 export const app = command('app', {
   description: 'Create Percy builds for native app snapshots',
-  hidden: 'This command is still in development and may not work as expected',
+  hidden: true,
   commands: [exec]
 });
 

--- a/packages/cli-command/test/help.test.js
+++ b/packages/cli-command/test/help.test.js
@@ -394,4 +394,19 @@ describe('Help output', () => {
         -s, --silent   Log nothing
     ` + '\n']);
   });
+
+  it('can log warnings for hidden commands', async () => {
+    let test = command('test', {
+      commands: [command('hidden', {
+        hidden: 'this is hidden for a reason',
+        commands: [command('nested', {}, () => {})]
+      })]
+    });
+
+    await test(['hidden:nested']);
+
+    expect(logger.stderr).toEqual([
+      '\n[percy] Warning: this is hidden for a reason\n'
+    ]);
+  });
 });

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -450,7 +450,7 @@ export class PercyClient {
     this.log.debug(`Verifying comparison tile with sha: ${sha}`);
 
     try {
-      return await this.get(`comparisons/${comparisonId}/tiles/verify`, {
+      return await this.post(`comparisons/${comparisonId}/tiles/verify`, {
         data: {
           type: 'tiles',
           attributes: {

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -1017,6 +1017,7 @@ describe('PercyClient', () => {
 
       expect(api.requests['/comparisons/123/tiles/verify']).toBeDefined();
       expect(api.requests['/comparisons/1234/tiles/verify']).not.toBeDefined();
+      expect(api.requests['/comparisons/123/tiles/verify'][0].method).toBe('POST');
     });
   });
 


### PR DESCRIPTION
- Updating verify tiles from get to post.
- Removing warning for app:exec command.