### PR TITLE
👷 Add storybook & selenium ruby to regression

### DIFF
--- a/.github/workflows/sdk-regression.yml
+++ b/.github/workflows/sdk-regression.yml
@@ -16,7 +16,7 @@ jobs:
           - percy-ember
           - percy-cypress
           - percy-puppeteer
-          # - percy-storybook
+          - percy-storybook
           - percy-playwright
           - percy-testcafe
           - percy-nightwatch
@@ -28,6 +28,7 @@ jobs:
           - percy-selenium-dotnet
           - percy-selenium-java
           - percy-selenium-python
+          - percy-selenium-ruby
           - percy-capybara
           - percy-appium-js
           - gatsby-plugin-percy


### PR DESCRIPTION
We fixed storybook and selenium ruby regression issues in https://github.com/percy/percy-storybook/pull/723 and https://github.com/percy/percy-selenium-ruby/pull/9 respectively. Now they can be added to the regression pipeline