### PR TITLE
Bump cosmiconfig to 8.x.x

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@percy/logger": "1.24.0",
     "ajv": "^8.6.2",
-    "cosmiconfig": "^7.0.0",
+    "cosmiconfig": "^8.0.0",
     "yaml": "^2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3249,6 +3249,16 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cosmiconfig@^8.0.0:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.1.3.tgz#0e614a118fcc2d9e5afc2f87d53cd09931015689"
+  integrity sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==
+  dependencies:
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+
 cross-env@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"


### PR DESCRIPTION
Changes:
- Updated cosmiconfig to 8.x.x
- Older version was using `yaml` 1.x.x which had open cve's, newer version has moved to `js-yaml` package as dependency 
- We still have older `yaml` as dependency as its a dependency of `lerna` as well, but as lerna is not included as dependency in final released package, it would be not distributed