### PR TITLE
Fix - percy upload for Safari browser

### DIFF
--- a/packages/cli-upload/src/utils.js
+++ b/packages/cli-upload/src/utils.js
@@ -20,7 +20,7 @@ export async function getImageResources({
   absolutePath
 }) {
   let rootUrl = `http://localhost/${encodeURIComponent(name)}`;
-  let imageUrl = `http://localhost/${encodeURIComponent(relativePath)}`;
+  let imageUrl = `http://local/${encodeURIComponent(relativePath)}`;
   let content = await fs.promises.readFile(absolutePath);
   let mimetype = `image/${type}`;
 


### PR DESCRIPTION
`localhost` keyword not supported in Safari. That causes `percy upload` html resource to be unable to fetch image resource