### PR TITLE
Update the reversePolyFill function so custom elements get defined

### DIFF
--- a/packages/dom/src/inject-polyfill.js
+++ b/packages/dom/src/inject-polyfill.js
@@ -16,7 +16,16 @@ export function injectDeclarativeShadowDOMPolyfill(ctx) {
         template.remove();
       });
 
-      root.querySelectorAll('[data-percy-shadow-host]').forEach(shadowHost => reversePolyFill(shadowHost.shadowRoot));
+      root.querySelectorAll('[data-percy-shadow-host]').forEach(shadowHost => {
+        reversePolyFill(shadowHost.shadowRoot);
+        const customElementName = shadowHost.tagName.toLowerCase();
+        if (customElementName.includes('-') && !customElements.get(customElementName)) {
+          customElements.define(
+            customElementName,
+            class extends HTMLElement {}
+          );
+        }
+      });
     }
 
     if (["interactive", "complete"].includes(document.readyState)) {

--- a/packages/dom/test/inject-polyfill.test.js
+++ b/packages/dom/test/inject-polyfill.test.js
@@ -2,10 +2,9 @@ import injectDeclarativeShadowDOMPolyfill from '../src/inject-polyfill';
 import { withExample } from './helpers';
 
 describe('injectDeclarativeShadowDOMPolyfill', () => {
-  let dom;
-
-  beforeEach(() => {
-    dom = withExample(`
+  it('All template tags are converted to Shadow DOM', () => {
+    const dom = withExample(
+      `
         <div data-percy-shadow-host>
         <template shadowroot="open">
                 <div data-percy-shadow-host>
@@ -14,13 +13,33 @@ describe('injectDeclarativeShadowDOMPolyfill', () => {
                 </div>
         </template>
         </div>
-        `, { withShadow: false });
+        `,
+      { withShadow: false }
+    );
 
     let ctx = { clone: dom };
     injectDeclarativeShadowDOMPolyfill(ctx);
+    expect(Array.from(dom.documentElement.innerHTML.matchAll(/<\/template>/g)).length).toBe(0);
   });
 
-  it('All template tags are converted to Shadow DOM', () => {
-    expect(Array.from(dom.documentElement.innerHTML.matchAll(/<\/template>/g)).length).toBe(0);
+  it('All custom elements get defined', () => {
+    const dom = withExample(
+      `
+        <div data-percy-shadow-host>
+        <template shadowroot="open">
+                <custom-element data-percy-shadow-host>
+                    <template shadowroot="open">
+                    </template>
+                </custom-element>
+        </template>
+        </div>
+        `,
+      { withShadow: false }
+    );
+
+    let ctx = { clone: dom };
+    injectDeclarativeShadowDOMPolyfill(ctx);
+
+    expect(window.customElements.get('custom-element')).toBeDefined();
   });
 });


### PR DESCRIPTION
This helps solve issues where CSS wants to ensure custom elements are defined:

```css
custom-element:defined {
  /* ... */
}
```