### PR TITLE
Regression Fix job url and status update

### DIFF
--- a/.github/workflows/sdk-regression.yml
+++ b/.github/workflows/sdk-regression.yml
@@ -34,6 +34,14 @@ jobs:
       - uses: xt0rted/pull-request-comment-branch@v2
         if: ${{ github.event.issue.pull_request }}
         id: comment-branch
+      - name: Get Current Job Log URL
+        uses: Tiryoh/gha-jobid-action@v0
+        id: job-url
+        with:
+          github_token: ${{ secrets.WORKFLOW_DISPATCH_ACTIONS_TOKEN }}
+          job_name: "regression (${{ matrix.repo }})" 
+      - name: Output Current Job Log URL
+        run: echo ${{ steps.jobs.outputs.html_url }}
       - uses: actions/github-script@v4
         with:
           github-token: ${{ secrets.WORKFLOW_DISPATCH_ACTIONS_TOKEN }}
@@ -41,7 +49,7 @@ jobs:
             const { owner, repo } = context.repo;
             const sha = '${{ steps.comment-branch.outputs.head_sha }}'
             const state = 'pending';
-            const target_url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ jobs.job_id }}'
+            const target_url = '${{ steps.job-url.outputs.html_url }}'
             const check_name = 'SDK Regression ${{ matrix.repo }}'
             
             github.repos.createCommitStatus({
@@ -76,7 +84,7 @@ jobs:
             const { owner, repo } = context.repo;
             const sha = '${{ steps.comment-branch.outputs.head_sha }}'
             const state = '${{ steps.reg-test.outcome }}';
-            const target_url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ jobs.job_id }}'
+            const target_url = '${{ steps.job-url.outputs.html_url }}'
             const check_name = 'SDK Regression ${{ matrix.repo }}'
             
             github.repos.createCommitStatus({

--- a/.github/workflows/sdk-regression.yml
+++ b/.github/workflows/sdk-regression.yml
@@ -41,7 +41,7 @@ jobs:
             const { owner, repo } = context.repo;
             const sha = '${{ steps.comment-branch.outputs.head_sha }}'
             const state = 'pending';
-            const target_url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            const target_url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ jobs.job_id }}'
             const check_name = 'SDK Regression ${{ matrix.repo }}'
             
             github.repos.createCommitStatus({
@@ -74,9 +74,9 @@ jobs:
           github-token: ${{ secrets.WORKFLOW_DISPATCH_ACTIONS_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
-            const sha = '${{ steps.reg-test.outcome }}'
-            const state = 'pending';
-            const target_url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            const sha = '${{ steps.comment-branch.outputs.head_sha }}'
+            const state = '${{ steps.reg-test.outcome }}';
+            const target_url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs/${{ jobs.job_id }}'
             const check_name = 'SDK Regression ${{ matrix.repo }}'
             
             github.repos.createCommitStatus({


### PR DESCRIPTION
We don't have access to job id needed to build the URL in the action context. We fetch it using the API.