### PR TITLE
✨ Introduce new config option for cli-snapshot for enabling JS in asset discovery page

### DIFF
--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -1101,7 +1101,8 @@ describe('PercyConfig', () => {
         'Bar BAZ qux': 'xyzzy',
         'percy-css': '',
         'enable-javascript': false,
-        'disable-shadow-dom': true
+        'disable-shadow-dom': true,
+        'cli-enable-javascript': true
       })).toEqual({
         fooBar: 'baz',
         foo: { barBaz: 'qux' },
@@ -1109,7 +1110,8 @@ describe('PercyConfig', () => {
         barBazQux: 'xyzzy',
         percyCSS: '',
         enableJavaScript: false,
-        disableShadowDOM: true
+        disableShadowDOM: true,
+        cliEnableJavaScript: true
       });
     });
 
@@ -1120,14 +1122,16 @@ describe('PercyConfig', () => {
         fooBar_baz: ['qux'],
         percyCSS: '',
         enableJavaScript: false,
-        disableShadowDOM: true
+        disableShadowDOM: true,
+        cliEnableJavaScript: true
       }, { kebab: true })).toEqual({
         'foo-bar': 'baz',
         foo: { 'bar-baz': 'qux' },
         'foo-bar-baz': ['qux'],
         'percy-css': '',
         'enable-javascript': false,
-        'disable-shadow-dom': true
+        'disable-shadow-dom': true,
+        'cli-enable-javascript': true
       });
     });
 
@@ -1138,14 +1142,16 @@ describe('PercyConfig', () => {
         fooBar_baz: ['qux'],
         percyCSS: '',
         enableJavaScript: false,
-        disableShadowDOM: true
+        disableShadowDOM: true,
+        cliEnableJavaScript: true
       }, { snake: true })).toEqual({
         foo_bar: 'baz',
         foo: { bar_baz: 'qux' },
         foo_bar_baz: ['qux'],
         percy_css: '',
         enable_javascript: false,
-        disable_shadow_dom: true
+        disable_shadow_dom: true,
+        cli_enable_javascript: true
       });
     });
 

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -33,7 +33,12 @@ export const configSchema = {
         default: ''
       },
       enableJavaScript: {
-        type: 'boolean'
+        type: 'boolean',
+        default: false
+      },
+      cliEnableJavaScript: {
+        type: 'boolean',
+        default: true
       },
       disableShadowDOM: {
         type: 'boolean',
@@ -156,6 +161,7 @@ export const snapshotSchema = {
         minHeight: { $ref: '/config/snapshot#/properties/minHeight' },
         percyCSS: { $ref: '/config/snapshot#/properties/percyCSS' },
         enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },
+        cliEnableJavaScript: { $ref: '/config/snapshot#/properties/cliEnableJavaScript' },
         disableShadowDOM: { $ref: '/config/snapshot#/properties/disableShadowDOM' },
         domTransformation: { $ref: '/config/snapshot#/properties/domTransformation' },
         discovery: {

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -34,6 +34,7 @@ function debugSnapshotOptions(snapshot) {
   debugProp(snapshot, 'widths', v => `${v}px`);
   debugProp(snapshot, 'minHeight', v => `${v}px`);
   debugProp(snapshot, 'enableJavaScript');
+  debugProp(snapshot, 'cliEnableJavaScript');
   debugProp(snapshot, 'disableShadowDOM');
   debugProp(snapshot, 'deviceScaleFactor');
   debugProp(snapshot, 'waitForTimeout');
@@ -265,9 +266,13 @@ export function createDiscoveryQueue(percy) {
     .handle('task', async function*(snapshot, callback) {
       percy.log.debug(`Discovering resources: ${snapshot.name}`, snapshot.meta);
 
+      // expectation explained in tests
+      let assetDiscoveryPageEnableJS = (snapshot.cliEnableJavaScript && !snapshot.domSnapshot) || (snapshot.enableJavaScript ?? !snapshot.domSnapshot);
+
+      percy.log.debug(`Asset discovery Browser Page enable JS: ${assetDiscoveryPageEnableJS}`);
       // create a new browser page
       let page = yield percy.browser.page({
-        enableJavaScript: snapshot.enableJavaScript ?? !snapshot.domSnapshot,
+        enableJavaScript: assetDiscoveryPageEnableJS,
         networkIdleTimeout: snapshot.discovery.networkIdleTimeout,
         requestHeaders: snapshot.discovery.requestHeaders,
         authorization: snapshot.discovery.authorization,

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -267,6 +267,7 @@ export function createDiscoveryQueue(percy) {
       percy.log.debug(`Discovering resources: ${snapshot.name}`, snapshot.meta);
 
       // expectation explained in tests
+      /* istanbul ignore next: tested, but coverage is stripped */
       let assetDiscoveryPageEnableJS = (snapshot.cliEnableJavaScript && !snapshot.domSnapshot) || (snapshot.enableJavaScript ?? !snapshot.domSnapshot);
 
       percy.log.debug(`Asset discovery Browser Page enable JS: ${assetDiscoveryPageEnableJS}`);

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -1603,7 +1603,7 @@ describe('Discovery', () => {
     });
   });
 
-  fdescribe('Asset Discovery Page JS =>', () => {
+  describe('Asset Discovery Page JS =>', () => {
     beforeEach(() => {
       // global defaults
       percy.config.snapshot.enableJavaScript = false;

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -1602,4 +1602,187 @@ describe('Discovery', () => {
       );
     });
   });
+
+  fdescribe('Asset Discovery Page JS =>', () => {
+    beforeEach(() => {
+      // global defaults
+      percy.config.snapshot.enableJavaScript = false;
+      percy.config.snapshot.cliEnableJavaScript = true;
+    });
+
+    describe('cli-snapshot =>', () => {
+      it('enabled when enableJavascript: false and cliEnableJavaScript: true', async () => {
+        percy.loglevel('debug');
+
+        await percy.snapshot({
+          name: 'test snapshot',
+          url: 'http://localhost:8000',
+          domSnapshot: ''
+        });
+
+        await percy.idle();
+
+        expect(logger.stderr).toEqual(jasmine.arrayContaining([
+          '[percy:core:snapshot] - enableJavaScript: false',
+          '[percy:core:snapshot] - cliEnableJavaScript: true',
+          '[percy:core:snapshot] - domSnapshot: false',
+          '[percy:core] Asset discovery Browser Page enable JS: true'
+        ]));
+      });
+
+      it('enabled when enableJavascript: true and cliEnableJavaScript: true', async () => {
+        percy.config.snapshot.enableJavaScript = true;
+        percy.config.snapshot.cliEnableJavaScript = true;
+
+        percy.loglevel('debug');
+
+        await percy.snapshot({
+          name: 'test snapshot',
+          url: 'http://localhost:8000',
+          domSnapshot: ''
+        });
+
+        await percy.idle();
+
+        expect(logger.stderr).toEqual(jasmine.arrayContaining([
+          '[percy:core:snapshot] - enableJavaScript: true',
+          '[percy:core:snapshot] - cliEnableJavaScript: true',
+          '[percy:core:snapshot] - domSnapshot: false',
+          '[percy:core] Asset discovery Browser Page enable JS: true'
+        ]));
+      });
+
+      it('enabled when enableJavascript: true and cliEnableJavaScript: false', async () => {
+        percy.config.snapshot.enableJavaScript = true;
+        percy.config.snapshot.cliEnableJavaScript = false;
+
+        percy.loglevel('debug');
+
+        await percy.snapshot({
+          name: 'test snapshot',
+          url: 'http://localhost:8000',
+          domSnapshot: ''
+        });
+
+        await percy.idle();
+
+        expect(logger.stderr).toEqual(jasmine.arrayContaining([
+          '[percy:core:snapshot] - enableJavaScript: true',
+          '[percy:core:snapshot] - cliEnableJavaScript: false',
+          '[percy:core:snapshot] - domSnapshot: false',
+          '[percy:core] Asset discovery Browser Page enable JS: true'
+        ]));
+      });
+
+      it('disabled when enableJavascript: false and cliEnableJavaScript: false', async () => {
+        percy.config.snapshot.enableJavaScript = false;
+        percy.config.snapshot.cliEnableJavaScript = false;
+
+        percy.loglevel('debug');
+
+        await percy.snapshot({
+          name: 'test snapshot',
+          url: 'http://localhost:8000',
+          domSnapshot: ''
+        });
+
+        await percy.idle();
+
+        expect(logger.stderr).toEqual(jasmine.arrayContaining([
+          '[percy:core:snapshot] - enableJavaScript: false',
+          '[percy:core:snapshot] - cliEnableJavaScript: false',
+          '[percy:core:snapshot] - domSnapshot: false',
+          '[percy:core] Asset discovery Browser Page enable JS: false'
+        ]));
+      });
+    });
+
+    describe('percySnapshot with cli-exec =>', () => {
+      // cliEnableJavaScript has no effect
+      it('disabled when enableJavascript: false and cliEnableJavaScript: true', async () => {
+        percy.loglevel('debug');
+
+        await percy.snapshot({
+          name: 'test snapshot',
+          url: 'http://localhost:8000',
+          domSnapshot: testDOM
+        });
+
+        await percy.idle();
+
+        expect(logger.stderr).toEqual(jasmine.arrayContaining([
+          '[percy:core:snapshot] - enableJavaScript: false',
+          '[percy:core:snapshot] - cliEnableJavaScript: true',
+          '[percy:core:snapshot] - domSnapshot: true',
+          '[percy:core] Asset discovery Browser Page enable JS: false'
+        ]));
+      });
+
+      it('enabled when enableJavascript: true and cliEnableJavaScript: true', async () => {
+        percy.config.snapshot.enableJavaScript = true;
+        percy.config.snapshot.cliEnableJavaScript = true;
+
+        percy.loglevel('debug');
+
+        await percy.snapshot({
+          name: 'test snapshot',
+          url: 'http://localhost:8000',
+          domSnapshot: testDOM
+        });
+
+        await percy.idle();
+
+        expect(logger.stderr).toEqual(jasmine.arrayContaining([
+          '[percy:core:snapshot] - enableJavaScript: true',
+          '[percy:core:snapshot] - cliEnableJavaScript: true',
+          '[percy:core:snapshot] - domSnapshot: true',
+          '[percy:core] Asset discovery Browser Page enable JS: true'
+        ]));
+      });
+
+      it('enabled when enableJavascript: true and cliEnableJavaScript: false', async () => {
+        percy.config.snapshot.enableJavaScript = true;
+        percy.config.snapshot.cliEnableJavaScript = false;
+
+        percy.loglevel('debug');
+
+        await percy.snapshot({
+          name: 'test snapshot',
+          url: 'http://localhost:8000',
+          domSnapshot: testDOM
+        });
+
+        await percy.idle();
+
+        expect(logger.stderr).toEqual(jasmine.arrayContaining([
+          '[percy:core:snapshot] - enableJavaScript: true',
+          '[percy:core:snapshot] - cliEnableJavaScript: false',
+          '[percy:core:snapshot] - domSnapshot: true',
+          '[percy:core] Asset discovery Browser Page enable JS: true'
+        ]));
+      });
+
+      it('disabled when enableJavascript: false and cliEnableJavaScript: false', async () => {
+        percy.config.snapshot.enableJavaScript = false;
+        percy.config.snapshot.cliEnableJavaScript = false;
+
+        percy.loglevel('debug');
+
+        await percy.snapshot({
+          name: 'test snapshot',
+          url: 'http://localhost:8000',
+          domSnapshot: testDOM
+        });
+
+        await percy.idle();
+
+        expect(logger.stderr).toEqual(jasmine.arrayContaining([
+          '[percy:core:snapshot] - enableJavaScript: false',
+          '[percy:core:snapshot] - cliEnableJavaScript: false',
+          '[percy:core:snapshot] - domSnapshot: true',
+          '[percy:core] Asset discovery Browser Page enable JS: false'
+        ]));
+      });
+    });
+  });
 });

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -57,7 +57,9 @@ describe('Percy', () => {
       widths: [375, 1280],
       minHeight: 1024,
       percyCSS: '',
-      disableShadowDOM: false
+      enableJavaScript: false,
+      disableShadowDOM: false,
+      cliEnableJavaScript: true
     });
   });
 


### PR DESCRIPTION
* we now introduce a new config alongside the existing `enableJavaScript` called `cliEnableJavaScript`
* purpose for this new `cliEnableJavaScript`  flag is we'll use it to override Asset discovery browser page JS before taking dom Snapshot
  * since we take dom snapshot in CLI for only `cli-snapshot` ( or `percy snapshot` command) this doesn't affect `percySnapshot` ( or `percy exec --`) flow
 * This change is backwards compatible and doesn't affect existing users.
 * Tests are updated for a better understanding of the expectations.
