### PR TITLE
Serialize text resources as utf8

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -79,7 +79,7 @@ function parseDomResources({ url, domSnapshot }) {
   // reduce the array of resources into a keyed map
   return resources.reduce((map, { url, content, mimetype }) => {
     // serialized resource contents are base64 encoded
-    content = Buffer.from(content, 'base64');
+    content = Buffer.from(content, mimetype.includes('text') ? 'utf8' : 'base64');
     // specify the resource as provided to prevent overwriting during asset discovery
     let resource = createResource(url, content, mimetype, { provided: true });
     // key the resource by its url and return the map

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -596,13 +596,19 @@ describe('Snapshot', () => {
       mimetype: 'image/gif'
     };
 
+    let textResource = {
+      url: 'http://localhost:8000/__serialized__/_style1.css',
+      content: 'p{color:blue;}',
+      mimetype: 'text/css'
+    };
+
     await percy.snapshot({
       name: 'Serialized Snapshot',
       url: 'http://localhost:8000/',
       domSnapshot: {
         html: `<img src="${resource.url}"/>`,
         warnings: ['Test serialize warning'],
-        resources: [resource]
+        resources: [resource, textResource]
       }
     });
 
@@ -626,6 +632,7 @@ describe('Snapshot', () => {
       .toMatch(`<img src="${resource.url}"/>`);
     // domSnapshot.resources are also uploaded
     expect(uploads[1]).toEqual(resource.content);
+    expect(uploads[2]).toEqual(Buffer.from(textResource.content).toString('base64'));
   });
 
   it('handles duplicate snapshots', async () => {

--- a/packages/dom/src/utils.js
+++ b/packages/dom/src/utils.js
@@ -19,11 +19,9 @@ export function resourceFromText(uid, mimetype, data) {
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
   let url = new URL(path, document.URL).toString();
-  // converts text to base64
-  let content = window.btoa(data);
 
-  // return the url, base64 content, and mimetype
-  return { url, content, mimetype };
+  // return the url, text content, and mimetype
+  return { url, content: data, mimetype };
 }
 
 export function styleSheetFromNode(node) {

--- a/packages/dom/test/serialize-css.test.js
+++ b/packages/dom/test/serialize-css.test.js
@@ -97,7 +97,7 @@ describe('serializeCSSOM', () => {
       const resultShadowEl = $('#Percy-0')[0];
       expect(capture.resources).toEqual(jasmine.arrayContaining([{
         url: jasmine.stringMatching('\\.css$'),
-        content: window.btoa(style),
+        content: style,
         mimetype: 'text/css'
       }]));
 


### PR DESCRIPTION
Fixes https://github.com/percy/cli/issues/1204

Percy CLI Server expects base64 data for resources by default. There's no straightforward way to convert unicode javascript strings, which have a 2 byte character size to base64 in the browser. Hence, we modify CLI server to accept resources with a text mimetype with UTF8 encoding