### PR TITLE
:sparkles: support domTransformation in Page.snapshot function

### DIFF
--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -39,6 +39,9 @@ export const configSchema = {
         type: 'boolean',
         default: false
       },
+      domTransformation: {
+        type: 'string'
+      },
       scope: {
         type: 'string'
       }
@@ -154,6 +157,7 @@ export const snapshotSchema = {
         percyCSS: { $ref: '/config/snapshot#/properties/percyCSS' },
         enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },
         disableShadowDOM: { $ref: '/config/snapshot#/properties/disableShadowDOM' },
+        domTransformation: { $ref: '/config/snapshot#/properties/domTransformation' },
         discovery: {
           type: 'object',
           additionalProperties: false,

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -140,7 +140,7 @@ export class Page {
     execute,
     ...snapshot
   }) {
-    let { name, width, enableJavaScript, disableShadowDOM } = snapshot;
+    let { name, width, enableJavaScript, disableShadowDOM, domTransformation } = snapshot;
     this.log.debug(`Taking snapshot: ${name}${width ? ` @${width}px` : ''}`, this.meta);
 
     // wait for any specified timeout
@@ -181,7 +181,7 @@ export class Page {
       /* eslint-disable-next-line no-undef */
       domSnapshot: PercyDOM.serialize(options),
       url: document.URL
-    }), { enableJavaScript, disableShadowDOM });
+    }), { enableJavaScript, disableShadowDOM, domTransformation });
 
     return { ...snapshot, ...capture };
   }

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -73,6 +73,8 @@ describe('Percy', () => {
     // navigate to a page and capture a snapshot outside of core
     await page.goto('http://localhost:8000');
 
+    let evalSpy = spyOn(page, 'eval').and.callThrough();
+
     let snapshot = await page.snapshot({
       execute() {
         let p = document.querySelector('p');
@@ -80,6 +82,9 @@ describe('Percy', () => {
       },
       disableShadowDOM: true
     });
+
+    // expect required arguments are passed to PercyDOM.serialize
+    expect(evalSpy.calls.allArgs()[3]).toEqual(jasmine.arrayContaining([jasmine.anything(), { enableJavaScript: undefined, disableShadowDOM: true, domTransformation: undefined }]));
 
     expect(snapshot.url).toEqual('http://localhost:8000/');
     expect(snapshot.domSnapshot).toEqual(jasmine.objectContaining({

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -995,7 +995,13 @@ describe('Snapshot', () => {
         execute: {
           afterNavigation: domtest('afterNavigation', () => window.location.href),
           beforeSnapshot: domtest('beforeSnapshot', () => 'done!')
-        }
+        },
+        domTransformation: `(documentElement) => 
+            { 
+              let p = document.createElement('p');
+              p.innerText = 'added using domTransformation';
+              documentElement.querySelector('body').append(p);
+              return documentElement;}`
       });
 
       await percy.snapshot({
@@ -1021,7 +1027,8 @@ describe('Snapshot', () => {
           .body.data.attributes['base64-content']
       ), 'base64').toString()).toMatch([
         '<p>afterNavigation - http://localhost:8000/</p>',
-        '<p>beforeSnapshot - done!</p>'
+        '<p>beforeSnapshot - done!</p>',
+        '<p>added using domTransformation</p>'
       ].join(''));
 
       expect(Buffer.from((

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -1001,7 +1001,6 @@ describe('Snapshot', () => {
               let p = document.createElement('p');
               p.innerText = 'added using domTransformation';
               documentElement.querySelector('body').append(p);
-              return documentElement;
           }`
       });
 

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -996,12 +996,13 @@ describe('Snapshot', () => {
           afterNavigation: domtest('afterNavigation', () => window.location.href),
           beforeSnapshot: domtest('beforeSnapshot', () => 'done!')
         },
-        domTransformation: `(documentElement) => 
-            { 
+        domTransformation: `
+          (documentElement) => { 
               let p = document.createElement('p');
               p.innerText = 'added using domTransformation';
               documentElement.querySelector('body').append(p);
-              return documentElement;}`
+              return documentElement;
+          }`
       });
 
       await percy.snapshot({

--- a/packages/core/test/unit/config.test.js
+++ b/packages/core/test/unit/config.test.js
@@ -1,5 +1,5 @@
 import logger from '@percy/logger/test/helpers';
-import { configMigration } from '../../src/config.js';
+import { configMigration, snapshotSchema } from '../../src/config.js';
 
 describe('Unit / Config Migration', () => {
   let mocked = {
@@ -75,5 +75,11 @@ describe('Unit / Config Migration', () => {
 
     expect(mocked.migrate.map).toEqual([]);
     expect(mocked.migrate.del).toEqual([]);
+  });
+});
+
+describe('SnapshotSchema', () => {
+  it('should contain domTransformation', () => {
+    expect(snapshotSchema.$defs.common.properties).toEqual(jasmine.objectContaining({ domTransformation: jasmine.anything() }));
   });
 });


### PR DESCRIPTION
* `domTransformation` is a feature of `@percy/dom` package where in we can run arbitrary JS to modify the snapshotted DOM post serialization - [ref](https://github.com/percy/cli/tree/master/packages/dom#options)
* `Page.snapshot` is used by `cli-snapshot` and `percy-storybook` packages, other SDKs don't borrow `Page` from the asset discovery browser we inject `PercyDOM` script in the user's test browser. 
* With this PR cli snapshot and storybook SDK will be able to leverage `domTransformation` param. 