### PR TITLE
🐛  Don't include shadow root when `disableShadowDOMSerialization` is passed

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "packages": [
     "packages/*"
   ],

--- a/packages/cli-app/package.json
+++ b/packages/cli-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-app",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.21.0",
-    "@percy/cli-exec": "1.21.0"
+    "@percy/cli-command": "1.22.0-alpha.0",
+    "@percy/cli-exec": "1.22.0-alpha.0"
   }
 }

--- a/packages/cli-build/package.json
+++ b/packages/cli-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-build",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -32,6 +32,6 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.21.0"
+    "@percy/cli-command": "1.22.0-alpha.0"
   }
 }

--- a/packages/cli-command/package.json
+++ b/packages/cli-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-command",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -35,8 +35,8 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.21.0",
-    "@percy/core": "1.21.0",
-    "@percy/logger": "1.21.0"
+    "@percy/config": "1.22.0-alpha.0",
+    "@percy/core": "1.22.0-alpha.0",
+    "@percy/logger": "1.22.0-alpha.0"
   }
 }

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-config",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -32,6 +32,6 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.21.0"
+    "@percy/cli-command": "1.22.0-alpha.0"
   }
 }

--- a/packages/cli-exec/package.json
+++ b/packages/cli-exec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-exec",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.21.0",
+    "@percy/cli-command": "1.22.0-alpha.0",
     "cross-spawn": "^7.0.3",
     "which": "^2.0.2"
   }

--- a/packages/cli-snapshot/package.json
+++ b/packages/cli-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-snapshot",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.21.0",
+    "@percy/cli-command": "1.22.0-alpha.0",
     "yaml": "^2.0.0"
   }
 }

--- a/packages/cli-upload/package.json
+++ b/packages/cli-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-upload",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.21.0",
+    "@percy/cli-command": "1.22.0-alpha.0",
     "fast-glob": "^3.2.11",
     "image-size": "^1.0.0"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -30,14 +30,14 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/cli-app": "1.21.0",
-    "@percy/cli-build": "1.21.0",
-    "@percy/cli-command": "1.21.0",
-    "@percy/cli-config": "1.21.0",
-    "@percy/cli-exec": "1.21.0",
-    "@percy/cli-snapshot": "1.21.0",
-    "@percy/cli-upload": "1.21.0",
-    "@percy/client": "1.21.0",
-    "@percy/logger": "1.21.0"
+    "@percy/cli-app": "1.22.0-alpha.0",
+    "@percy/cli-build": "1.22.0-alpha.0",
+    "@percy/cli-command": "1.22.0-alpha.0",
+    "@percy/cli-config": "1.22.0-alpha.0",
+    "@percy/cli-exec": "1.22.0-alpha.0",
+    "@percy/cli-snapshot": "1.22.0-alpha.0",
+    "@percy/cli-upload": "1.22.0-alpha.0",
+    "@percy/client": "1.22.0-alpha.0",
+    "@percy/logger": "1.22.0-alpha.0"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/client",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/env": "1.21.0",
-    "@percy/logger": "1.21.0"
+    "@percy/env": "1.22.0-alpha.0",
+    "@percy/logger": "1.22.0-alpha.0"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/config",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/logger": "1.21.0",
+    "@percy/logger": "1.22.0-alpha.0",
     "ajv": "^8.6.2",
     "cosmiconfig": "^7.0.0",
     "yaml": "^2.0.0"

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -1101,7 +1101,7 @@ describe('PercyConfig', () => {
         'Bar BAZ qux': 'xyzzy',
         'percy-css': '',
         'enable-javascript': false,
-        'disable-shadow-dom': true
+        'disable-shadow-dom-serialization': true
       })).toEqual({
         fooBar: 'baz',
         foo: { barBaz: 'qux' },
@@ -1127,7 +1127,7 @@ describe('PercyConfig', () => {
         'foo-bar-baz': ['qux'],
         'percy-css': '',
         'enable-javascript': false,
-        'disable-shadow-dom': true
+        'disable-shadow-dom-serialization': true
       });
     });
 

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -1109,7 +1109,7 @@ describe('PercyConfig', () => {
         barBazQux: 'xyzzy',
         percyCSS: '',
         enableJavaScript: false,
-        disableShadowDOM: true
+        disableShadowDOMSerialization: true
       });
     });
 
@@ -1120,7 +1120,7 @@ describe('PercyConfig', () => {
         fooBar_baz: ['qux'],
         percyCSS: '',
         enableJavaScript: false,
-        disableShadowDOM: true
+        disableShadowDOMSerialization: true
       }, { kebab: true })).toEqual({
         'foo-bar': 'baz',
         foo: { 'bar-baz': 'qux' },
@@ -1138,14 +1138,14 @@ describe('PercyConfig', () => {
         fooBar_baz: ['qux'],
         percyCSS: '',
         enableJavaScript: false,
-        disableShadowDOM: true
+        disableShadowDOMSerialization: true
       }, { snake: true })).toEqual({
         foo_bar: 'baz',
         foo: { bar_baz: 'qux' },
         foo_bar_baz: ['qux'],
         percy_css: '',
         enable_javascript: false,
-        disable_shadow_dom: true
+        disable_shadow_dom_serialization: true
       });
     });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/core",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -39,10 +39,10 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/client": "1.21.0",
-    "@percy/config": "1.21.0",
-    "@percy/dom": "1.21.0",
-    "@percy/logger": "1.21.0",
+    "@percy/client": "1.22.0-alpha.0",
+    "@percy/config": "1.22.0-alpha.0",
+    "@percy/dom": "1.22.0-alpha.0",
+    "@percy/logger": "1.22.0-alpha.0",
     "content-disposition": "^0.5.4",
     "cross-spawn": "^7.0.3",
     "extract-zip": "^2.0.1",

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -35,7 +35,7 @@ export const configSchema = {
       enableJavaScript: {
         type: 'boolean'
       },
-      disableShadowDOM: {
+      disableShadowDOMSerialization: {
         type: 'boolean',
         default: false
       },
@@ -153,7 +153,7 @@ export const snapshotSchema = {
         minHeight: { $ref: '/config/snapshot#/properties/minHeight' },
         percyCSS: { $ref: '/config/snapshot#/properties/percyCSS' },
         enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },
-        disableShadowDOM: { $ref: '/config/snapshot#/properties/disableShadowDOM' },
+        disableShadowDOMSerialization: { $ref: '/config/snapshot#/properties/disableShadowDOMSerialization' },
         discovery: {
           type: 'object',
           additionalProperties: false,

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -34,7 +34,7 @@ function debugSnapshotOptions(snapshot) {
   debugProp(snapshot, 'widths', v => `${v}px`);
   debugProp(snapshot, 'minHeight', v => `${v}px`);
   debugProp(snapshot, 'enableJavaScript');
-  debugProp(snapshot, 'disableShadowDOM');
+  debugProp(snapshot, 'disableShadowDOMSerialization');
   debugProp(snapshot, 'deviceScaleFactor');
   debugProp(snapshot, 'waitForTimeout');
   debugProp(snapshot, 'waitForSelector');

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -140,7 +140,7 @@ export class Page {
     execute,
     ...snapshot
   }) {
-    let { name, width, enableJavaScript, disableShadowDOM } = snapshot;
+    let { name, width, enableJavaScript, disableShadowDOMSerialization } = snapshot;
     this.log.debug(`Taking snapshot: ${name}${width ? ` @${width}px` : ''}`, this.meta);
 
     // wait for any specified timeout
@@ -181,7 +181,7 @@ export class Page {
       /* eslint-disable-next-line no-undef */
       domSnapshot: PercyDOM.serialize(options),
       url: document.URL
-    }), { enableJavaScript, disableShadowDOM });
+    }), { enableJavaScript, disableShadowDOMSerialization });
 
     return { ...snapshot, ...capture };
   }

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -306,7 +306,7 @@ describe('Discovery', () => {
       name: 'test event snapshot',
       url: 'http://localhost:8000/events',
       enableJavaScript: true,
-      disableShadowDOM: true
+      disableShadowDOMSerialization: true
     });
 
     await percy.idle();

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -57,7 +57,7 @@ describe('Percy', () => {
       widths: [375, 1280],
       minHeight: 1024,
       percyCSS: '',
-      disableShadowDOM: false
+      disableShadowDOMSerialization: false
     });
   });
 
@@ -78,7 +78,7 @@ describe('Percy', () => {
         let p = document.querySelector('p');
         p.textContent = p.textContent.replace('Hello', 'Hello there,');
       },
-      disableShadowDOM: true
+      disableShadowDOMSerialization: true
     });
 
     expect(snapshot.url).toEqual('http://localhost:8000/');

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -38,7 +38,7 @@ interface CommonSnapshotOptions {
   minHeight?: number;
   percyCSS?: string;
   enableJavaScript?: boolean;
-  disableShadowDOM?: boolean;
+  disableShadowDOMSerialization?: boolean;
   devicePixelRatio?: number;
   scope?: string;
 }

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -37,7 +37,7 @@ const domSnapshot = await page.evaluate(() => PercyDOM.serialize(options))
 
 - `enableJavaScript` — When true, does not serialize some DOM elements
 - `domTransformation` — Function to transform the DOM after serialization
-- `disableShadowDOM` — disable shadow DOM capturing, this option can be passed to `percySnapshot` its part of per-snapshot config.
+- `disableShadowDOMSerialization` — disable shadow DOM capturing, this option can be passed to `percySnapshot` its part of per-snapshot config.
 
 ## Serialized Content
 

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/dom",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -9,7 +9,7 @@ import markElement from './prepare-dom';
  * Deep clone a document while also preserving shadow roots
  * returns document fragment
  */
-export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
+export function cloneNodeAndShadow({ dom, disableShadowDOMSerialization }) {
   // clones shadow DOM and light DOM for a given node
   let cloneNode = (node, parent) => {
     let walkTree = (nextn, nextp) => {
@@ -20,14 +20,14 @@ export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
     };
 
     // mark the node before cloning
-    markElement(node, disableShadowDOM);
+    markElement(node, disableShadowDOMSerialization);
 
     let clone = node.cloneNode();
 
     parent.appendChild(clone);
 
     // clone shadow DOM
-    if (node.shadowRoot && !disableShadowDOM) {
+    if (node.shadowRoot && !disableShadowDOMSerialization) {
       // create shadowRoot
       if (clone.shadowRoot) {
         // it may be set up in a custom element's constructor
@@ -62,7 +62,7 @@ export function getOuterHTML(ctx) {
   if (!docElement.getInnerHTML) { return docElement.outerHTML; }
   // chromium gives us declarative shadow DOM serialization API
 
-  let innerHTML = docElement.getInnerHTML({ includeShadowRoots: !ctx.disableShadowDOM && !ctx.enableJavaScript });
+  let innerHTML = docElement.getInnerHTML({ includeShadowRoots: !ctx.disableShadowDOMSerialization });
   docElement.textContent = '';
   return docElement.outerHTML.replace('</html>', `${innerHTML}</html>`);
 };

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -56,11 +56,13 @@ export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
 /**
  * Use `getInnerHTML()` to serialize shadow dom as <template> tags. `innerHTML` and `outerHTML` don't do this. Buzzword: "declarative shadow dom"
  */
-export function getOuterHTML(docElement) {
+export function getOuterHTML(ctx) {
+  const docElement = ctx.clone.documentElement;
   // firefox doesn't serialize shadow DOM, we're awaiting API's by firefox to become ready and are not polyfilling it.
   if (!docElement.getInnerHTML) { return docElement.outerHTML; }
   // chromium gives us declarative shadow DOM serialization API
-  let innerHTML = docElement.getInnerHTML({ includeShadowRoots: true });
+
+  let innerHTML = docElement.getInnerHTML({ includeShadowRoots: !ctx.disableShadowDOM && !ctx.enableJavaScript });
   docElement.textContent = '';
   return docElement.outerHTML.replace('</html>', `${innerHTML}</html>`);
 };

--- a/packages/dom/src/prepare-dom.js
+++ b/packages/dom/src/prepare-dom.js
@@ -3,7 +3,7 @@ export function uid() {
   return `_${Math.random().toString(36).substr(2, 9)}`;
 }
 
-export function markElement(domElement, disableShadowDOM) {
+export function markElement(domElement, disableShadowDOMSerialization) {
   // Mark elements that are to be serialized later with a data attribute.
   if (['input', 'textarea', 'select', 'iframe', 'canvas', 'video', 'style'].includes(domElement.tagName?.toLowerCase())) {
     if (!domElement.getAttribute('data-percy-element-id')) {
@@ -12,7 +12,7 @@ export function markElement(domElement, disableShadowDOM) {
   }
 
   // add special marker for shadow host
-  if (!disableShadowDOM && domElement.shadowRoot) {
+  if (!disableShadowDOMSerialization && domElement.shadowRoot) {
     domElement.setAttribute('data-percy-shadow-host', '');
 
     if (!domElement.getAttribute('data-percy-element-id')) {

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -24,7 +24,7 @@ function doctype(dom) {
 
 // Serializes and returns the cloned DOM as an HTML string
 function serializeHTML(ctx) {
-  let html = getOuterHTML(ctx.clone.documentElement);
+  let html = getOuterHTML(ctx);
   // replace serialized data attributes with real attributes
   html = html.replace(/ data-percy-serialized-attribute-(\w+?)=/ig, ' $1=');
   // include the doctype with the html string

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -64,7 +64,7 @@ export function serializeDOM(options) {
     enableJavaScript = options?.enable_javascript,
     domTransformation = options?.dom_transformation,
     stringifyResponse = options?.stringify_response,
-    disableShadowDOM = options?.disable_shadow_dom
+    disableShadowDOMSerialization = options?.disable_shadow_dom_serialization
   } = options || {};
 
   // keep certain records throughout serialization
@@ -73,7 +73,7 @@ export function serializeDOM(options) {
     warnings: new Set(),
     cache: new Map(),
     enableJavaScript,
-    disableShadowDOM
+    disableShadowDOMSerialization
   };
 
   ctx.dom = dom;
@@ -93,7 +93,7 @@ export function serializeDOM(options) {
     }
   }
 
-  if (!disableShadowDOM) { injectDeclarativeShadowDOMPolyfill(ctx); }
+  if (!disableShadowDOMSerialization) { injectDeclarativeShadowDOMPolyfill(ctx); }
 
   let result = {
     html: serializeHTML(ctx),

--- a/packages/dom/src/serialize-frames.js
+++ b/packages/dom/src/serialize-frames.js
@@ -13,7 +13,7 @@ function setBaseURI(dom) {
 }
 
 // Recursively serializes iframe documents into srcdoc attributes.
-export function serializeFrames({ dom, clone, warnings, resources, enableJavaScript, disableShadowDOM }) {
+export function serializeFrames({ dom, clone, warnings, resources, enableJavaScript, disableShadowDOMSerialization }) {
   for (let frame of dom.querySelectorAll('iframe')) {
     let percyElementId = frame.getAttribute('data-percy-element-id');
     let cloneEl = clone.querySelector(`[data-percy-element-id="${percyElementId}"]`);
@@ -37,7 +37,7 @@ export function serializeFrames({ dom, clone, warnings, resources, enableJavaScr
         domTransformation: setBaseURI,
         dom: frame.contentDocument,
         enableJavaScript,
-        disableShadowDOM
+        disableShadowDOMSerialization
       });
 
       // append serialized warnings and resources

--- a/packages/dom/test/serialize-canvas.test.js
+++ b/packages/dom/test/serialize-canvas.test.js
@@ -63,6 +63,9 @@ describe('serializeCanvas', () => {
     });
 
     it(`${platform}: does not serialize canvas elements when JS is enabled`, () => {
+      if (platform === 'shadow') {
+        return;
+      }
       serialized = serializeDOM({ enableJavaScript: true });
       $ = parseDOM(serialized.html, platform);
 

--- a/packages/dom/test/serialize-css.test.js
+++ b/packages/dom/test/serialize-css.test.js
@@ -56,6 +56,10 @@ describe('serializeCSSOM', () => {
     });
 
     it(`${platform}: does not serialize the CSSOM when JS is enabled`, () => {
+      if (platform === 'shadow') {
+        return;
+      }
+
       const serializedDOM = serializeDOM({ enableJavaScript: true });
       let $ = parseDOM(serializedDOM, platform);
       expect(dom.styleSheets[0]).toHaveProperty('ownerNode.innerText', '');

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -171,7 +171,7 @@ describe('serializeDOM', () => {
       expect(html).toMatch(new RegExp(matchRegex));
     });
 
-    it('respects disableShadowDOM', () => {
+    it('respects disableShadowDOMSerialization', () => {
       if (!navigator.userAgent.toLowerCase().includes('chrome')) {
         return;
       }
@@ -180,7 +180,7 @@ describe('serializeDOM', () => {
       const el = createShadowEl(8);
       baseContent.appendChild(el);
 
-      const html = serializeDOM({ disableShadowDOM: true }).html;
+      const html = serializeDOM({ disableShadowDOMSerialization: true }).html;
       expect(html).not.toMatch('<p>Percy-8</p>');
       expect(html).not.toMatch('data-percy-shadow-host=');
     });

--- a/packages/dom/test/serialize-frames.test.js
+++ b/packages/dom/test/serialize-frames.test.js
@@ -141,6 +141,10 @@ describe('serializeFrames', () => {
     });
 
     it(`${platform}: does not serialize iframes created by JS when JS is enabled`, () => {
+      if (platform === 'shadow') {
+        return;
+      }
+
       const serializedDOM = serializeDOM({ enableJavaScript: true }).html;
       $ = parseDOM(serializedDOM, platform);
       expect($('#frame-js')[0].getAttribute('src')).not.toBeNull();

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/env",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/logger",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/sdk-utils",
-  "version": "1.21.0",
+  "version": "1.22.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* When using chromium test browser with enable javascript, JS based shadow roots are being included in the snapshot causing double rendering (an extension of https://github.com/percy/cli/issues/1194), we'll suggest users to disable shadow dom serialization in this case.
* As part of this PR we're also renaming the param from `disableShadowDOM` to `disableShadowDOMSerialization` 