### PR TITLE
Add ability to pass in `page` to `getBuilds` method

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -131,6 +131,9 @@ await client.getBuilds(projectSlug)
 
 // get all builds for a project's "master" branch
 await client.getBuilds(projectSlug, { branch: 'master' })
+
+// get all builds for a project with limit
+await client.getBuilds(projectSlug, {}, { limit: 20 }) 
 ```
 
 #### Filters

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -177,17 +177,22 @@ export class PercyClient {
   }
 
   // Retrieves project builds optionally filtered. Requires a read access token.
-  async getBuilds(project, filters = {}) {
+  async getBuilds(project, filters = {}, page = {}) {
     validateProjectPath(project);
 
-    let qs = Object.keys(filters).map(k => (
-      Array.isArray(filters[k])
-        ? filters[k].map(v => `filter[${k}][]=${v}`).join('&')
-        : `filter[${k}]=${filters[k]}`
-    )).join('&');
+    let qs = this.#buildQueryString(filters, 'filter');
+    qs = qs.length && Object.keys(page).length ? qs + '&' : qs;
+    qs += this.#buildQueryString(page, 'page');
 
     this.log.debug(`Fetching builds for ${project}`);
     return this.get(`projects/${project}/builds?${qs}`);
+  }
+
+  #buildQueryString(arr, arrName) {
+    return Object.keys(arr).map(k => (Array.isArray(arr[k])
+      ? arr[k].map(v => `${arrName}[${k}][]=${v}`).join('&')
+      : `${arrName}[${k}]=${arr[k]}`
+    )).join('&');
   }
 
   // Resolves when the build has finished and is no longer pending or

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -4,12 +4,13 @@ import { git } from '@percy/env/utils';
 import logger from '@percy/logger';
 
 import {
+  buildQueryStringArrayFromObject,
   pool,
   request,
   sha256hash,
   base64encode,
   getPackageJSON,
-  waitForTimeout, buildQueryStringArrayFromObject
+  waitForTimeout
 } from './utils.js';
 
 // Default client API URL can be set with an env var for API development

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -9,7 +9,7 @@ import {
   sha256hash,
   base64encode,
   getPackageJSON,
-  waitForTimeout
+  waitForTimeout, buildQueryStringArrayFromObject
 } from './utils.js';
 
 // Default client API URL can be set with an env var for API development
@@ -180,19 +180,12 @@ export class PercyClient {
   async getBuilds(project, filters = {}, page = {}) {
     validateProjectPath(project);
 
-    let qs = this.#buildQueryString(filters, 'filter');
+    let qs = buildQueryStringArrayFromObject(filters, 'filter');
     qs = qs.length && Object.keys(page).length ? qs + '&' : qs;
-    qs += this.#buildQueryString(page, 'page');
+    qs += buildQueryStringArrayFromObject(page, 'page');
 
     this.log.debug(`Fetching builds for ${project}`);
     return this.get(`projects/${project}/builds?${qs}`);
-  }
-
-  #buildQueryString(arr, arrName) {
-    return Object.keys(arr).map(k => (Array.isArray(arr[k])
-      ? arr[k].map(v => `${arrName}[${k}][]=${v}`).join('&')
-      : `${arrName}[${k}]=${arr[k]}`
-    )).join('&');
   }
 
   // Resolves when the build has finished and is no longer pending or

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -19,6 +19,19 @@ export function base64encode(content) {
     .toString('base64');
 }
 
+/**
+ * Takes an object and builds a query string out of it
+ * @param obj       the object to iterate through and generate a query string with
+ * @param arrayKey  the array key for the query string params
+ * @return {string}
+ */
+export function buildQueryStringArrayFromObject(obj, arrayKey) {
+  return Object.keys(obj).map(k => (Array.isArray(obj[k])
+    ? obj[k].map(v => `${arrayKey}[${k}][]=${v}`).join('&')
+    : `${arrayKey}[${k}]=${obj[k]}`
+  )).join('&');
+}
+
 export function waitForTimeout() {
   return new Promise(resolve => setTimeout(resolve, ...arguments));
 }

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -320,6 +320,24 @@ describe('PercyClient', () => {
         .toBeResolvedTo({ data: ['<<build-data>>'] });
     });
 
+    it('get projects builds with "page" params', async() => {
+      api.reply('/projects/foo/bar/builds?page[cursor]=56789&page[limit]=150&page[project_id]=12345', () => (
+        [200, { data: ['<<build-data>>'] }]
+      ));
+
+      await expectAsync(client.getBuilds('foo/bar', {}, { cursor: '56789', limit: 150, project_id: '12345' }))
+        .toBeResolvedTo({ data: ['<<build-data>>'] });
+    })
+
+    it('get projects builds with "filter" and "page" params together', async() => {
+      api.reply('/projects/foo/bar/builds?filter[sha]=test-sha&page[cursor]=56789&page[limit]=150&page[project_id]=12345', () => (
+        [200, { data: ['<<build-data>>'] }]
+      ));
+
+      await expectAsync(client.getBuilds('foo/bar', { sha: 'test-sha' }, { cursor: '56789', limit: 150, project_id: '12345' }))
+        .toBeResolvedTo({ data: ['<<build-data>>'] });
+    })
+
     it('gets project builds data filtered by state, branch, and shas', async () => {
       api.reply('/projects/foo/bar/builds?' + [
         'filter[branch]=master',

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -321,20 +321,20 @@ describe('PercyClient', () => {
     });
 
     it('get projects builds with "page" params', async() => {
-      api.reply('/projects/foo/bar/builds?page[limit]=150', () => (
+      api.reply('/projects/foo/bar/builds?page[limit]=20', () => (
         [200, { data: ['<<build-data>>'] }]
       ));
 
-      await expectAsync(client.getBuilds('foo/bar', {}, { limit: 150 }))
+      await expectAsync(client.getBuilds('foo/bar', {}, { limit: 20 }))
         .toBeResolvedTo({ data: ['<<build-data>>'] });
     })
 
     it('get projects builds with "filter" and "page" params together', async() => {
-      api.reply('/projects/foo/bar/builds?filter[sha]=test-sha&page[limit]=150', () => (
+      api.reply('/projects/foo/bar/builds?filter[sha]=test-sha&page[cursor]=56789&page[limit]=20', () => (
         [200, { data: ['<<build-data>>'] }]
       ));
 
-      await expectAsync(client.getBuilds('foo/bar', { sha: 'test-sha' }, { limit: 150 }))
+      await expectAsync(client.getBuilds('foo/bar', { sha: 'test-sha' }, { cursor: '56789', limit: 20 }))
         .toBeResolvedTo({ data: ['<<build-data>>'] });
     })
 

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -321,20 +321,20 @@ describe('PercyClient', () => {
     });
 
     it('get projects builds with "page" params', async() => {
-      api.reply('/projects/foo/bar/builds?page[cursor]=56789&page[limit]=150&page[project_id]=12345', () => (
+      api.reply('/projects/foo/bar/builds?page[limit]=150', () => (
         [200, { data: ['<<build-data>>'] }]
       ));
 
-      await expectAsync(client.getBuilds('foo/bar', {}, { cursor: '56789', limit: 150, project_id: '12345' }))
+      await expectAsync(client.getBuilds('foo/bar', {}, { limit: 150 }))
         .toBeResolvedTo({ data: ['<<build-data>>'] });
     })
 
     it('get projects builds with "filter" and "page" params together', async() => {
-      api.reply('/projects/foo/bar/builds?filter[sha]=test-sha&page[cursor]=56789&page[limit]=150&page[project_id]=12345', () => (
+      api.reply('/projects/foo/bar/builds?filter[sha]=test-sha&page[limit]=150', () => (
         [200, { data: ['<<build-data>>'] }]
       ));
 
-      await expectAsync(client.getBuilds('foo/bar', { sha: 'test-sha' }, { cursor: '56789', limit: 150, project_id: '12345' }))
+      await expectAsync(client.getBuilds('foo/bar', { sha: 'test-sha' }, { limit: 150 }))
         .toBeResolvedTo({ data: ['<<build-data>>'] });
     })
 


### PR DESCRIPTION
This PR adds the ability to pass in `page` params into the `getBuilds` method.  Before the method only supported `filter`.

I've added it as a third argument because I did not want to break existing functionality.

I've tested this on my own project and works as expected.