### PR TITLE
✨ increase interval for polling build

### DIFF
--- a/packages/cli-build/README.md
+++ b/packages/cli-build/README.md
@@ -36,7 +36,7 @@ Options:
   -p, --project <slug>   Build project slug, requires '--commit'
   -c, --commit <sha>     Build commit sha, requires '--project'
   -t, --timeout <ms>     Timeout before exiting without updates, defaults to 10 minutes
-  -i, --interval <ms>    Interval at which to poll for updates, defaults to 1 second
+  -i, --interval <ms>    Interval at which to poll for updates, defaults to 10 second
   -f, --fail-on-changes  Exit with an error when diffs are found
   --pass-if-approved     Doesn't Exit with an error if the build is approved, requires '--fail-on-changes'
 

--- a/packages/cli-build/src/wait.js
+++ b/packages/cli-build/src/wait.js
@@ -28,7 +28,7 @@ export const wait = command('wait', {
     short: 't'
   }, {
     name: 'interval',
-    description: 'Interval at which to poll for updates, defaults to 1 second',
+    description: 'Interval at which to poll for updates, defaults to 10 second',
     type: 'ms',
     parse: Number,
     short: 'i'

--- a/packages/cli-build/test/wait.test.js
+++ b/packages/cli-build/test/wait.test.js
@@ -54,7 +54,7 @@ describe('percy build:wait', () => {
 
     await wait(['--project=foo/bar', '--commit=sha123', '--timeout=500', '--interval=50']);
 
-    expect(logger.stderr).toEqual([]);
+    expect(logger.stderr).toEqual(['[percy] Considering interval 1000ms, it cannot be less than that.']);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
       '[percy] Waiting for build...'
     ]));
@@ -72,7 +72,7 @@ describe('percy build:wait', () => {
 
     await wait(['--build=123', '--interval=50']);
 
-    expect(logger.stderr).toEqual([]);
+    expect(logger.stderr).toEqual(['[percy] Considering interval 1000ms, it cannot be less than that.']);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
       '[percy] Recieving snapshots...'
     ]));
@@ -95,7 +95,7 @@ describe('percy build:wait', () => {
 
     await wait(['--build=123', '--interval=50']);
 
-    expect(logger.stderr).toEqual([]);
+    expect(logger.stderr).toEqual(['[percy] Considering interval 1000ms, it cannot be less than that.']);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
       '[percy] Processing 18 snapshots - 16 of 72 comparisons finished...',
       '[percy] Processing 18 snapshots - 32 of 72 comparisons finished...',

--- a/packages/cli-build/test/wait.test.js
+++ b/packages/cli-build/test/wait.test.js
@@ -54,7 +54,7 @@ describe('percy build:wait', () => {
 
     await wait(['--project=foo/bar', '--commit=sha123', '--timeout=500', '--interval=50']);
 
-    expect(logger.stderr).toEqual(['[percy] Considering interval 1000ms, it cannot be less than that.']);
+    expect(logger.stderr).toEqual(['[percy] Ignoring interval since it cannot be less than 1000ms.']);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
       '[percy] Waiting for build...'
     ]));
@@ -72,7 +72,7 @@ describe('percy build:wait', () => {
 
     await wait(['--build=123', '--interval=50']);
 
-    expect(logger.stderr).toEqual(['[percy] Considering interval 1000ms, it cannot be less than that.']);
+    expect(logger.stderr).toEqual(['[percy] Ignoring interval since it cannot be less than 1000ms.']);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
       '[percy] Recieving snapshots...'
     ]));
@@ -95,7 +95,7 @@ describe('percy build:wait', () => {
 
     await wait(['--build=123', '--interval=50']);
 
-    expect(logger.stderr).toEqual(['[percy] Considering interval 1000ms, it cannot be less than that.']);
+    expect(logger.stderr).toEqual(['[percy] Ignoring interval since it cannot be less than 1000ms.']);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
       '[percy] Processing 18 snapshots - 16 of 72 comparisons finished...',
       '[percy] Processing 18 snapshots - 32 of 72 comparisons finished...',

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -164,4 +164,4 @@ await client.waitForBuild({
 - `commit` — Commit SHA (**required** when missing `build`)
 - `project` — Project slug (**required** when using `commit`)
 - `timeout` — Timeout in milliseconds to wait with no updates (**default** `10 * 60 * 1000`)
-- `interval` — Interval in miliseconds to check for updates (**default** `1000`)
+- `interval` — Interval in miliseconds to check for updates (**default** `10000`)

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -200,7 +200,7 @@ export class PercyClient {
     interval = 10_000
   }, onProgress) {
     if (interval < MIN_POLLING_INTERVAL) {
-      this.log.warn(`Considering interval ${MIN_POLLING_INTERVAL}ms, it cannot be less than that.`);
+      this.log.warn(`Ignoring interval since it cannot be less than ${MIN_POLLING_INTERVAL}ms.`);
       interval = MIN_POLLING_INTERVAL;
     }
     if (!project && commit) {

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -225,7 +225,6 @@ export class PercyClient {
       : (await this.getBuilds(project, { sha })).data?.[0];
 
     this.log.debug(`Waiting for build ${build || `${project} (${commit})`}...`);
-    let self = this;
 
     // recursively poll every second until the build finishes
     return new Promise((resolve, reject) => (async function poll(last, t) {
@@ -251,7 +250,6 @@ export class PercyClient {
 
         // not finished, poll again
         if (pending) {
-          setTimeout(self.log.debug, interval, 'Fetching now...');
           return setTimeout(poll, interval, data, t);
 
         // build finished

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -190,11 +190,6 @@ export class PercyClient {
     return this.get(`projects/${project}/builds?${qs}`);
   }
 
-  // required so we could mock this method in tests :P
-  isIntervalLessThanThreshold(interval) {
-    return interval < MIN_POLLING_INTERVAL;
-  }
-
   // Resolves when the build has finished and is no longer pending or
   // processing. By default, will time out if no update after 10 minutes.
   waitForBuild({
@@ -204,7 +199,7 @@ export class PercyClient {
     timeout = 10 * 60 * 1000,
     interval = 10_000
   }, onProgress) {
-    if (this.isIntervalLessThanThreshold(interval)) {
+    if (interval < MIN_POLLING_INTERVAL) {
       this.log.warn(`Considering interval ${MIN_POLLING_INTERVAL}ms, it cannot be less than that.`);
       interval = MIN_POLLING_INTERVAL;
     }

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -365,8 +365,13 @@ describe('PercyClient', () => {
         .toThrowError('Invalid project path. Expected "org/project" but received "test"');
     });
 
-    it('warns when interval is less than 1000ms', () => {
-      client.waitForBuild({ project: 'foo/bar', interval: 50 });
+    it('warns when interval is less than 1000ms', async () => {
+      api
+        .reply('/builds/123', () => [200, {
+          data: { attributes: { state: 'finished' } }
+        }]);
+
+      await client.waitForBuild({ build: '123', interval: 50 });
       expect(logger.stderr).toEqual(jasmine.arrayContaining(['[percy:client] Considering interval 1000ms, it cannot be less than that.']));
     });
 

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -367,10 +367,10 @@ describe('PercyClient', () => {
 
     it('warns when interval is less than 1000ms', () => {
       client.waitForBuild({ project: 'foo/bar', interval: 50 });
-      expect(logger.stderr).toEqual(jasmine.arrayContaining([`[percy:client] Considering interval 1000ms, it cannot be less than that.`]))
+      expect(logger.stderr).toEqual(jasmine.arrayContaining(['[percy:client] Considering interval 1000ms, it cannot be less than that.']));
     });
 
-    fit('invokes the callback when data changes while waiting', async () => {
+    it('invokes the callback when data changes while waiting', async () => {
       let progress = 0;
 
       api
@@ -390,13 +390,9 @@ describe('PercyClient', () => {
       }, () => progress++);
 
       expect(progress).toEqual(2);
-      expect(logger.stderr).toEqual(jasmine.arrayContaining([
-        '[percy:client] Fetching now...',
-        '[percy:client] Fetching now...'
-      ]));
     });
 
-    fit('throws when no update happens within the timeout', async () => {
+    it('throws when no update happens within the timeout', async () => {
       api.reply('/builds/123', () => [200, {
         data: { attributes: { state: 'processing' } }
       }]);

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -372,7 +372,7 @@ describe('PercyClient', () => {
         }]);
 
       await client.waitForBuild({ build: '123', interval: 50 });
-      expect(logger.stderr).toEqual(jasmine.arrayContaining(['[percy:client] Considering interval 1000ms, it cannot be less than that.']));
+      expect(logger.stderr).toEqual(jasmine.arrayContaining(['[percy:client] Ignoring interval since it cannot be less than 1000ms.']));
     });
 
     it('invokes the callback when data changes while waiting', async () => {


### PR DESCRIPTION
* Increase polling interval for build to default to 10s.
* polling 1s is unnecessary and also causes stress on API, A build usually doesn't finish in 1s granularity. if less than 1s is given we'll clamp it to 1s
