### PR TITLE
rewrite localhost domain for serialized assets to render.percy.local

### DIFF
--- a/packages/dom/src/utils.js
+++ b/packages/dom/src/utils.js
@@ -43,5 +43,5 @@ export function styleSheetFromNode(node) {
 
 export function rewriteLocalhostURL(url) {
   let baseURL = url.toString();
-  return baseURL.replace(/(http[s]{0,1}:\/\/)localhost[:\d+]*/, '$1render.percy.local')
+  return baseURL.replace(/(http[s]{0,1}:\/\/)localhost[:\d+]*/, '$1render.percy.local');
 }

--- a/packages/dom/src/utils.js
+++ b/packages/dom/src/utils.js
@@ -8,7 +8,7 @@ export function resourceFromDataURL(uid, dataURL) {
   // build a URL for the serialized asset
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
-  let url = document.URL.includes("localhost") ? new URL(path,"http://render.percy.local").toString() : new URL(path, document.URL).toString();
+  let url = document.URL.includes('localhost') ? new URL(path, 'http://render.percy.local').toString() : new URL(path, document.URL).toString();
 
   // return the url, base64 content, and mimetype
   return { url, content, mimetype };
@@ -18,7 +18,7 @@ export function resourceFromText(uid, mimetype, data) {
   // build a URL for the serialized asset
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
-  let url = document.URL.includes("localhost") ? new URL(path,"http://render.percy.local").toString() : new URL(path, document.URL).toString();
+  let url = document.URL.includes('localhost') ? new URL(path, 'http://render.percy.local').toString() : new URL(path, document.URL).toString();
   // return the url, text content, and mimetype
   return { url, content: data, mimetype };
 }

--- a/packages/dom/src/utils.js
+++ b/packages/dom/src/utils.js
@@ -8,7 +8,7 @@ export function resourceFromDataURL(uid, dataURL) {
   // build a URL for the serialized asset
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
-  let url = new URL(path, document.URL).toString();
+  let url = document.URL.includes("localhost") ? new URL(path,"http://render.percy.local").toString() : new URL(path, document.URL).toString();
 
   // return the url, base64 content, and mimetype
   return { url, content, mimetype };
@@ -18,8 +18,7 @@ export function resourceFromText(uid, mimetype, data) {
   // build a URL for the serialized asset
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
-  let url = new URL(path, document.URL).toString();
-
+  let url = document.URL.includes("localhost") ? new URL(path,"http://render.percy.local").toString() : new URL(path, document.URL).toString();
   // return the url, text content, and mimetype
   return { url, content: data, mimetype };
 }

--- a/packages/dom/src/utils.js
+++ b/packages/dom/src/utils.js
@@ -8,7 +8,7 @@ export function resourceFromDataURL(uid, dataURL) {
   // build a URL for the serialized asset
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
-  let url = new URL(path, rewriteLocalhostURL(document.URL)).toString();
+  let url = rewriteLocalhostURL(new URL(path, document.URL).toString());
 
   // return the url, base64 content, and mimetype
   return { url, content, mimetype };
@@ -18,7 +18,7 @@ export function resourceFromText(uid, mimetype, data) {
   // build a URL for the serialized asset
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
-  let url = new URL(path, rewriteLocalhostURL(document.URL)).toString();
+  let url = rewriteLocalhostURL(new URL(path, document.URL).toString());
   // return the url, text content, and mimetype
   return { url, content: data, mimetype };
 }
@@ -42,6 +42,5 @@ export function styleSheetFromNode(node) {
 }
 
 export function rewriteLocalhostURL(url) {
-  let baseURL = url.toString();
-  return baseURL.replace(/(http[s]{0,1}:\/\/)localhost[:\d+]*/, '$1render.percy.local');
+  return url.replace(/(http[s]{0,1}:\/\/)localhost[:\d+]*/, '$1render.percy.local');
 }

--- a/packages/dom/src/utils.js
+++ b/packages/dom/src/utils.js
@@ -8,7 +8,7 @@ export function resourceFromDataURL(uid, dataURL) {
   // build a URL for the serialized asset
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
-  let url = rewriteLocalhostURL(path)
+  let url = rewriteLocalhostURL(path);
 
   // return the url, base64 content, and mimetype
   return { url, content, mimetype };
@@ -18,7 +18,7 @@ export function resourceFromText(uid, mimetype, data) {
   // build a URL for the serialized asset
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
-  let url = rewriteLocalhostURL(path)
+  let url = rewriteLocalhostURL(path);
   // return the url, text content, and mimetype
   return { url, content: data, mimetype };
 }

--- a/packages/dom/src/utils.js
+++ b/packages/dom/src/utils.js
@@ -41,7 +41,6 @@ export function styleSheetFromNode(node) {
   return sheet;
 }
 
-export function rewriteLocalhostURL(path) {
-  let renderPercyURL = document.URL.replace(/(http[s]{0,1}:\/\/)localhost[:\d+]*/, '$1render.percy.local');
-  return document.URL.includes('localhost') ? new URL(path, renderPercyURL).toString() : new URL(path, document.URL).toString();
+function rewriteLocalhostURL(path) {
+  return new URL(path, document.URL.replace(/(http[s]{0,1}:\/\/)localhost[:\d+]*/, '$1render.percy.local')).toString();
 }

--- a/packages/dom/src/utils.js
+++ b/packages/dom/src/utils.js
@@ -8,7 +8,7 @@ export function resourceFromDataURL(uid, dataURL) {
   // build a URL for the serialized asset
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
-  let url = rewriteLocalhostURL(path);
+  let url = new URL(path, rewriteLocalhostURL(document.URL)).toString();
 
   // return the url, base64 content, and mimetype
   return { url, content, mimetype };
@@ -18,7 +18,7 @@ export function resourceFromText(uid, mimetype, data) {
   // build a URL for the serialized asset
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
-  let url = rewriteLocalhostURL(path);
+  let url = new URL(path, rewriteLocalhostURL(document.URL)).toString();
   // return the url, text content, and mimetype
   return { url, content: data, mimetype };
 }
@@ -41,6 +41,7 @@ export function styleSheetFromNode(node) {
   return sheet;
 }
 
-function rewriteLocalhostURL(path) {
-  return new URL(path, document.URL.replace(/(http[s]{0,1}:\/\/)localhost[:\d+]*/, '$1render.percy.local')).toString();
+export function rewriteLocalhostURL(url) {
+  let baseURL = url.toString();
+  return baseURL.replace(/(http[s]{0,1}:\/\/)localhost[:\d+]*/, '$1render.percy.local')
 }

--- a/packages/dom/src/utils.js
+++ b/packages/dom/src/utils.js
@@ -8,7 +8,7 @@ export function resourceFromDataURL(uid, dataURL) {
   // build a URL for the serialized asset
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
-  let url = document.URL.includes('localhost') ? new URL(path, 'http://render.percy.local').toString() : new URL(path, document.URL).toString();
+  let url = rewriteLocalhostURL(path)
 
   // return the url, base64 content, and mimetype
   return { url, content, mimetype };
@@ -18,7 +18,7 @@ export function resourceFromText(uid, mimetype, data) {
   // build a URL for the serialized asset
   let [, ext] = mimetype.split('/');
   let path = `/__serialized__/${uid}.${ext}`;
-  let url = document.URL.includes('localhost') ? new URL(path, 'http://render.percy.local').toString() : new URL(path, document.URL).toString();
+  let url = rewriteLocalhostURL(path)
   // return the url, text content, and mimetype
   return { url, content: data, mimetype };
 }
@@ -39,4 +39,9 @@ export function styleSheetFromNode(node) {
   tempStyle.remove();
 
   return sheet;
+}
+
+export function rewriteLocalhostURL(path) {
+  let renderPercyURL = document.URL.replace(/(http[s]{0,1}:\/\/)localhost[:\d+]*/, '$1render.percy.local');
+  return document.URL.includes('localhost') ? new URL(path, renderPercyURL).toString() : new URL(path, document.URL).toString();
 }

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -17,12 +17,12 @@ describe('utils', () => {
     const uid = (Math.random() + 1).toString(36).substring(10);
     const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+';
     it('If URL is localhost, replace it to render.percy.local', () => {
-    Object.defineProperty(window.document, 'URL', {
+      Object.defineProperty(window.document, 'URL', {
         writable: true,
         value: 'http://localhost'
-    });
-    const result = resourceFromDataURL(uid, dataURL);
-    expect(result).toEqual({
+      });
+      const result = resourceFromDataURL(uid, dataURL);
+      expect(result).toEqual({
         url: `http://render.percy.local/__serialized__/${uid}.png`,
         content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
         mimetype: 'image/png'
@@ -43,7 +43,6 @@ describe('utils', () => {
     it('Shouldve been called twice', () => {
       expect(spyResourceFromDataURL).toHaveBeenCalled();
       expect(spyResourceFromDataURL.calls.count()).toEqual(2);
-
     });
   });
   describe('resourceFromText', () => {
@@ -76,7 +75,7 @@ describe('utils', () => {
     });
     it('Shouldve been called twice', () => {
       expect(spyResourceFromText).toHaveBeenCalled();
-      expect(spyResourceFromDataURL.calls.count()).toEqual(2);
+      expect(spyResourceFromText.calls.count()).toEqual(2);
     });
   });
 });

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -13,15 +13,16 @@ describe('utils', () => {
   });
 
   describe('resourceFromDataURL', () => {
+    const spyResourceFromDataURL = spyOn(window, 'resourceFromDataURL').and.callThrough();
     const uid = (Math.random() + 1).toString(36).substring(10);
     const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+';
     it('If URL is localhost, replace it to render.percy.local', () => {
-      Object.defineProperty(window.document, 'URL', {
+    Object.defineProperty(window.document, 'URL', {
         writable: true,
         value: 'http://localhost'
-      });
-      const result = resourceFromDataURL(uid, dataURL);
-      expect(result).toEqual({
+    });
+    const result = resourceFromDataURL(uid, dataURL);
+    expect(result).toEqual({
         url: `http://render.percy.local/__serialized__/${uid}.png`,
         content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
         mimetype: 'image/png'
@@ -39,8 +40,14 @@ describe('utils', () => {
         mimetype: 'image/png'
       });
     });
+    it('Shouldve been called twice', () => {
+      expect(spyResourceFromDataURL).toHaveBeenCalled();
+      expect(spyResourceFromDataURL.calls.count()).toEqual(2);
+
+    });
   });
   describe('resourceFromText', () => {
+    const spyResourceFromText = spyOn(window, 'resourceFromText').and.callThrough();
     const uid = (Math.random() + 1).toString(36).substring(10);
     const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+';
     it('Replace localhost to render.percy.local', () => {
@@ -66,6 +73,10 @@ describe('utils', () => {
         content: dataURL,
         mimetype: 'image/png'
       });
+    });
+    it('Shouldve been called twice', () => {
+      expect(spyResourceFromText).toHaveBeenCalled();
+      expect(spyResourceFromDataURL.calls.count()).toEqual(2);
     });
   });
 });

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -77,7 +77,7 @@ describe('utils', () => {
       const case3 = rewriteLocalhostURL('http://localhost/hello');
       expect(case3).toEqual('http://render.percy.local/hello');
       const case4 = rewriteLocalhostURL('https://localhost:4000/hello');
-      expect(case4).toEqual('https://render.percy.local/hello')
+      expect(case4).toEqual('https://render.percy.local/hello');
     });
     it('Should not replace url', () => {
       const case1 = rewriteLocalhostURL('http://hello.com/localhost/');

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -1,11 +1,11 @@
-import { styleSheetFromNode, resourceFromDataURL, resourceFromText } from '../src/utils';
+import * as utilFunction from '../src/utils';
 describe('utils', () => {
   describe('styleSheetFromNode', () => {
     it('creates stylesheet properly', () => {
       const node = document.createElement('style');
       node.innerText = 'p { background-color: red }';
       const cloneSpy = spyOn(node, 'cloneNode').and.callThrough();
-      const sheet = styleSheetFromNode(node);
+      const sheet = utilFunction.styleSheetFromNode(node);
       expect(sheet.cssRules[0].cssText).toEqual('p { background-color: red; }');
       // nonce needs to be copied
       expect(cloneSpy).toHaveBeenCalled();
@@ -13,7 +13,6 @@ describe('utils', () => {
   });
 
   describe('resourceFromDataURL', () => {
-    const spyResourceFromDataURL = spyOn(window, 'resourceFromDataURL').and.callThrough();
     const uid = (Math.random() + 1).toString(36).substring(10);
     const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+';
     it('If URL is localhost, replace it to render.percy.local', () => {
@@ -21,7 +20,7 @@ describe('utils', () => {
         writable: true,
         value: 'http://localhost'
       });
-      const result = resourceFromDataURL(uid, dataURL);
+      const result = utilFunction.resourceFromDataURL(uid, dataURL);
       expect(result).toEqual({
         url: `http://render.percy.local/__serialized__/${uid}.png`,
         content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
@@ -33,20 +32,15 @@ describe('utils', () => {
         writable: true,
         value: 'http://example.com'
       });
-      const result = resourceFromDataURL(uid, dataURL);
+      const result = utilFunction.resourceFromDataURL(uid, dataURL);
       expect(result).toEqual({
         url: `http://example.com/__serialized__/${uid}.png`,
         content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
         mimetype: 'image/png'
       });
     });
-    it('Shouldve been called twice', () => {
-      expect(spyResourceFromDataURL).toHaveBeenCalled();
-      expect(spyResourceFromDataURL.calls.count()).toEqual(2);
-    });
   });
   describe('resourceFromText', () => {
-    const spyResourceFromText = spyOn(window, 'resourceFromText').and.callThrough();
     const uid = (Math.random() + 1).toString(36).substring(10);
     const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+';
     it('Replace localhost to render.percy.local', () => {
@@ -54,7 +48,7 @@ describe('utils', () => {
         writable: true,
         value: 'http://localhost'
       });
-      const result = resourceFromText(uid, 'image/png', dataURL);
+      const result = utilFunction.resourceFromText(uid, 'image/png', dataURL);
       expect(result).toEqual({
         url: `http://render.percy.local/__serialized__/${uid}.png`,
         content: dataURL,
@@ -66,16 +60,12 @@ describe('utils', () => {
         writable: true,
         value: 'http://example.com'
       });
-      const result = resourceFromText(uid, 'image/png', dataURL);
+      const result = utilFunction.resourceFromText(uid, 'image/png', dataURL);
       expect(result).toEqual({
         url: `http://example.com/__serialized__/${uid}.png`,
         content: dataURL,
         mimetype: 'image/png'
       });
-    });
-    it('Shouldve been called twice', () => {
-      expect(spyResourceFromText).toHaveBeenCalled();
-      expect(spyResourceFromText.calls.count()).toEqual(2);
     });
   });
 });

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -39,7 +39,7 @@ describe('utils', () => {
         mimetype: 'image/png'
       });
     });
-  });
+  });  
   describe('resourceFromText', () => {
     const uid = (Math.random() + 1).toString(36).substring(10);
     const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+';
@@ -66,6 +66,22 @@ describe('utils', () => {
         content: dataURL,
         mimetype: 'image/png'
       });
+    });
+  });
+  describe('rewriteLocalhostURL', () => {
+    it('should replace with render.percy.local', () => {
+      const case1 = utilFunction.rewriteLocalhostURL('https://localhost/hello')
+      expect(case1).toEqual('https://render.percy.local/hello')
+      const case2 = utilFunction.rewriteLocalhostURL('http://localhost:4000/hello')
+      expect(case2).toEqual('http://render.percy.local/hello')
+      const case3 = utilFunction.rewriteLocalhostURL('http://localhost/hello')
+      expect(case3).toEqual('http://render.percy.local/hello')
+    });
+    it('Should not replace url', () => {
+      const case1 = utilFunction.rewriteLocalhostURL('http://hello.com/localhost/')
+      expect(case1).toEqual('http://hello.com/localhost/')
+      const case2 = utilFunction.rewriteLocalhostURL('http://hello/world')
+      expect(case2).toEqual('http://hello/world')
     });
   });
 });

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -13,43 +13,37 @@ describe('utils', () => {
   });
 
   describe('resourceFromDataURL', () => {
-
     const uid = (Math.random() + 1).toString(36).substring(10);
-    const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+'
-
+    const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+';
     it('If URL is localhost, replace it to render.percy.local', () => {
-
       Object.defineProperty(window.document, 'URL', {
         writable: true,
-        value: 'http://localhost',
+        value: 'http://localhost'
       });
       const result = resourceFromDataURL(uid, dataURL);
       expect(result).toEqual({
         url: `http://render.percy.local/__serialized__/${uid}.png`,
         content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
-        mimetype: 'image/png',  
+        mimetype: 'image/png'  
       });
     });
-
     it('If URL is not localhost, return as is', () => {
       Object.defineProperty(window.document, 'URL', {
         writable: true,
-        value: 'http://example.com',
+        value: 'http://example.com'
       });
       const result = resourceFromDataURL(uid, dataURL);
       expect(result).toEqual({
         url: `http://example.com/__serialized__/${uid}.png`,
         content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
-        mimetype: 'image/png',        
+        mimetype: 'image/png'       
       });
     });
   })
   describe('resourceFromText', () => {
     const uid = (Math.random() + 1).toString(36).substring(10);
-    const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+'
-
+    const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+';
     it('Replace localhost to render.percy.local', () => {
-
       Object.defineProperty(window.document, 'URL', {
         writable: true,
         value: 'http://localhost',
@@ -61,17 +55,16 @@ describe('utils', () => {
         mimetype: 'image/png',  
       });
     });
-
     it('If URL is not localhost, return as is', () => {
       Object.defineProperty(window.document, 'URL', {
         writable: true,
-        value: 'http://example.com',
+        value: 'http://example.com'
       });
       const result = resourceFromText(uid, 'image/png', dataURL);
       expect(result).toEqual({
         url: `http://example.com/__serialized__/${uid}.png`,
         content: dataURL,
-        mimetype: 'image/png',        
+        mimetype: 'image/png'        
       });
     });
   })

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -1,5 +1,4 @@
-import { styleSheetFromNode } from '../src/utils';
-
+import { styleSheetFromNode, resourceFromDataURL, resourceFromText } from '../src/utils';
 describe('utils', () => {
   describe('styleSheetFromNode', () => {
     it('creates stylesheet properly', () => {
@@ -12,4 +11,68 @@ describe('utils', () => {
       expect(cloneSpy).toHaveBeenCalled();
     });
   });
+
+  describe('resourceFromDataURL', () => {
+
+    const uid = (Math.random() + 1).toString(36).substring(10);
+    const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+'
+
+    it('If URL is localhost, replace it to render.percy.local', () => {
+
+      Object.defineProperty(window.document, 'URL', {
+        writable: true,
+        value: 'http://localhost',
+      });
+      const result = resourceFromDataURL(uid, dataURL);
+      expect(result).toEqual({
+        url: `http://render.percy.local/__serialized__/${uid}.png`,
+        content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
+        mimetype: 'image/png',  
+      });
+    });
+
+    it('If URL is not localhost, return as is', () => {
+      Object.defineProperty(window.document, 'URL', {
+        writable: true,
+        value: 'http://example.com',
+      });
+      const result = resourceFromDataURL(uid, dataURL);
+      expect(result).toEqual({
+        url: `http://example.com/__serialized__/${uid}.png`,
+        content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
+        mimetype: 'image/png',        
+      });
+    });
+  })
+  describe('resourceFromText', () => {
+    const uid = (Math.random() + 1).toString(36).substring(10);
+    const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+'
+
+    it('Replace localhost to render.percy.local', () => {
+
+      Object.defineProperty(window.document, 'URL', {
+        writable: true,
+        value: 'http://localhost',
+      });
+      const result = resourceFromText(uid, 'image/png', dataURL);
+      expect(result).toEqual({
+        url: `http://render.percy.local/__serialized__/${uid}.png`,
+        content: dataURL,
+        mimetype: 'image/png',  
+      });
+    });
+
+    it('If URL is not localhost, return as is', () => {
+      Object.defineProperty(window.document, 'URL', {
+        writable: true,
+        value: 'http://example.com',
+      });
+      const result = resourceFromText(uid, 'image/png', dataURL);
+      expect(result).toEqual({
+        url: `http://example.com/__serialized__/${uid}.png`,
+        content: dataURL,
+        mimetype: 'image/png',        
+      });
+    });
+  })
 });

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -24,7 +24,7 @@ describe('utils', () => {
       expect(result).toEqual({
         url: `http://render.percy.local/__serialized__/${uid}.png`,
         content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
-        mimetype: 'image/png'  
+        mimetype: 'image/png'
       });
     });
     it('If URL is not localhost, return as is', () => {
@@ -36,23 +36,23 @@ describe('utils', () => {
       expect(result).toEqual({
         url: `http://example.com/__serialized__/${uid}.png`,
         content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
-        mimetype: 'image/png'       
+        mimetype: 'image/png'
       });
     });
-  })
+  });
   describe('resourceFromText', () => {
     const uid = (Math.random() + 1).toString(36).substring(10);
     const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+';
     it('Replace localhost to render.percy.local', () => {
       Object.defineProperty(window.document, 'URL', {
         writable: true,
-        value: 'http://localhost',
+        value: 'http://localhost'
       });
       const result = resourceFromText(uid, 'image/png', dataURL);
       expect(result).toEqual({
         url: `http://render.percy.local/__serialized__/${uid}.png`,
         content: dataURL,
-        mimetype: 'image/png',  
+        mimetype: 'image/png'
       });
     });
     it('If URL is not localhost, return as is', () => {
@@ -64,8 +64,8 @@ describe('utils', () => {
       expect(result).toEqual({
         url: `http://example.com/__serialized__/${uid}.png`,
         content: dataURL,
-        mimetype: 'image/png'        
+        mimetype: 'image/png'
       });
     });
-  })
+  });
 });

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -39,7 +39,7 @@ describe('utils', () => {
         mimetype: 'image/png'
       });
     });
-  });  
+  });
   describe('resourceFromText', () => {
     const uid = (Math.random() + 1).toString(36).substring(10);
     const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+';
@@ -70,18 +70,18 @@ describe('utils', () => {
   });
   describe('rewriteLocalhostURL', () => {
     it('should replace with render.percy.local', () => {
-      const case1 = utilFunction.rewriteLocalhostURL('https://localhost/hello')
-      expect(case1).toEqual('https://render.percy.local/hello')
-      const case2 = utilFunction.rewriteLocalhostURL('http://localhost:4000/hello')
-      expect(case2).toEqual('http://render.percy.local/hello')
-      const case3 = utilFunction.rewriteLocalhostURL('http://localhost/hello')
-      expect(case3).toEqual('http://render.percy.local/hello')
+      const case1 = utilFunction.rewriteLocalhostURL('https://localhost/hello');
+      expect(case1).toEqual('https://render.percy.local/hello');
+      const case2 = utilFunction.rewriteLocalhostURL('http://localhost:4000/hello');
+      expect(case2).toEqual('http://render.percy.local/hello');
+      const case3 = utilFunction.rewriteLocalhostURL('http://localhost/hello');
+      expect(case3).toEqual('http://render.percy.local/hello');
     });
     it('Should not replace url', () => {
-      const case1 = utilFunction.rewriteLocalhostURL('http://hello.com/localhost/')
-      expect(case1).toEqual('http://hello.com/localhost/')
-      const case2 = utilFunction.rewriteLocalhostURL('http://hello/world')
-      expect(case2).toEqual('http://hello/world')
+      const case1 = utilFunction.rewriteLocalhostURL('http://hello.com/localhost/');
+      expect(case1).toEqual('http://hello.com/localhost/');
+      const case2 = utilFunction.rewriteLocalhostURL('http://hello/world');
+      expect(case2).toEqual('http://hello/world');
     });
   });
 });

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -1,11 +1,11 @@
-import * as utilFunction from '../src/utils';
+import { resourceFromDataURL, resourceFromText, rewriteLocalhostURL, styleSheetFromNode } from '../src/utils';
 describe('utils', () => {
   describe('styleSheetFromNode', () => {
     it('creates stylesheet properly', () => {
       const node = document.createElement('style');
       node.innerText = 'p { background-color: red }';
       const cloneSpy = spyOn(node, 'cloneNode').and.callThrough();
-      const sheet = utilFunction.styleSheetFromNode(node);
+      const sheet = styleSheetFromNode(node);
       expect(sheet.cssRules[0].cssText).toEqual('p { background-color: red; }');
       // nonce needs to be copied
       expect(cloneSpy).toHaveBeenCalled();
@@ -20,7 +20,7 @@ describe('utils', () => {
         writable: true,
         value: 'http://localhost'
       });
-      const result = utilFunction.resourceFromDataURL(uid, dataURL);
+      const result = resourceFromDataURL(uid, dataURL);
       expect(result).toEqual({
         url: `http://render.percy.local/__serialized__/${uid}.png`,
         content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
@@ -32,7 +32,7 @@ describe('utils', () => {
         writable: true,
         value: 'http://example.com'
       });
-      const result = utilFunction.resourceFromDataURL(uid, dataURL);
+      const result = resourceFromDataURL(uid, dataURL);
       expect(result).toEqual({
         url: `http://example.com/__serialized__/${uid}.png`,
         content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
@@ -48,7 +48,7 @@ describe('utils', () => {
         writable: true,
         value: 'http://localhost'
       });
-      const result = utilFunction.resourceFromText(uid, 'image/png', dataURL);
+      const result = resourceFromText(uid, 'image/png', dataURL);
       expect(result).toEqual({
         url: `http://render.percy.local/__serialized__/${uid}.png`,
         content: dataURL,
@@ -60,7 +60,7 @@ describe('utils', () => {
         writable: true,
         value: 'http://example.com'
       });
-      const result = utilFunction.resourceFromText(uid, 'image/png', dataURL);
+      const result = resourceFromText(uid, 'image/png', dataURL);
       expect(result).toEqual({
         url: `http://example.com/__serialized__/${uid}.png`,
         content: dataURL,
@@ -70,18 +70,24 @@ describe('utils', () => {
   });
   describe('rewriteLocalhostURL', () => {
     it('should replace with render.percy.local', () => {
-      const case1 = utilFunction.rewriteLocalhostURL('https://localhost/hello');
+      const case1 = rewriteLocalhostURL('https://localhost/hello');
       expect(case1).toEqual('https://render.percy.local/hello');
-      const case2 = utilFunction.rewriteLocalhostURL('http://localhost:4000/hello');
+      const case2 = rewriteLocalhostURL('http://localhost:4000/hello');
       expect(case2).toEqual('http://render.percy.local/hello');
-      const case3 = utilFunction.rewriteLocalhostURL('http://localhost/hello');
+      const case3 = rewriteLocalhostURL('http://localhost/hello');
       expect(case3).toEqual('http://render.percy.local/hello');
+      const case4 = rewriteLocalhostURL('https://localhost:4000/hello');
+      expect(case4).toEqual('https://render.percy.local/hello')
     });
     it('Should not replace url', () => {
-      const case1 = utilFunction.rewriteLocalhostURL('http://hello.com/localhost/');
+      const case1 = rewriteLocalhostURL('http://hello.com/localhost/');
       expect(case1).toEqual('http://hello.com/localhost/');
-      const case2 = utilFunction.rewriteLocalhostURL('http://hello/world');
+      const case2 = rewriteLocalhostURL('http://hello/world');
       expect(case2).toEqual('http://hello/world');
+      const case3 = rewriteLocalhostURL('http://hellolocalhost:2000/world');
+      expect(case3).toEqual('http://hellolocalhost:2000/world');
+      const case4 = rewriteLocalhostURL('https://hellolocalhost:2000/world');
+      expect(case4).toEqual('https://hellolocalhost:2000/world');
     });
   });
 });


### PR DESCRIPTION
Issue: https://github.com/percy/cli/issues/1246

Difficulty in showing canvas serialized images on safari browser. Fixed by replacing `localhost`  with `render.percy.local`

read more here https://docs.percy.io/docs/browsers-specific-handling#localhost-proxy-support-on-safari