### PR TITLE
feat: added support for extracting and passing header and footer heights

### DIFF
--- a/karma.config.cjs
+++ b/karma.config.cjs
@@ -23,6 +23,7 @@ module.exports = async config => {
       { pattern: 'test/**/*.test.js', type: 'module', watched: false },
       { pattern: 'test/assets/**', watched: false, included: false }
     ],
+// NOTE: Although sdk-utils test run in browser as well, we do not run sdk-utils/request test in browsers as we require creation of https server for this test
     exclude: [
       '**/test/request.test.js',
     ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,7 @@
     "@percy/config": "1.27.0-alpha.0",
     "@percy/dom": "1.27.0-alpha.0",
     "@percy/logger": "1.27.0-alpha.0",
+    "@percy/webdriver-utils": "1.27.0-alpha.0",
     "content-disposition": "^0.5.4",
     "cross-spawn": "^7.0.3",
     "extract-zip": "^2.0.1",

--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -4,9 +4,7 @@ import { createRequire } from 'module';
 import logger from '@percy/logger';
 import { normalize } from '@percy/config/utils';
 import { getPackageJSON, Server, percyAutomateRequestHandler } from './utils.js';
-// TODO Remove below esline disable once we publish webdriver-util
-import WebdriverUtils from '@percy/webdriver-utils'; // eslint-disable-line import/no-extraneous-dependencies
-
+import WebdriverUtils from '@percy/webdriver-utils';
 // need require.resolve until import.meta.resolve can be transpiled
 export const PERCY_DOM = createRequire(import.meta.url).resolve('@percy/dom');
 

--- a/packages/sdk-utils/test/request.test.js
+++ b/packages/sdk-utils/test/request.test.js
@@ -4,6 +4,7 @@ import http from 'http';
 import fs from 'fs';
 import path from 'path';
 
+// NOTE: Although sdk-utils test run in browser as well, we do not run sdk-utils/request test in browsers as we require creation of https server for this test
 const ssl = {
   cert: fs.readFileSync(path.join(__dirname, 'assets', 'certs', 'test.crt')),
   key: fs.readFileSync(path.join(__dirname, 'assets', 'certs', 'test.key'))

--- a/packages/webdriver-utils/src/index.js
+++ b/packages/webdriver-utils/src/index.js
@@ -33,11 +33,11 @@ export default class WebdriverUtils {
   }
 
   async automateScreenshot() {
-    log.info('Starting automate screenshot ...');
+    this.log.info('Starting automate screenshot ...');
     const automate = ProviderResolver.resolve(this.sessionId, this.commandExecutorUrl, this.capabilities, this.sessionCapabilites, this.clientInfo, this.environmentInfo, this.options, this.buildInfo);
-    log.debug('Resolved provider ...')
+    this.log.debug('Resolved provider ...')
     await automate.createDriver();
-    log.debug('Created driver ...')
+    this.log.debug('Created driver ...')
     return await automate.screenshot(this.snapshotName, this.options);
   }
 }

--- a/packages/webdriver-utils/src/index.js
+++ b/packages/webdriver-utils/src/index.js
@@ -35,9 +35,9 @@ export default class WebdriverUtils {
   async automateScreenshot() {
     this.log.info('Starting automate screenshot ...');
     const automate = ProviderResolver.resolve(this.sessionId, this.commandExecutorUrl, this.capabilities, this.sessionCapabilites, this.clientInfo, this.environmentInfo, this.options, this.buildInfo);
-    this.log.debug('Resolved provider ...')
+    this.log.debug('Resolved provider ...');
     await automate.createDriver();
-    this.log.debug('Created driver ...')
+    this.log.debug('Created driver ...');
     return await automate.screenshot(this.snapshotName, this.options);
   }
 }

--- a/packages/webdriver-utils/src/index.js
+++ b/packages/webdriver-utils/src/index.js
@@ -33,9 +33,11 @@ export default class WebdriverUtils {
   }
 
   async automateScreenshot() {
-    this.log.info('Starting automate screenshot');
+    log.info('Starting automate screenshot ...');
     const automate = ProviderResolver.resolve(this.sessionId, this.commandExecutorUrl, this.capabilities, this.sessionCapabilites, this.clientInfo, this.environmentInfo, this.options, this.buildInfo);
+    log.debug('Resolved provider ...')
     await automate.createDriver();
+    log.debug('Created driver ...')
     return await automate.screenshot(this.snapshotName, this.options);
   }
 }

--- a/packages/webdriver-utils/src/metadata/desktopMetaData.js
+++ b/packages/webdriver-utils/src/metadata/desktopMetaData.js
@@ -27,7 +27,7 @@ export default class DesktopMetaData {
 
   // combination of browserName + browserVersion + osVersion + osName
   deviceName() {
-    return this.browserName() + '_' + this.browserVersion() + '_' + this.osVersion() + '_' + this.osName();
+    return this.osName() + '_' + this.osVersion() + '_' + this.browserName() + '_' + this.browserVersion();
   }
 
   orientation() {

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -42,11 +42,11 @@ export default class AutomateProvider extends GenericProvider {
   }) {
     let response = null;
     let error;
-    log.info('Preparing to capture screenshots on automate ...')
+    log.info('Preparing to capture screenshots on automate ...');
     try {
-      log.debug('Marking automate session as percy ...')
+      log.debug('Marking automate session as percy ...');
       let result = await this.percyScreenshotBegin(name);
-      log.debug('Fetching the debug url ...')
+      log.debug('Fetching the debug url ...');
       this.setDebugUrl(result);
       response = await super.screenshot(name, { ignoreRegionXpaths, ignoreRegionSelectors, ignoreRegionElements, customIgnoreRegions });
     } catch (e) {
@@ -89,14 +89,14 @@ export default class AutomateProvider extends GenericProvider {
         });
       } catch (e) {
         log.debug(`[${name}] Could not execute percyScreenshot command for Automate`);
-        log.error(e)
+        log.error(e);
       }
     });
   }
 
   async getTiles(headerHeight, footerHeight, fullscreen) {
     if (!this.driver) throw new Error('Driver is null, please initialize driver with createDriver().');
-    log.info('Starting actual screenshotting phase')
+    log.info('Starting actual screenshotting phase');
 
     const response = await TimeIt.run('percyScreenshot:screenshot', async () => {
       return await this.browserstackExecutor('percyScreenshot', {

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -110,14 +110,13 @@ export default class AutomateProvider extends GenericProvider {
     const tiles = [];
     const tileResponse = JSON.parse(responseValue.result);
     log.debug('Tiles captured successfully');
-    const [header, footer] = await this.getHeaderFooter();
 
     for (let tileData of tileResponse.sha) {
       tiles.push(new Tile({
-        statusBarHeight: header,
-        navBarHeight: footer,
-        headerHeight: 0,
-        footerHeight: 0,
+        statusBarHeight: 0,
+        navBarHeight: 0,
+        headerHeight: this.header,
+        footerHeight: this.footer,
         fullscreen,
         sha: tileData.split('-')[0] // drop build id
       }));

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -42,8 +42,11 @@ export default class AutomateProvider extends GenericProvider {
   }) {
     let response = null;
     let error;
+    log.info('Preparing to capture screenshots on automate ...')
     try {
+      log.debug('Marking automate session as percy ...')
       let result = await this.percyScreenshotBegin(name);
+      log.debug('Fetching the debug url ...')
       this.setDebugUrl(result);
       response = await super.screenshot(name, { ignoreRegionXpaths, ignoreRegionSelectors, ignoreRegionElements, customIgnoreRegions });
     } catch (e) {
@@ -86,12 +89,14 @@ export default class AutomateProvider extends GenericProvider {
         });
       } catch (e) {
         log.debug(`[${name}] Could not execute percyScreenshot command for Automate`);
+        log.error(e)
       }
     });
   }
 
   async getTiles(headerHeight, footerHeight, fullscreen) {
     if (!this.driver) throw new Error('Driver is null, please initialize driver with createDriver().');
+    log.info('Starting actual screenshotting phase')
 
     const response = await TimeIt.run('percyScreenshot:screenshot', async () => {
       return await this.browserstackExecutor('percyScreenshot', {

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -109,11 +109,13 @@ export default class AutomateProvider extends GenericProvider {
 
     const tiles = [];
     const tileResponse = JSON.parse(responseValue.result);
+    log.debug('Tiles captured successfully');
+    const [header, footer] = await this.getHeaderFooter();
 
     for (let tileData of tileResponse.sha) {
       tiles.push(new Tile({
-        statusBarHeight: 0,
-        navBarHeight: 0,
+        statusBarHeight: header,
+        navBarHeight: footer,
         headerHeight: 0,
         footerHeight: 0,
         fullscreen,

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -88,7 +88,7 @@ export default class AutomateProvider extends GenericProvider {
     });
   }
 
-  async getTiles(fullscreen) {
+  async getTiles(headerHeight, footerHeight, fullscreen) {
     if (!this.driver) throw new Error('Driver is null, please initialize driver with createDriver().');
 
     const response = await TimeIt.run('percyScreenshot:screenshot', async () => {
@@ -115,8 +115,8 @@ export default class AutomateProvider extends GenericProvider {
       tiles.push(new Tile({
         statusBarHeight: 0,
         navBarHeight: 0,
-        headerHeight: this.header,
-        footerHeight: this.footer,
+        headerHeight,
+        footerHeight,
         fullscreen,
         sha: tileData.split('-')[0] // drop build id
       }));

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -85,7 +85,7 @@ export default class AutomateProvider extends GenericProvider {
           state: 'end'
         });
       } catch (e) {
-        log.debug(`[${name}] Could not mark Automate session as percy`);
+        log.debug(`[${name}] Could not execute percyScreenshot command for Automate`);
       }
     });
   }

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -174,7 +174,7 @@ export default class GenericProvider {
     const orientation = this.metaData.orientation();
     [this.header, this.footer] = await this.getHeaderFooter();
     // for android window size only constitutes of browser viewport, hence adding nav / status / url bar heights
-    height = this.capabilities.platformName && this.capabilities.platformName.toLowerCase() === 'android' ? height + this.header + this.footer : height;
+    height = this.metaData.osName() === 'android' ? height + this.header + this.footer : height;
     return {
       name: this.metaData.deviceName(),
       osName: this.metaData.osName(),

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -69,7 +69,9 @@ export default class GenericProvider {
 
   async createDriver() {
     this.driver = new Driver(this.sessionId, this.commandExecutorUrl);
+    log.debug(`Passed capabilities -> ${JSON.stringify(this.capabilities)}`)
     const caps = await this.driver.getCapabilites();
+    log.debug(`Fetched capabilities -> ${JSON.stringify(caps)}`)
     this.metaData = await MetaDataResolver.resolve(this.driver, caps, this.capabilities);
   }
 
@@ -114,19 +116,23 @@ export default class GenericProvider {
     this.addDefaultOptions();
 
     const percyCSS = (this.defaultPercyCSS() + (this.options.percyCSS || '')).split('\n').join('');
+    log.debug(`Applying the percyCSS - ${this.options.percyCSS}`)
     await this.addPercyCSS(percyCSS);
+
+    log.debug('Fetching comparisong tag ...');
     const tag = await this.getTag();
+    log.debug(`${name} : Tag ${JSON.stringify(tag)}`);
 
     const tiles = await this.getTiles(this.header, this.footer, fullscreen);
+    log.debug(`${name} : Tiles ${JSON.stringify(tiles)}`);
+
     const ignoreRegions = await this.findIgnoredRegions(
       ignoreRegionXpaths, ignoreRegionSelectors, ignoreRegionElements, customIgnoreRegions
     );
     await this.setDebugUrl();
-    await this.removePercyCSS();
-
-    log.debug(`${name} : Tag ${JSON.stringify(tag)}`);
-    log.debug(`${name} : Tiles ${JSON.stringify(tiles)}`);
     log.debug(`${name} : Debug url ${this.debugUrl}`);
+
+    await this.removePercyCSS();
     return {
       name,
       tag,

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -161,7 +161,6 @@ export default class GenericProvider {
       tiles: [
         new Tile({
           content: base64content,
-          // TODO: Need to add method to fetch these attr
           statusBarHeight: 0,
           navBarHeight: 0,
           headerHeight,
@@ -169,7 +168,7 @@ export default class GenericProvider {
           fullscreen
         })
       ],
-      // TODO: Add Generic support sha for contextual diff
+      // TODO: Add Generic support sha for contextual diff for non-automate
       domInfoSha: await this.getDomContent()
     };
   }
@@ -195,7 +194,7 @@ export default class GenericProvider {
     };
   }
 
-  // TODO: Add Debugging Url
+  // TODO: Add Debugging Url for non-automate
   async setDebugUrl() {
     this.debugUrl = 'https://localhost/v1';
   }

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -69,9 +69,9 @@ export default class GenericProvider {
 
   async createDriver() {
     this.driver = new Driver(this.sessionId, this.commandExecutorUrl);
-    log.debug(`Passed capabilities -> ${JSON.stringify(this.capabilities)}`)
+    log.debug(`Passed capabilities -> ${JSON.stringify(this.capabilities)}`);
     const caps = await this.driver.getCapabilites();
-    log.debug(`Fetched capabilities -> ${JSON.stringify(caps)}`)
+    log.debug(`Fetched capabilities -> ${JSON.stringify(caps)}`);
     this.metaData = await MetaDataResolver.resolve(this.driver, caps, this.capabilities);
   }
 
@@ -116,7 +116,7 @@ export default class GenericProvider {
     this.addDefaultOptions();
 
     const percyCSS = (this.defaultPercyCSS() + (this.options.percyCSS || '')).split('\n').join('');
-    log.debug(`Applying the percyCSS - ${this.options.percyCSS}`)
+    log.debug(`Applying the percyCSS - ${this.options.percyCSS}`);
     await this.addPercyCSS(percyCSS);
 
     log.debug('Fetching comparisong tag ...');

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -289,7 +289,7 @@ export default class GenericProvider {
 
   async getHeaderFooter() {
     const devicesConfig = (await request(DEVICES_CONFIG_URL)).body;
-    let deviceKey = this.capabilities.deviceModel ? this.capabilities.deviceModel : this.capabilities.deviceName;
+    let deviceKey = `${this.metaData.deviceName()}-${this.metaData.osVersion()}`
     let browserName = this.capabilities.browserName;
     return devicesConfig[deviceKey]
       ? (

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -169,16 +169,18 @@ export default class GenericProvider {
 
   async getTag() {
     if (!this.driver) throw new Error('Driver is null, please initialize driver with createDriver().');
-    const { width, height } = await this.metaData.windowSize();
+    let { width, height } = await this.metaData.windowSize();
     const resolution = await this.metaData.screenResolution();
     const orientation = this.metaData.orientation();
     [this.header, this.footer] = await this.getHeaderFooter();
+    // for android window size only constitutes of browser viewport, hence adding nav / status / url bar heights
+    height = this.capabilities.platformName && this.capabilities.platformName.toLowerCase() === "android" ? height + this.header + this.footer : height
     return {
       name: this.metaData.deviceName(),
       osName: this.metaData.osName(),
       osVersion: this.metaData.osVersion(),
       width,
-      height: height + this.header + this.footer,
+      height,
       orientation: orientation,
       browserName: this.metaData.browserName(),
       browserVersion: this.metaData.browserVersion(),

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -5,7 +5,7 @@ import Tile from '../util/tile.js';
 import Driver from '../driver.js';
 const { request } = utils;
 
-const DEVICES_CONFIG_URL = 'https://storage.googleapis.com/percy-utils/devices.json'
+const DEVICES_CONFIG_URL = 'https://storage.googleapis.com/percy-utils/devices.json';
 const log = utils.logger('webdriver-utils:genericProvider');
 
 export default class GenericProvider {
@@ -250,14 +250,14 @@ export default class GenericProvider {
   }
 
   async getHeaderFooter() {
-    const devicesConfig = (await request(DEVICES_CONFIG_URL)).body
-    let deviceKey = this.capabilities['deviceModel'] ? this.capabilities['deviceModel'] : this.capabilities['deviceName']
-    let browserName = this.capabilities['browserName']
-    return devicesConfig[deviceKey] ?
-      (
-        devicesConfig[deviceKey][browserName] ?
-        [devicesConfig[deviceKey][browserName]['header'], devicesConfig[deviceKey][browserName]['footer']] :
-        [0,0]
-      ) : [0,0]
+    const devicesConfig = (await request(DEVICES_CONFIG_URL)).body;
+    let deviceKey = this.capabilities.deviceModel ? this.capabilities.deviceModel : this.capabilities.deviceName;
+    let browserName = this.capabilities.browserName;
+    return devicesConfig[deviceKey]
+      ? (
+          devicesConfig[deviceKey][browserName]
+            ? [devicesConfig[deviceKey][browserName].header, devicesConfig[deviceKey][browserName].footer]
+            : [0, 0]
+        ) : [0, 0];
   }
 }

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -3,6 +3,7 @@ import utils from '@percy/sdk-utils';
 import MetaDataResolver from '../metadata/metaDataResolver.js';
 import Tile from '../util/tile.js';
 import Driver from '../driver.js';
+import Cache from '../util/cache.js';
 const { request } = utils;
 
 const DEVICES_CONFIG_URL = 'https://storage.googleapis.com/percy-utils/devices.json';
@@ -294,7 +295,10 @@ export default class GenericProvider {
   }
 
   async getHeaderFooter() {
-    const devicesConfig = (await request(DEVICES_CONFIG_URL)).body;
+    // passing 0 as key, since across different pages and tests, this config will remain same
+    const devicesConfig = await Cache.withCache(Cache.devicesConfig, 0, async() => {
+      return (await request(DEVICES_CONFIG_URL)).body
+    });
     let deviceKey = `${this.metaData.deviceName()}-${this.metaData.osVersion()}`;
     let browserName = this.capabilities.browserName;
     return devicesConfig[deviceKey]

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -289,7 +289,7 @@ export default class GenericProvider {
 
   async getHeaderFooter() {
     const devicesConfig = (await request(DEVICES_CONFIG_URL)).body;
-    let deviceKey = `${this.metaData.deviceName()}-${this.metaData.osVersion()}`
+    let deviceKey = `${this.metaData.deviceName()}-${this.metaData.osVersion()}`;
     let browserName = this.capabilities.browserName;
     return devicesConfig[deviceKey]
       ? (

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -83,7 +83,7 @@ export default class GenericProvider {
     await this.addPercyCSS(percyCSS);
     const tag = await this.getTag();
 
-    const tiles = await this.getTiles(fullscreen);
+    const tiles = await this.getTiles(this.header, this.footer, fullscreen);
     const ignoreRegions = await this.findIgnoredRegions(
       ignoreRegionXpaths, ignoreRegionSelectors, ignoreRegionElements, customIgnoreRegions
     );
@@ -112,7 +112,7 @@ export default class GenericProvider {
     return 'dummyValue';
   }
 
-  async getTiles(fullscreen) {
+  async getTiles(headerHeight, footerHeight, fullscreen) {
     if (!this.driver) throw new Error('Driver is null, please initialize driver with createDriver().');
     const base64content = await this.driver.takeScreenshot();
     log.debug('Tiles captured successfully');
@@ -123,8 +123,8 @@ export default class GenericProvider {
           // TODO: Need to add method to fetch these attr
           statusBarHeight: 0,
           navBarHeight: 0,
-          headerHeight: this.header,
-          footerHeight: this.footer,
+          headerHeight,
+          footerHeight,
           fullscreen
         })
       ],

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -296,8 +296,8 @@ export default class GenericProvider {
 
   async getHeaderFooter() {
     // passing 0 as key, since across different pages and tests, this config will remain same
-    const devicesConfig = await Cache.withCache(Cache.devicesConfig, 0, async() => {
-      return (await request(DEVICES_CONFIG_URL)).body
+    const devicesConfig = await Cache.withCache(Cache.devicesConfig, 0, async () => {
+      return (await request(DEVICES_CONFIG_URL)).body;
     });
     let deviceKey = `${this.metaData.deviceName()}-${this.metaData.osVersion()}`;
     let browserName = this.capabilities.browserName;

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -174,7 +174,7 @@ export default class GenericProvider {
     const orientation = this.metaData.orientation();
     [this.header, this.footer] = await this.getHeaderFooter();
     // for android window size only constitutes of browser viewport, hence adding nav / status / url bar heights
-    height = this.capabilities.platformName && this.capabilities.platformName.toLowerCase() === "android" ? height + this.header + this.footer : height
+    height = this.capabilities.platformName && this.capabilities.platformName.toLowerCase() === 'android' ? height + this.header + this.footer : height;
     return {
       name: this.metaData.deviceName(),
       osName: this.metaData.osName(),

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -31,6 +31,8 @@ export default class GenericProvider {
     this.driver = null;
     this.metaData = null;
     this.debugUrl = null;
+    this.header = 0;
+    this.footer = 0;
   }
 
   async createDriver() {
@@ -114,16 +116,15 @@ export default class GenericProvider {
     if (!this.driver) throw new Error('Driver is null, please initialize driver with createDriver().');
     const base64content = await this.driver.takeScreenshot();
     log.debug('Tiles captured successfully');
-    const [header, footer] = await this.getHeaderFooter();
     return {
       tiles: [
         new Tile({
           content: base64content,
           // TODO: Need to add method to fetch these attr
-          statusBarHeight: header,
-          navBarHeight: footer,
-          headerHeight: 0,
-          footerHeight: 0,
+          statusBarHeight: 0,
+          navBarHeight: 0,
+          headerHeight: this.header,
+          footerHeight: this.footer,
           fullscreen
         })
       ],
@@ -137,12 +138,13 @@ export default class GenericProvider {
     const { width, height } = await this.metaData.windowSize();
     const resolution = await this.metaData.screenResolution();
     const orientation = this.metaData.orientation();
+    [this.header, this.footer] = await this.getHeaderFooter();
     return {
       name: this.metaData.deviceName(),
       osName: this.metaData.osName(),
       osVersion: this.metaData.osVersion(),
       width,
-      height,
+      height: height + this.header + this.footer,
       orientation: orientation,
       browserName: this.metaData.browserName(),
       browserVersion: this.metaData.browserVersion(),

--- a/packages/webdriver-utils/src/util/cache.js
+++ b/packages/webdriver-utils/src/util/cache.js
@@ -9,6 +9,7 @@ export default class Cache {
   static caps = 'caps';
   static bstackSessionDetails = 'bstackSessionDetails';
   static systemBars = 'systemBars';
+  static devicesConfig = 'devicesConfig';
 
   // maintainance
   static lastTime = Date.now();

--- a/packages/webdriver-utils/test/metadata/desktopMetaData.test.js
+++ b/packages/webdriver-utils/test/metadata/desktopMetaData.test.js
@@ -55,7 +55,7 @@ describe('DesktopMetaData', () => {
 
   describe('deviceName', () => {
     it('calculates deviceName', () => {
-      expect(desktopMetaData.deviceName()).toEqual('chrome_111_10_win');
+      expect(desktopMetaData.deviceName()).toEqual('win_10_chrome_111');
     });
   });
 

--- a/packages/webdriver-utils/test/providers/automateProvider.test.js
+++ b/packages/webdriver-utils/test/providers/automateProvider.test.js
@@ -183,8 +183,8 @@ describe('AutomateProvider', () => {
       expect(res.tiles[1]).toBeInstanceOf(Tile);
       expect(res.tiles[0].sha).toEqual('abc');
       expect(res.tiles[1].sha).toEqual('xyz');
-      expect(res.tiles[0].statusBarHeight).toEqual(123);
-      expect(res.tiles[0].navBarHeight).toEqual(456);
+      expect(res.tiles[0].headerHeight).toEqual(0);
+      expect(res.tiles[0].footerHeight).toEqual(0);
     });
 
     it('throws error when response is false', async () => {

--- a/packages/webdriver-utils/test/providers/automateProvider.test.js
+++ b/packages/webdriver-utils/test/providers/automateProvider.test.js
@@ -173,7 +173,7 @@ describe('AutomateProvider', () => {
 
     it('should return tiles when success', async () => {
       await automateProvider.createDriver();
-      const res = await automateProvider.getTiles(false);
+      const res = await automateProvider.getTiles(123, 456, false);
       expect(browserstackExecutorSpy).toHaveBeenCalledTimes(1);
       expect(executeScriptSpy).toHaveBeenCalledTimes(1);
       expect(Object.keys(res).length).toEqual(2);
@@ -183,8 +183,10 @@ describe('AutomateProvider', () => {
       expect(res.tiles[1]).toBeInstanceOf(Tile);
       expect(res.tiles[0].sha).toEqual('abc');
       expect(res.tiles[1].sha).toEqual('xyz');
-      expect(res.tiles[0].headerHeight).toEqual(0);
-      expect(res.tiles[0].footerHeight).toEqual(0);
+      expect(res.tiles[0].headerHeight).toEqual(123);
+      expect(res.tiles[0].footerHeight).toEqual(456);
+      expect(res.tiles[0].navBarHeight).toEqual(0);
+      expect(res.tiles[0].statusBarHeight).toEqual(0);
     });
 
     it('throws error when response is false', async () => {

--- a/packages/webdriver-utils/test/providers/automateProvider.test.js
+++ b/packages/webdriver-utils/test/providers/automateProvider.test.js
@@ -164,6 +164,7 @@ describe('AutomateProvider', () => {
 
     beforeEach(async () => {
       spyOn(Driver.prototype, 'getCapabilites');
+      spyOn(GenericProvider.prototype, 'getHeaderFooter').and.returnValue(Promise.resolve([123, 456]));
       browserstackExecutorSpy = spyOn(AutomateProvider.prototype, 'browserstackExecutor')
         .and.returnValue(Promise.resolve({ value: '{ "result": "{\\"dom_sha\\": \\"abc\\", \\"sha\\": [\\"abc-1\\", \\"xyz-2\\"]}", "success":true }' }));
       executeScriptSpy = spyOn(Driver.prototype, 'executeScript')
@@ -182,6 +183,8 @@ describe('AutomateProvider', () => {
       expect(res.tiles[1]).toBeInstanceOf(Tile);
       expect(res.tiles[0].sha).toEqual('abc');
       expect(res.tiles[1].sha).toEqual('xyz');
+      expect(res.tiles[0].statusBarHeight).toEqual(123);
+      expect(res.tiles[0].navBarHeight).toEqual(456);
     });
 
     it('throws error when response is false', async () => {

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -4,6 +4,7 @@ import MetaDataResolver from '../../src/metadata/metaDataResolver.js';
 import DesktopMetaData from '../../src/metadata/desktopMetaData.js';
 import Cache from '../../src/util/cache.js';
 import MobileMetaData from '../../src/metadata/mobileMetaData.js';
+import utils from '@percy/sdk-utils';
 
 describe('GenericProvider', () => {
   let genericProvider;
@@ -416,14 +417,18 @@ describe('GenericProvider', () => {
     it('should return the matching header and footer', async () => {
       await provider.createDriver();
       let mockResponseObject = {
-        'iPhone 12 Pro-13': {
-          safari: {
-            header: 141,
-            footer: 399
+        body: {
+          'iPhone 12 Pro-13': {
+            safari: {
+              header: 141,
+              footer: 399
+            }
           }
-        }
+        },
+        status: 200,
+        headers: { 'content-type': 'application/json' }
       };
-      spyOn(Cache, 'withCache').and.returnValue(
+      spyOn(utils.request, 'fetch').and.returnValue(
         Promise.resolve(mockResponseObject)
       );
       const [header, footer] = await provider.getHeaderFooter();

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -42,8 +42,8 @@ describe('GenericProvider', () => {
       genericProvider.createDriver();
       const tiles = await genericProvider.getTiles(false);
       expect(tiles.tiles.length).toEqual(1);
-      expect(tiles.tiles[0].statusBarHeight).toEqual(123);
-      expect(tiles.tiles[0].navBarHeight).toEqual(456);
+      expect(tiles.tiles[0].statusBarHeight).toEqual(0);
+      expect(tiles.tiles[0].navBarHeight).toEqual(0);
       expect(Object.keys(tiles)).toContain('domInfoSha');
     });
 
@@ -71,6 +71,7 @@ describe('GenericProvider', () => {
         .and.returnValue('111');
       spyOn(DesktopMetaData.prototype, 'screenResolution')
         .and.returnValue('1980 x 1080');
+      spyOn(GenericProvider.prototype, 'getHeaderFooter').and.returnValue(Promise.resolve([123, 456]));
     });
 
     it('returns correct tag', async () => {
@@ -82,7 +83,7 @@ describe('GenericProvider', () => {
         osName: 'mockOsName',
         osVersion: 'mockOsVersion',
         width: 1000,
-        height: 1000,
+        height: 1000 + 123 + 456,
         orientation: 'landscape',
         browserName: 'mockBrowserName',
         browserVersion: '111',

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -40,10 +40,12 @@ describe('GenericProvider', () => {
     it('creates tiles from screenshot', async () => {
       genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
       genericProvider.createDriver();
-      const tiles = await genericProvider.getTiles(false);
+      const tiles = await genericProvider.getTiles(123, 456, false);
       expect(tiles.tiles.length).toEqual(1);
-      expect(tiles.tiles[0].footerHeight).toEqual(0);
-      expect(tiles.tiles[0].headerHeight).toEqual(0);
+      expect(tiles.tiles[0].navBarHeight).toEqual(0);
+      expect(tiles.tiles[0].statusBarHeight).toEqual(0);
+      expect(tiles.tiles[0].footerHeight).toEqual(456);
+      expect(tiles.tiles[0].headerHeight).toEqual(123);
       expect(Object.keys(tiles)).toContain('domInfoSha');
     });
 
@@ -118,7 +120,7 @@ describe('GenericProvider', () => {
       let res = await genericProvider.screenshot('mock-name', {});
       expect(addPercyCSSSpy).toHaveBeenCalledTimes(1);
       expect(getTagSpy).toHaveBeenCalledTimes(1);
-      expect(getTilesSpy).toHaveBeenCalledOnceWith(false);
+      expect(getTilesSpy).toHaveBeenCalledOnceWith(0,0,false);
       expect(removePercyCSSSpy).toHaveBeenCalledTimes(1);
       expect(res).toEqual({
         name: 'mock-name',

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -408,13 +408,16 @@ describe('GenericProvider', () => {
     let provider;
 
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { browserName: 'safari', deviceName: 'iPhone 12 Pro' }, {});
+      provider = new GenericProvider('123', 'http:executorUrl', { browserName: 'safari', deviceName: 'iPhone 12 Pro', platform: 'iOS' }, {});
+      spyOn(MobileMetaData.prototype, 'deviceName').and.returnValue('iPhone 12 Pro')
+      spyOn(MobileMetaData.prototype, 'osVersion').and.returnValue('13')
     });
 
     it('should return the matching header and footer', async () => {
+      await provider.createDriver()
       let mockResponseObject = {
         body: {
-          'iPhone 12 Pro': {
+          'iPhone 12 Pro-13': {
             safari: {
               header: 141,
               footer: 399
@@ -433,9 +436,10 @@ describe('GenericProvider', () => {
     });
 
     it('should return 0,0 for unmatched device name', async () => {
+      await provider.createDriver()
       let mockResponseObject = {
         body: {
-          'iPhone 13 Pro': {
+          'iPhone 13 Pro-14': {
             safari: {
               header: 141,
               footer: 399
@@ -454,9 +458,10 @@ describe('GenericProvider', () => {
     });
 
     it('should return 0,0 for unmatched browser name', async () => {
+      await provider.createDriver()
       let mockResponseObject = {
         body: {
-          'iPhone 12 Pro': {
+          'iPhone 12 Pro-13': {
             chrome: {
               header: 141,
               footer: 399

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -80,8 +80,6 @@ describe('GenericProvider', () => {
         .and.returnValue('landscape');
       spyOn(MobileMetaData.prototype, 'deviceName')
         .and.returnValue('mockDeviceName');
-      spyOn(MobileMetaData.prototype, 'osName')
-        .and.returnValue('mockOsName');
       spyOn(MobileMetaData.prototype, 'osVersion')
         .and.returnValue('mockOsVersion');
       spyOn(MobileMetaData.prototype, 'browserName')
@@ -95,11 +93,12 @@ describe('GenericProvider', () => {
 
     it('returns correct tag for android', async () => {
       genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'android', platformName: 'android' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
+      spyOn(MobileMetaData.prototype, 'osName').and.returnValue('android');
       await genericProvider.createDriver();
       const tag = await genericProvider.getTag();
       expect(tag).toEqual({
         name: 'mockDeviceName',
-        osName: 'mockOsName',
+        osName: 'android',
         osVersion: 'mockOsVersion',
         width: 1000,
         height: 1000 + 123 + 456,
@@ -112,6 +111,7 @@ describe('GenericProvider', () => {
 
     it('returns correct tag for others', async () => {
       genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
+      spyOn(MobileMetaData.prototype, 'osName').and.returnValue('mockOsName');
       await genericProvider.createDriver();
       const tag = await genericProvider.getTag();
       expect(tag).toEqual({

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -42,8 +42,8 @@ describe('GenericProvider', () => {
       genericProvider.createDriver();
       const tiles = await genericProvider.getTiles(false);
       expect(tiles.tiles.length).toEqual(1);
-      expect(tiles.tiles[0].statusBarHeight).toEqual(0);
-      expect(tiles.tiles[0].navBarHeight).toEqual(0);
+      expect(tiles.tiles[0].footerHeight).toEqual(0);
+      expect(tiles.tiles[0].headerHeight).toEqual(0);
       expect(Object.keys(tiles)).toContain('domInfoSha');
     });
 

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -3,6 +3,7 @@ import Driver from '../../src/driver.js';
 import MetaDataResolver from '../../src/metadata/metaDataResolver.js';
 import DesktopMetaData from '../../src/metadata/desktopMetaData.js';
 import utils from '@percy/sdk-utils';
+import Cache from '../../src/util/cache.js'
 import MobileMetaData from '../../src/metadata/mobileMetaData.js';
 
 describe('GenericProvider', () => {
@@ -416,18 +417,14 @@ describe('GenericProvider', () => {
     it('should return the matching header and footer', async () => {
       await provider.createDriver();
       let mockResponseObject = {
-        body: {
-          'iPhone 12 Pro-13': {
-            safari: {
-              header: 141,
-              footer: 399
-            }
+        'iPhone 12 Pro-13': {
+          safari: {
+            header: 141,
+            footer: 399
           }
-        },
-        status: 200,
-        headers: { 'content-type': 'application/json' }
+        }
       };
-      spyOn(utils.request, 'fetch').and.returnValue(
+      spyOn(Cache, 'withCache').and.returnValue(
         Promise.resolve(mockResponseObject)
       );
       const [header, footer] = await provider.getHeaderFooter();
@@ -438,18 +435,14 @@ describe('GenericProvider', () => {
     it('should return 0,0 for unmatched device name', async () => {
       await provider.createDriver();
       let mockResponseObject = {
-        body: {
-          'iPhone 13 Pro-14': {
-            safari: {
-              header: 141,
-              footer: 399
-            }
+        'iPhone 13 Pro-14': {
+          safari: {
+            header: 141,
+            footer: 399
           }
-        },
-        status: 200,
-        headers: { 'content-type': 'application/json' }
+        }
       };
-      spyOn(utils.request, 'fetch').and.returnValue(
+      spyOn(Cache, 'withCache').and.returnValue(
         Promise.resolve(mockResponseObject)
       );
       const [header, footer] = await provider.getHeaderFooter();
@@ -460,18 +453,14 @@ describe('GenericProvider', () => {
     it('should return 0,0 for unmatched browser name', async () => {
       await provider.createDriver();
       let mockResponseObject = {
-        body: {
-          'iPhone 12 Pro-13': {
-            chrome: {
-              header: 141,
-              footer: 399
-            }
+        'iPhone 12 Pro-13': {
+          chrome: {
+            header: 141,
+            footer: 399
           }
-        },
-        status: 200,
-        headers: { 'content-type': 'application/json' }
+        }
       };
-      spyOn(utils.request, 'fetch').and.returnValue(
+      spyOn(Cache, 'withCache').and.returnValue(
         Promise.resolve(mockResponseObject)
       );
       const [header, footer] = await provider.getHeaderFooter();

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -2,8 +2,7 @@ import GenericProvider from '../../src/providers/genericProvider.js';
 import Driver from '../../src/driver.js';
 import MetaDataResolver from '../../src/metadata/metaDataResolver.js';
 import DesktopMetaData from '../../src/metadata/desktopMetaData.js';
-import utils from '@percy/sdk-utils';
-import Cache from '../../src/util/cache.js'
+import Cache from '../../src/util/cache.js';
 import MobileMetaData from '../../src/metadata/mobileMetaData.js';
 
 describe('GenericProvider', () => {

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -409,12 +409,12 @@ describe('GenericProvider', () => {
 
     beforeEach(async () => {
       provider = new GenericProvider('123', 'http:executorUrl', { browserName: 'safari', deviceName: 'iPhone 12 Pro', platform: 'iOS' }, {});
-      spyOn(MobileMetaData.prototype, 'deviceName').and.returnValue('iPhone 12 Pro')
-      spyOn(MobileMetaData.prototype, 'osVersion').and.returnValue('13')
+      spyOn(MobileMetaData.prototype, 'deviceName').and.returnValue('iPhone 12 Pro');
+      spyOn(MobileMetaData.prototype, 'osVersion').and.returnValue('13');
     });
 
     it('should return the matching header and footer', async () => {
-      await provider.createDriver()
+      await provider.createDriver();
       let mockResponseObject = {
         body: {
           'iPhone 12 Pro-13': {
@@ -436,7 +436,7 @@ describe('GenericProvider', () => {
     });
 
     it('should return 0,0 for unmatched device name', async () => {
-      await provider.createDriver()
+      await provider.createDriver();
       let mockResponseObject = {
         body: {
           'iPhone 13 Pro-14': {
@@ -458,7 +458,7 @@ describe('GenericProvider', () => {
     });
 
     it('should return 0,0 for unmatched browser name', async () => {
-      await provider.createDriver()
+      await provider.createDriver();
       let mockResponseObject = {
         body: {
           'iPhone 12 Pro-13': {

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -3,6 +3,7 @@ import Driver from '../../src/driver.js';
 import MetaDataResolver from '../../src/metadata/metaDataResolver.js';
 import DesktopMetaData from '../../src/metadata/desktopMetaData.js';
 import utils from '@percy/sdk-utils';
+import MobileMetaData from '../../src/metadata/mobileMetaData.js';
 
 describe('GenericProvider', () => {
   let genericProvider;
@@ -73,11 +74,27 @@ describe('GenericProvider', () => {
         .and.returnValue('111');
       spyOn(DesktopMetaData.prototype, 'screenResolution')
         .and.returnValue('1980 x 1080');
+      spyOn(MobileMetaData.prototype, 'windowSize')
+        .and.returnValue(Promise.resolve({ width: 1000, height: 1000 }));
+      spyOn(MobileMetaData.prototype, 'orientation')
+        .and.returnValue('landscape');
+      spyOn(MobileMetaData.prototype, 'deviceName')
+        .and.returnValue('mockDeviceName');
+      spyOn(MobileMetaData.prototype, 'osName')
+        .and.returnValue('mockOsName');
+      spyOn(MobileMetaData.prototype, 'osVersion')
+        .and.returnValue('mockOsVersion');
+      spyOn(MobileMetaData.prototype, 'browserName')
+        .and.returnValue('mockBrowserName');
+      spyOn(MobileMetaData.prototype, 'browserVersion')
+        .and.returnValue('111');
+      spyOn(MobileMetaData.prototype, 'screenResolution')
+        .and.returnValue('1980 x 1080');
       spyOn(GenericProvider.prototype, 'getHeaderFooter').and.returnValue(Promise.resolve([123, 456]));
     });
 
-    it('returns correct tag', async () => {
-      genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
+    it('returns correct tag for android', async () => {
+      genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'android', platformName: 'android' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
       await genericProvider.createDriver();
       const tag = await genericProvider.getTag();
       expect(tag).toEqual({
@@ -86,6 +103,23 @@ describe('GenericProvider', () => {
         osVersion: 'mockOsVersion',
         width: 1000,
         height: 1000 + 123 + 456,
+        orientation: 'landscape',
+        browserName: 'mockBrowserName',
+        browserVersion: '111',
+        resolution: '1980 x 1080'
+      });
+    });
+
+    it('returns correct tag for others', async () => {
+      genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
+      await genericProvider.createDriver();
+      const tag = await genericProvider.getTag();
+      expect(tag).toEqual({
+        name: 'mockDeviceName',
+        osName: 'mockOsName',
+        osVersion: 'mockOsVersion',
+        width: 1000,
+        height: 1000,
         orientation: 'landscape',
         browserName: 'mockBrowserName',
         browserVersion: '111',

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -335,73 +335,72 @@ describe('GenericProvider', () => {
 
   describe('getHeaderFooter', () => {
     let provider;
-    let requestSpy;
 
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { 'browserName': 'safari', 'deviceName': 'iPhone 12 Pro' }, {});
+      provider = new GenericProvider('123', 'http:executorUrl', { browserName: 'safari', deviceName: 'iPhone 12 Pro' }, {});
     });
 
     it('should return the matching header and footer', async () => {
       let mockResponseObject = {
         body: {
-          'iPhone 12 Pro':{
-            'safari': {
-              'header': 141,
-              'footer': 399
+          'iPhone 12 Pro': {
+            safari: {
+              header: 141,
+              footer: 399
             }
           }
         },
         status: 200,
         headers: { 'content-type': 'application/json' }
-      }
-      requestSpy = spyOn(utils.request, 'fetch').and.returnValue(
+      };
+      spyOn(utils.request, 'fetch').and.returnValue(
         Promise.resolve(mockResponseObject)
       );
-      const [header, footer] = await provider.getHeaderFooter()
+      const [header, footer] = await provider.getHeaderFooter();
       expect(header).toEqual(141);
       expect(footer).toEqual(399);
-    })
+    });
 
     it('should return 0,0 for unmatched device name', async () => {
       let mockResponseObject = {
         body: {
-          'iPhone 13 Pro':{
-            'safari': {
-              'header': 141,
-              'footer': 399
+          'iPhone 13 Pro': {
+            safari: {
+              header: 141,
+              footer: 399
             }
           }
         },
         status: 200,
         headers: { 'content-type': 'application/json' }
-      }
-      requestSpy = spyOn(utils.request, 'fetch').and.returnValue(
+      };
+      spyOn(utils.request, 'fetch').and.returnValue(
         Promise.resolve(mockResponseObject)
       );
-      const [header, footer] = await provider.getHeaderFooter()
+      const [header, footer] = await provider.getHeaderFooter();
       expect(header).toEqual(0);
       expect(footer).toEqual(0);
-    })
+    });
 
     it('should return 0,0 for unmatched browser name', async () => {
       let mockResponseObject = {
         body: {
-          'iPhone 12 Pro':{
-            'chrome': {
-              'header': 141,
-              'footer': 399
+          'iPhone 12 Pro': {
+            chrome: {
+              header: 141,
+              footer: 399
             }
           }
         },
         status: 200,
         headers: { 'content-type': 'application/json' }
-      }
-      requestSpy = spyOn(utils.request, 'fetch').and.returnValue(
+      };
+      spyOn(utils.request, 'fetch').and.returnValue(
         Promise.resolve(mockResponseObject)
       );
-      const [header, footer] = await provider.getHeaderFooter()
+      const [header, footer] = await provider.getHeaderFooter();
       expect(header).toEqual(0);
       expect(footer).toEqual(0);
-    })
-  })
+    });
+  });
 });

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -156,7 +156,7 @@ describe('GenericProvider', () => {
       expect(addPercyCSSSpy).toHaveBeenCalledTimes(1);
       expect(addPercyCSSSpy).toHaveBeenCalledWith(defaultPercyCSS);
       expect(getTagSpy).toHaveBeenCalledTimes(1);
-      expect(getTilesSpy).toHaveBeenCalledOnceWith(0,0,false);
+      expect(getTilesSpy).toHaveBeenCalledOnceWith(0, 0, false);
       expect(removePercyCSSSpy).toHaveBeenCalledTimes(1);
       expect(res).toEqual({
         name: 'mock-name',


### PR DESCRIPTION
**Context -**
- When capturing screenshots for mobile devices we have observed instances where we are also adding `nav` / `status` / `url` bars to the screenshot image.
- We want to remove these extra heights as they are **not** the part of the webpage.
- To remove these elements, we need some way to identify the device / platform / browser combination and subsequently find the heights for the sections to remove.