### PR TITLE
✨  Support loading lazy attribute 

### DIFF
--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -4,6 +4,7 @@
  * https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#parameters
  */
 import markElement from './prepare-dom';
+import { maybeTranformElement } from './transform-dom';
 
 /**
  * Deep clone a document while also preserving shadow roots
@@ -23,6 +24,8 @@ export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
     markElement(node, disableShadowDOM);
 
     let clone = node.cloneNode();
+
+    maybeTranformElement(clone);
 
     parent.appendChild(clone);
 

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -4,7 +4,7 @@
  * https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#parameters
  */
 import markElement from './prepare-dom';
-import { maybeTranformElement } from './transform-dom';
+import applyElementTransformation from './transform-dom';
 
 /**
  * Deep clone a document while also preserving shadow roots
@@ -25,7 +25,8 @@ export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
 
     let clone = node.cloneNode();
 
-    maybeTranformElement(clone);
+    // We apply any element transformations here to avoid another treeWalk
+    applyElementTransformation(clone);
 
     parent.appendChild(clone);
 

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -4,7 +4,7 @@
  * https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#parameters
  */
 import markElement from './prepare-dom';
-import applyElementTransformation from './transform-dom';
+import applyElementTransformations from './transform-dom';
 
 /**
  * Deep clone a document while also preserving shadow roots
@@ -26,7 +26,7 @@ export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
     let clone = node.cloneNode();
 
     // We apply any element transformations here to avoid another treeWalk
-    applyElementTransformation(clone);
+    applyElementTransformations(clone);
 
     parent.appendChild(clone);
 

--- a/packages/dom/src/transform-dom.js
+++ b/packages/dom/src/transform-dom.js
@@ -6,6 +6,8 @@ function dropLoadingAttribute(domElement) {
 }
 
 // All transformations that we need to apply for a successful discovery and stable render
-export function maybeTranformElement(domElement) {
+export function applyElementTransformations(domElement) {
   dropLoadingAttribute(domElement);
 }
+
+export default applyElementTransformations;

--- a/packages/dom/src/transform-dom.js
+++ b/packages/dom/src/transform-dom.js
@@ -1,0 +1,11 @@
+// Drop loading attribute. We do not scroll page in discovery stage but we want to make sure that
+// all resources are requested, so we drop loading attribute [as it can be set to lazy]
+function dropLoadingAttribute(domElement) {
+  if (!['img', 'iframe'].includes(domElement.tagName?.toLowerCase())) return;
+  domElement.removeAttribute('loading');
+}
+
+// All transformations that we need to apply for a successful discovery and stable render
+export function maybeTranformElement(domElement) {
+  dropLoadingAttribute(domElement);
+}

--- a/packages/dom/src/transform-dom.js
+++ b/packages/dom/src/transform-dom.js
@@ -1,12 +1,12 @@
 // Drop loading attribute. We do not scroll page in discovery stage but we want to make sure that
 // all resources are requested, so we drop loading attribute [as it can be set to lazy]
-function dropLoadingAttribute(domElement) {
+export function dropLoadingAttribute(domElement) {
   if (!['img', 'iframe'].includes(domElement.tagName?.toLowerCase())) return;
   domElement.removeAttribute('loading');
 }
 
 // All transformations that we need to apply for a successful discovery and stable render
-export function applyElementTransformations(domElement) {
+function applyElementTransformations(domElement) {
   dropLoadingAttribute(domElement);
 }
 

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -60,7 +60,7 @@ describe('serializeDOM', () => {
     expect($('h2.callback').length).toEqual(1);
   });
 
-  it('drops the loading attribute', () => {
+  it('applies dom transformations', () => {
     withExample('<img loading="lazy" src="http://some-url"/><iframe loading="lazy" src="">');
 
     const result = serializeDOM();

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -60,6 +60,13 @@ describe('serializeDOM', () => {
     expect($('h2.callback').length).toEqual(1);
   });
 
+  it('drops the loading attribute', () => {
+    withExample('<img loading="lazy" src="http://some-url"/><iframe loading="lazy" src="">');
+
+    const result = serializeDOM();
+    expect(result.html).not.toContain('loading="lazy"');
+  });
+
   it('clone node is always shallow', () => {
     class AttributeCallbackTestElement extends window.HTMLElement {
       static get observedAttributes() {

--- a/packages/dom/test/transform-dom.test.js
+++ b/packages/dom/test/transform-dom.test.js
@@ -1,0 +1,34 @@
+import { dropLoadingAttribute } from '../src/transform-dom';
+import { withExample } from './helpers';
+
+// Note: applyElementTransformations is tested in serialize-dom tests
+
+describe('dropLoadingAttribute', () => {
+  let dom;
+
+  beforeEach(() => {
+    dom = withExample(`
+        <img id="image" loading="lazy"/>
+        <video id="other_tag" loading="lazy"/>
+        <iframe id="frame1" loading="lazy"/>
+        `);
+  });
+
+  it('drops loading from image tag', () => {
+    dropLoadingAttribute(dom.getElementById('image'));
+
+    expect(dom.getElementById('image').getAttribute('loading')).toBe(null);
+  });
+
+  it('drops loading from iframe tag', () => {
+    dropLoadingAttribute(dom.getElementById('frame1'));
+
+    expect(dom.getElementById('frame1').getAttribute('loading')).toBe(null);
+  });
+
+  it('does not drop loading from other tags', () => {
+    dropLoadingAttribute(dom.getElementById('other_tag'));
+
+    expect(dom.getElementById('other_tag').getAttribute('loading')).toBe('lazy');
+  });
+});

--- a/packages/dom/test/transform-dom.test.js
+++ b/packages/dom/test/transform-dom.test.js
@@ -1,34 +1,39 @@
 import { dropLoadingAttribute } from '../src/transform-dom';
-import { withExample } from './helpers';
+import { withExample, platforms, platformDOM } from './helpers';
 
 // Note: applyElementTransformations is tested in serialize-dom tests
 
-describe('dropLoadingAttribute', () => {
-  let dom;
+describe('transformDOM', () => {
+  describe('dropLoadingAttribute', () => {
+    let dom;
 
-  beforeEach(() => {
-    dom = withExample(`
-        <img id="image" loading="lazy"/>
-        <video id="other_tag" loading="lazy"/>
-        <iframe id="frame1" loading="lazy"/>
-        `);
-  });
+    platforms.forEach((platform) => {
+      beforeEach(() => {
+        withExample(`
+          <img id="image" loading="lazy"/>
+          <video id="other_tag" loading="lazy"/>
+          <iframe id="frame1" loading="lazy"/>
+        `, { withShadow: platform === 'shadow' });
+        dom = platformDOM(platform);
+      });
 
-  it('drops loading from image tag', () => {
-    dropLoadingAttribute(dom.getElementById('image'));
+      it(`${platform} drops loading from image tag`, () => {
+        dropLoadingAttribute(dom.getElementById('image'));
 
-    expect(dom.getElementById('image').getAttribute('loading')).toBe(null);
-  });
+        expect(dom.getElementById('image').getAttribute('loading')).toBe(null);
+      });
 
-  it('drops loading from iframe tag', () => {
-    dropLoadingAttribute(dom.getElementById('frame1'));
+      it(`${platform} drops loading from iframe tag`, () => {
+        dropLoadingAttribute(dom.getElementById('frame1'));
 
-    expect(dom.getElementById('frame1').getAttribute('loading')).toBe(null);
-  });
+        expect(dom.getElementById('frame1').getAttribute('loading')).toBe(null);
+      });
 
-  it('does not drop loading from other tags', () => {
-    dropLoadingAttribute(dom.getElementById('other_tag'));
+      it(`${platform} does not drop loading from other tags`, () => {
+        dropLoadingAttribute(dom.getElementById('other_tag'));
 
-    expect(dom.getElementById('other_tag').getAttribute('loading')).toBe('lazy');
+        expect(dom.getElementById('other_tag').getAttribute('loading')).toBe('lazy');
+      });
+    });
   });
 });


### PR DESCRIPTION
Context:
- We currently did not drop `loading="lazy"` attribute while serialising dom
- We do not scroll in discovery phase

Issue:
- We do not capture resources, especially `img` src where `loading="lazy"` attr is present and image is out of viewport
- So when we render it on percy, the full page screenshot shows broken images [ for out of first viewport images ]

Fix:
- We now drop `loading` attribute for `img` and `iframe` element