### PR TITLE
👷 update error code for retry logic

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -459,7 +459,7 @@ export class PercyClient {
         }
       });
     } catch (error) {
-      if (error.message.includes('409')) {
+      if (error.message.includes('400')) {
         return false;
       }
       throw error;

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -985,7 +985,7 @@ describe('PercyClient', () => {
 
     it('returns false if tile is not verified', async () => {
       api.reply('/comparisons/891011/tiles/verify', async () => {
-        return [409, 'Not found'];
+        return [400, 'failure'];
       });
 
       await expectAsync(client.uploadComparisonTiles(891011, [
@@ -997,7 +997,7 @@ describe('PercyClient', () => {
 
     it('throws any errors from verifying', async () => {
       api.reply('/comparisons/891011/tiles/verify', async () => {
-        return [400, 'failure'];
+        return [409, 'Not found'];
       });
 
       await expectAsync(client.uploadComparisonTiles(891011, [


### PR DESCRIPTION
- we have updated verify endpoint to raise err code 400, we previously were retying on 409 hence need to update it to fix the retry logic.
- currently, if a tile is not uploaded in 500ms which is the initial wait time we throw an error.