### PR TITLE
Regression use PR branch

### DIFF
--- a/.github/workflows/sdk-regression.yml
+++ b/.github/workflows/sdk-regression.yml
@@ -15,7 +15,7 @@ jobs:
           - percy-ember
           - percy-cypress
           - percy-puppeteer
-          - percy-storybook
+          # - percy-storybook
           - percy-playwright
           - percy-testcafe
           - percy-nightwatch

--- a/.github/workflows/sdk-regression.yml
+++ b/.github/workflows/sdk-regression.yml
@@ -35,5 +35,5 @@ jobs:
           github_token: ${{ secrets.WORKFLOW_DISPATCH_ACTIONS_TOKEN }}
           workflow_file_name: test.yml
           ref: master
-          client_payload: '{ "branch": "${{ github.head_ref || github.ref_name }}"}'
+          client_payload: '{ "branch": "${{ github.event.pull_request.head.ref || github.ref_name }}"}'
           wait_interval: 15


### PR DESCRIPTION
We updated SDK regression to use PR branch instead of current branch in https://github.com/percy/cli/pull/1211.  But selecting PR branch is not documented properly and we needed a merge to test it. There were issues and this plans to fix it