### PR TITLE
Added env var support for timeouts

### DIFF
--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -10,7 +10,7 @@ const ALLOWED_RESOURCES = ['Document', 'Stylesheet', 'Image', 'Media', 'Font', '
 // The Interceptor class creates common handlers for dealing with intercepting asset requests
 // for a given page using various devtools protocol events and commands.
 export class Network {
-  static TIMEOUT = 30000;
+  static TIMEOUT = undefined;
 
   log = logger('core:discovery');
 
@@ -29,6 +29,7 @@ export class Network {
       page.session.browser.version.userAgent.replace('Headless', '');
     this.intercept = options.intercept;
     this.meta = options.meta;
+    this._initializeNetworkIdleWaitTimeout();
   }
 
   watch(session) {
@@ -236,6 +237,18 @@ export class Network {
     }
 
     this._forgetRequest(request);
+  }
+
+  _initializeNetworkIdleWaitTimeout() {
+    if (Network.TIMEOUT) return;
+
+    Network.TIMEOUT = parseInt(process.env.PERCY_NETWORK_IDLE_WAIT_TIMEOUT) || 30000;
+
+    if (Network.TIMEOUT > 60000) {
+      this.log.warn('Setting PERCY_NETWORK_IDLE_WAIT_TIMEOUT over 60000ms is not recommended. ' +
+        'If your page needs more than 60000ms to idle due to CPU/Network load, ' +
+        'its recommended to increase CI resources where this cli is running.');
+    }
   }
 }
 

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -10,7 +10,7 @@ import {
 } from './utils.js';
 
 export class Page {
-  static TIMEOUT = 30000;
+  static TIMEOUT = undefined;
 
   log = logger('core:page');
 
@@ -20,6 +20,7 @@ export class Page {
     this.enableJavaScript = options.enableJavaScript ?? true;
     this.network = new Network(this, options);
     this.meta = options.meta;
+    this._initializeLoadTimeout();
 
     session.on('Runtime.executionContextCreated', this._handleExecutionContextCreated);
     session.on('Runtime.executionContextDestroyed', this._handleExecutionContextDestroyed);
@@ -235,6 +236,18 @@ export class Page {
 
   _handleExecutionContextsCleared = () => {
     this.contextId = null;
+  }
+
+  _initializeLoadTimeout() {
+    if (Page.TIMEOUT) return;
+
+    Page.TIMEOUT = parseInt(process.env.PERCY_PAGE_LOAD_TIMEOUT) || 30000;
+
+    if (Page.TIMEOUT > 60000) {
+      this.log.warn('Setting PERCY_PAGE_LOAD_TIMEOUT over 60000ms is not recommended. ' +
+        'If your page needs more than 60000ms to load due to CPU/Network load, ' +
+        'its recommended to increase CI resources where this cli is running.');
+    }
   }
 }
 

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -840,6 +840,7 @@ describe('Discovery', () => {
     });
 
     it('shows a warning when idle wait timeout is set over 60000ms', async () => {
+      percy.loglevel('debug');
       process.env.PERCY_NETWORK_IDLE_WAIT_TIMEOUT = 80000;
 
       await percy.snapshot({
@@ -848,7 +849,10 @@ describe('Discovery', () => {
       });
 
       expect(logger.stderr).toContain(jasmine.stringMatching(
-        '^\\[percy] Setting PERCY_NETWORK_IDLE_WAIT_TIMEOUT over 60000ms is not'
+        '^\\[percy:core:discovery] Wait for 100ms idle'
+      ));
+      expect(logger.stderr).toContain(jasmine.stringMatching(
+        '^\\[percy:core:discovery] Setting PERCY_NETWORK_IDLE_WAIT_TIMEOUT over 60000ms is not'
       ));
     });
   });
@@ -899,6 +903,9 @@ describe('Discovery', () => {
         url: 'http://localhost:8000'
       });
 
+      expect(logger.stderr).toContain(jasmine.stringMatching(
+        '^\\[percy:core:discovery] Wait for 100ms idle'
+      ));
       expect(logger.stderr).toContain(jasmine.stringMatching(
         '^\\[percy:core:page] Setting PERCY_PAGE_LOAD_TIMEOUT over 60000ms is not recommended.'
       ));


### PR DESCRIPTION
Added support for 2 flags as follows
1. `PERCY_NETWORK_IDLE_WAIT_TIMEOUT`: this flag is used to configure maximum time that percy cli would wait for network idle timeout to hit. i.e. if `networkIdleTimeout` is 600ms we would wait at most PERCY_NETWORK_IDLE_WAIT_TIMEOUT time to get a successful `networkIdleTimeout`.
2. `PERCY_PAGE_LOAD_TIMEOUT`: This is timeout for page_load event to fire on the page when we load page in the chromium.

Both of above are defaulted to 30000ms [ 30 sec ] and both would print a warning once per session when its set to over 60000ms [ 60 sec ].

We are adding this functionality so that in rare cases when someone wants to confirm that increasing timeout will solve the asset discovery issues for the page, they can confirm it by increasing the time.