### PR TITLE
🐛 copy full style node for deriving CSS rules

### DIFF
--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -1,4 +1,4 @@
-import { resourceFromText } from './utils';
+import { resourceFromText, styleSheetFromNode } from './utils';
 import { uid } from './prepare-dom';
 
 // Returns true if a stylesheet is a CSSOM-based stylesheet.
@@ -16,24 +16,6 @@ function styleSheetsMatch(sheetA, sheetB) {
   }
 
   return true;
-}
-
-function styleSheetFromNode(node) {
-  /* istanbul ignore if: sanity check */
-  if (node.sheet) return node.sheet;
-
-  // Cloned style nodes don't have a sheet instance unless they are within
-  // a document; we get it by temporarily adding the rules to DOM
-  const tempStyle = node.cloneNode();
-  tempStyle.setAttribute('data-percy-style-helper', '');
-  tempStyle.innerHTML = node.innerHTML;
-  const clone = document.cloneNode();
-  clone.appendChild(tempStyle);
-  const sheet = tempStyle.sheet;
-  // Cleanup node
-  tempStyle.remove();
-
-  return sheet;
 }
 
 export function serializeCSSOM({ dom, clone, resources, cache }) {

--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -24,7 +24,7 @@ function styleSheetFromNode(node) {
 
   // Cloned style nodes don't have a sheet instance unless they are within
   // a document; we get it by temporarily adding the rules to DOM
-  const tempStyle = document.createElement('style');
+  const tempStyle = node.cloneNode();
   tempStyle.setAttribute('data-percy-style-helper', '');
   tempStyle.innerHTML = node.innerHTML;
   const clone = document.cloneNode();

--- a/packages/dom/src/utils.js
+++ b/packages/dom/src/utils.js
@@ -25,3 +25,21 @@ export function resourceFromText(uid, mimetype, data) {
   // return the url, base64 content, and mimetype
   return { url, content, mimetype };
 }
+
+export function styleSheetFromNode(node) {
+  /* istanbul ignore if: sanity check */
+  if (node.sheet) return node.sheet;
+
+  // Cloned style nodes don't have a sheet instance unless they are within
+  // a document; we get it by temporarily adding the rules to DOM
+  const tempStyle = node.cloneNode();
+  tempStyle.setAttribute('data-percy-style-helper', '');
+  tempStyle.innerHTML = node.innerHTML;
+  const clone = document.cloneNode();
+  clone.appendChild(tempStyle);
+  const sheet = tempStyle.sheet;
+  // Cleanup node
+  tempStyle.remove();
+
+  return sheet;
+}

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -1,0 +1,13 @@
+import { styleSheetFromNode } from '../src/utils';
+
+describe('utils', () => {
+  it('creates styleSheetFromNode properly', () => {
+    const node = document.createElement('style');
+    node.innerText = 'p { background-color: red }';
+    const cloneSpy = spyOn(node, 'cloneNode').and.callThrough();
+    const sheet = styleSheetFromNode(node);
+    expect(sheet.cssRules[0].cssText).toEqual('p { background-color: red; }');
+    // nonce needs to be copied
+    expect(cloneSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -1,13 +1,15 @@
 import { styleSheetFromNode } from '../src/utils';
 
 describe('utils', () => {
-  it('creates styleSheetFromNode properly', () => {
-    const node = document.createElement('style');
-    node.innerText = 'p { background-color: red }';
-    const cloneSpy = spyOn(node, 'cloneNode').and.callThrough();
-    const sheet = styleSheetFromNode(node);
-    expect(sheet.cssRules[0].cssText).toEqual('p { background-color: red; }');
-    // nonce needs to be copied
-    expect(cloneSpy).toHaveBeenCalled();
+  describe('styleSheetFromNode', () => {
+    it('creates stylesheet properly', () => {
+      const node = document.createElement('style');
+      node.innerText = 'p { background-color: red }';
+      const cloneSpy = spyOn(node, 'cloneNode').and.callThrough();
+      const sheet = styleSheetFromNode(node);
+      expect(sheet.cssRules[0].cssText).toEqual('p { background-color: red; }');
+      // nonce needs to be copied
+      expect(cloneSpy).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/percy/cli/issues/1194
In order to serialize the styles, we mount them temporarily on a document clone. The presence of a content security policy on the page was blocking this from happening, throwing the following error:
```
Refused to apply inline style because it violates the following Content Security Policy directive:
```
To fix this, the node should have a [nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce). 