### PR TITLE
chore: fix percy types exports for newer typescript

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -23,7 +23,10 @@
   "types": "./types/index.d.ts",
   "type": "module",
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./utils": "./dist/utils/index.js",
     "./test/helpers": "./test/helpers.js"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,10 @@
   "types": "./types/index.d.ts",
   "type": "module",
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./types/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./utils": "./dist/utils.js",
     "./config": "./dist/config.js",
     "./install": "./dist/install.js",


### PR DESCRIPTION
Fixes https://github.com/percy/cli/issues/1290

I have tested this via my own application, it resolves the error I was seeing detailed in the issue. I'm no expert at this but this makes sense to me.

Please let me know if there are other steps needed to have this released & published