### PR TITLE
🐛 cloneNode ensure shallow clone

### DIFF
--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -29,9 +29,7 @@ export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
     // shallow clone should not contain children
     // these might get added due to DOM side effects
     if (clone.children) {
-      for (const child of Array.from(clone.children)) {
-        clone.removeChild(child);
-      }
+      Array.from(clone.children).forEach(child => clone.removeChild(child));
     }
 
     // clone shadow DOM

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -23,6 +23,7 @@ export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
     markElement(node, disableShadowDOM);
 
     let clone = node.cloneNode();
+
     parent.appendChild(clone);
 
     // shalow clone should not contain children

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -23,8 +23,15 @@ export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
     markElement(node, disableShadowDOM);
 
     let clone = node.cloneNode();
-
     parent.appendChild(clone);
+
+    // shalow clone should not contain children
+    // these might get added due to DOM side effects
+    if (clone.children) {
+      for (const child of Array.from(clone.children)) {
+        clone.removeChild(child);
+      }
+    }
 
     // clone shadow DOM
     if (node.shadowRoot && !disableShadowDOM) {

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -27,7 +27,6 @@ export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
     parent.appendChild(clone);
 
     // shallow clone should not contain children
-    // these might get added due to DOM side effects
     if (clone.children) {
       Array.from(clone.children).forEach(child => clone.removeChild(child));
     }

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -26,7 +26,7 @@ export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
 
     parent.appendChild(clone);
 
-    // shalow clone should not contain children
+    // shallow clone should not contain children
     // these might get added due to DOM side effects
     if (clone.children) {
       for (const child of Array.from(clone.children)) {

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -53,6 +53,29 @@ describe('serializeDOM', () => {
     expect($('h2.callback').length).toEqual(1);
   });
 
+  it('clone node is always shallow', () => {
+    class AttributeCallbackTestElement extends window.HTMLElement {
+      static get observedAttributes() {
+        return ['text'];
+      }
+
+      attributeChangedCallback() {
+        const wrapper = document.createElement('h2');
+        wrapper.className = 'callback';
+        wrapper.innerText = 'Test';
+        this.appendChild(wrapper);
+      }
+    }
+
+    if (!window.customElements.get('attr-callback-test')) {
+      window.customElements.define('attr-callback-test', AttributeCallbackTestElement);
+    }
+    withExample('<attr-callback-test text="1"/>', { withShadow: false });
+    const $ = parseDOM(serializeDOM().html);
+
+    expect($('h2.callback').length).toEqual(1);
+  });
+
   describe('shadow dom', () => {
     it('renders open root as template tag', () => {
       if (getTestBrowser() !== chromeBrowser) {


### PR DESCRIPTION
WebComponents have [lifecycle callbacks](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#using_the_lifecycle_callbacks) which can mess up the structure of the page while trying to create a clone. We'd earlier fixed it for `connectedCallback` and `disconnectedCallback` in https://github.com/percy/cli/pull/1185. `attributeChangedCallback` is called before `connectedCallback` and can also cause side effects when we clone a node. We solve for this effect by asserting the shallowness of the node cloned in this PR