### PR TITLE
✨ Update proxy.js to auto strip double quotes/spaces if any

### DIFF
--- a/packages/client/src/proxy.js
+++ b/packages/client/src/proxy.js
@@ -63,12 +63,15 @@ export function href(options) {
 // Returns the proxy URL for a set of request options
 export function getProxy(options) {
   let proxyUrl = (options.protocol === 'https:' &&
-    (stripQuotesAndSpaces(process.env.https_proxy) || stripQuotesAndSpaces(process.env.HTTPS_PROXY))) ||
-    (stripQuotesAndSpaces(process.env.http_proxy) || stripQuotesAndSpaces(process.env.HTTP_PROXY));
+    (process.env.https_proxy || process.env.HTTPS_PROXY)) ||
+    (process.env.http_proxy || process.env.HTTP_PROXY);
 
   let shouldProxy = !!proxyUrl && !hostnameMatches((
-    stripQuotesAndSpaces(process.env.no_proxy) || stripQuotesAndSpaces(process.env.NO_PROXY)
+    process.env.no_proxy || process.env.NO_PROXY
   ), href(options));
+
+  if (proxyUrl != null && typeof proxyUrl === 'string') { proxyUrl = stripQuotesAndSpaces(proxyUrl); }
+  if (shouldProxy != null && typeof shouldProxy === 'string') { shouldProxy = stripQuotesAndSpaces(shouldProxy); }
 
   if (shouldProxy) {
     proxyUrl = new URL(proxyUrl);

--- a/packages/client/src/proxy.js
+++ b/packages/client/src/proxy.js
@@ -66,12 +66,11 @@ export function getProxy(options) {
     (process.env.https_proxy || process.env.HTTPS_PROXY)) ||
     (process.env.http_proxy || process.env.HTTP_PROXY);
 
-  let shouldProxy = !!proxyUrl && !hostnameMatches((
-    process.env.no_proxy || process.env.NO_PROXY
-  ), href(options));
+  let shouldProxy = !!proxyUrl && !hostnameMatches(
+    stripQuotesAndSpaces(process.env.no_proxy || process.env.NO_PROXY)
+    , href(options));
 
-  if (proxyUrl != null && typeof proxyUrl === 'string') { proxyUrl = stripQuotesAndSpaces(proxyUrl); }
-  if (shouldProxy != null && typeof shouldProxy === 'string') { shouldProxy = stripQuotesAndSpaces(shouldProxy); }
+  if (proxyUrl && typeof proxyUrl === 'string') { proxyUrl = stripQuotesAndSpaces(proxyUrl); }
 
   if (shouldProxy) {
     proxyUrl = new URL(proxyUrl);

--- a/packages/client/src/proxy.js
+++ b/packages/client/src/proxy.js
@@ -59,14 +59,22 @@ export function href(options) {
     (path || `${pathname || ''}${search || ''}${hash || ''}`);
 };
 
+// auto strip double quotes/spaces if any
+function stripQuotesAndSpaces(line) {
+  if (line == null) {return null};
+  const regex = /^["\s"]+|["\s"]+$/g;
+  const strippedLine = line.replace(regex, '');
+  return strippedLine;
+}
+
 // Returns the proxy URL for a set of request options
 export function getProxy(options) {
   let proxyUrl = (options.protocol === 'https:' &&
-    (process.env.https_proxy || process.env.HTTPS_PROXY)) ||
-    (process.env.http_proxy || process.env.HTTP_PROXY);
+    (stripQuotesAndSpaces(process.env.https_proxy) || stripQuotesAndSpaces(process.env.HTTPS_PROXY))) ||
+    (stripQuotesAndSpaces(process.env.http_proxy) || stripQuotesAndSpaces(process.env.HTTP_PROXY));
 
   let shouldProxy = !!proxyUrl && !hostnameMatches((
-    process.env.no_proxy || process.env.NO_PROXY
+    stripQuotesAndSpaces(process.env.no_proxy) || stripQuotesAndSpaces(process.env.NO_PROXY)
   ), href(options));
 
   if (shouldProxy) {

--- a/packages/client/src/proxy.js
+++ b/packages/client/src/proxy.js
@@ -3,6 +3,7 @@ import tls from 'tls';
 import http from 'http';
 import https from 'https';
 import logger from '@percy/logger';
+import { stripQuotesAndSpaces } from '@percy/env/utils';
 
 const CRLF = '\r\n';
 const STATUS_REG = /^HTTP\/1.[01] (\d*)/;
@@ -58,14 +59,6 @@ export function href(options) {
   return `${protocol}//${hostname}:${port(options)}` +
     (path || `${pathname || ''}${search || ''}${hash || ''}`);
 };
-
-// auto strip double quotes/spaces if any
-function stripQuotesAndSpaces(line) {
-  if (line == null) {return null};
-  const regex = /^["\s"]+|["\s"]+$/g;
-  const strippedLine = line.replace(regex, '');
-  return strippedLine;
-}
 
 // Returns the proxy URL for a set of request options
 export function getProxy(options) {

--- a/packages/client/test/unit/request.test.js
+++ b/packages/client/test/unit/request.test.js
@@ -381,6 +381,20 @@ describe('Unit / Request', () => {
             expect(proxy.connects).toEqual([]);
           });
 
+          it('successfully proxies requests when `noProxy` is null or not string', async () => {
+            process.env.no_proxy = null;
+            proxyAgentFor.cache.clear();
+
+            await expectAsync(server.request('/test'))
+              .toBeResolvedTo('test proxied');
+
+            process.env.no_proxy = 1234;
+            proxyAgentFor.cache.clear();
+
+            await expectAsync(server.request('/test'))
+              .toBeResolvedTo('test proxied');
+          });
+
           it('does not proxy requests if the `noProxy` option is truthy', async () => {
             await expectAsync(server.request('/test', { noProxy: true }))
               .toBeResolvedTo('test');

--- a/packages/env/src/utils.js
+++ b/packages/env/src/utils.js
@@ -65,8 +65,9 @@ export function github({ GITHUB_EVENT_PATH }) {
 
 // auto strip double quotes/spaces if any
 export function stripQuotesAndSpaces(line) {
-  if (line == null) { return null; };
-  const regex = /^["\s"]+|["\s"]+$/g;
-  const strippedLine = line.replace(regex, '');
-  return strippedLine;
+  if (typeof line === 'string') {
+    const regex = /^["\s"]+|["\s"]+$/g;
+    const strippedLine = line.replace(regex, '');
+    return strippedLine;
+  } else { return null; };
 }

--- a/packages/env/src/utils.js
+++ b/packages/env/src/utils.js
@@ -62,3 +62,11 @@ export function github({ GITHUB_EVENT_PATH }) {
 
   return (github.payload ||= {});
 }
+
+// auto strip double quotes/spaces if any
+export function stripQuotesAndSpaces(line) {
+  if (line == null) { return null; };
+  const regex = /^["\s"]+|["\s"]+$/g;
+  const strippedLine = line.replace(regex, '');
+  return strippedLine;
+}

--- a/packages/env/test/stripQuotesAndSpaces.test.js
+++ b/packages/env/test/stripQuotesAndSpaces.test.js
@@ -21,4 +21,11 @@ describe('stripQuotesAndSpaces', () => {
     const actual = stripQuotesAndSpaces(line);
     expect(actual).toBe(expected);
   });
+
+  it('should return null if line is null', () => {
+    const line = null;
+    const expected = null;
+    const actual = stripQuotesAndSpaces(line);
+    expect(actual).toBe(expected);
+  });
 });

--- a/packages/env/test/stripQuotesAndSpaces.test.js
+++ b/packages/env/test/stripQuotesAndSpaces.test.js
@@ -1,0 +1,24 @@
+import { stripQuotesAndSpaces } from '@percy/env/utils';
+
+describe('stripQuotesAndSpaces', () => {
+  it('should remove leading and trailing spaces', () => {
+    const line = '  this is a line with spaces  ';
+    const expected = 'this is a line with spaces';
+    const actual = stripQuotesAndSpaces(line);
+    expect(actual).toBe(expected);
+  });
+
+  it('should remove leading and trailing double quotes', () => {
+    const line = '"this is a line with double quotes"';
+    const expected = 'this is a line with double quotes';
+    const actual = stripQuotesAndSpaces(line);
+    expect(actual).toBe(expected);
+  });
+
+  it('should remove both leading and trailing spaces and double quotes', () => {
+    const line = '" this is a line with spaces and double quotes  "';
+    const expected = 'this is a line with spaces and double quotes';
+    const actual = stripQuotesAndSpaces(line);
+    expect(actual).toBe(expected);
+  });
+});


### PR DESCRIPTION
Added a function `stripQuotesAndSpaces` in `env/utils.js` that removes double quotes or spaces present at starting or ending of a line.
Used it in `client/src/proxy.js` where environment variable are stored in `proxyURL` & `shouldProxy`