### PR TITLE
Add build info in percy-info

### DIFF
--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -140,6 +140,9 @@ export function createPercyServer(percy, port) {
       } else if (cmd === 'build-failure') {
         // the build-failure command will cause api errors to include a failed build
         percy.testing.build = { failed: true, error: 'Build failed' };
+      } else if (cmd === 'build-created') {
+        // the build-failure command will cause api errors to include a failed build
+        percy.testing.build = { id: '123', url: 'https://percy.io/test/test/123' };
       } else {
         // 404 for unknown commands
         return res.send(404);

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -364,6 +364,8 @@ describe('API Server', () => {
       expect(percy.testing).toEqual({});
       await post('/test/api/build-failure');
       expect(percy.testing).toHaveProperty('build', { failed: true, error: 'Build failed' });
+      await post('/test/api/build-created');
+      expect(percy.testing).toHaveProperty('build', { id: '123', url: 'https://percy.io/test/test/123' });
       await post('/test/api/error', '/percy/healthcheck');
       expect(percy.testing).toHaveProperty('api', { '/percy/healthcheck': 'error' });
       await post('/test/api/disconnect', '/percy/healthcheck');

--- a/packages/sdk-utils/src/percy-enabled.js
+++ b/packages/sdk-utils/src/percy-enabled.js
@@ -12,6 +12,7 @@ export async function isPercyEnabled() {
       let response = await request('/percy/healthcheck');
       percy.version = response.headers['x-percy-core-version'];
       percy.config = response.body.config;
+      percy.build = response.body.build;
       percy.enabled = true;
     } catch (e) {
       percy.enabled = false;

--- a/packages/sdk-utils/test/helpers.js
+++ b/packages/sdk-utils/test/helpers.js
@@ -4,6 +4,7 @@ const helpers = {
   async setupTest({ logger = true } = {}) {
     utils.percy.version = '';
     delete utils.percy.config;
+    delete utils.percy.build;
     delete utils.percy.enabled;
     delete utils.percy.domScript;
     delete utils.logger.log.history;

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -36,6 +36,7 @@ describe('SDK Utils', () => {
 
       beforeEach(async () => {
         await helpers.test('version', '1.2.3-beta.4');
+        await helpers.test('build-created');
         await expectAsync(isPercyEnabled()).toBeResolvedTo(true);
       });
 

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -51,6 +51,11 @@ describe('SDK Utils', () => {
       it('contains percy config', () => {
         expect(percy).toHaveProperty('config.snapshot.widths', [375, 1280]);
       });
+
+      it('contains percy build info', () => {
+        expect(percy.build).toHaveProperty('id', '123');
+        expect(percy.build).toHaveProperty('url', 'https://percy.io/test/test/123');
+      });
     });
   });
 


### PR DESCRIPTION
- For support of percy app:exec start/stop we need build id and url. adding as part of percy-info since we use sdk-utils in js SDK so we can make use of this and access using `percy.build.id` & `percy.build.url`