### PR TITLE
Added condition to check if dom supports adoptedStyleSheets

### DIFF
--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -63,24 +63,27 @@ export function serializeCSSOM({ dom, clone, resources, cache }) {
 
   // clone Adopted Stylesheets
   // Regarding ordering of the adopted stylesheets - https://github.com/WICG/construct-stylesheets/issues/93
-  for (let sheet of dom.adoptedStyleSheets) {
-    const styleLink = document.createElement('link');
-    styleLink.setAttribute('rel', 'stylesheet');
+  /* istanbul ignore next: tested, but coverage is stripped */
+  if (dom.adoptedStyleSheets) {
+    for (let sheet of dom.adoptedStyleSheets) {
+      const styleLink = document.createElement('link');
+      styleLink.setAttribute('rel', 'stylesheet');
 
-    if (!cache.has(sheet)) {
-      let resource = createStyleResource(sheet);
-      resources.add(resource);
-      cache.set(sheet, resource.url);
-    }
-    styleLink.setAttribute('data-percy-adopted-stylesheets-serialized', 'true');
-    styleLink.setAttribute('data-percy-serialized-attribute-href', cache.get(sheet));
+      if (!cache.has(sheet)) {
+        let resource = createStyleResource(sheet);
+        resources.add(resource);
+        cache.set(sheet, resource.url);
+      }
+      styleLink.setAttribute('data-percy-adopted-stylesheets-serialized', 'true');
+      styleLink.setAttribute('data-percy-serialized-attribute-href', cache.get(sheet));
 
-    /* istanbul ignore next: tested, but coverage is stripped */
-    if (clone.constructor.name === 'HTMLDocument' || clone.constructor.name === 'DocumentFragment') {
-      // handle document and iframe
-      clone.body.prepend(styleLink);
-    } else if (clone.constructor.name === 'ShadowRoot') {
-      clone.prepend(styleLink);
+      /* istanbul ignore next: tested, but coverage is stripped */
+      if (clone.constructor.name === 'HTMLDocument' || clone.constructor.name === 'DocumentFragment') {
+        // handle document and iframe
+        clone.body.prepend(styleLink);
+      } else if (clone.constructor.name === 'ShadowRoot') {
+        clone.prepend(styleLink);
+      }
     }
   }
 }

--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -25,7 +25,7 @@ function createStyleResource(styleSheet) {
   return resource;
 }
 
-export function serializeCSSOM({ dom, clone, resources, cache }) {
+export function serializeCSSOM({ dom, clone, resources, cache, warnings }) {
   // in-memory CSSOM into their respective DOM nodes.
   for (let styleSheet of dom.styleSheets) {
     if (isCSSOM(styleSheet)) {
@@ -85,6 +85,8 @@ export function serializeCSSOM({ dom, clone, resources, cache }) {
         clone.prepend(styleLink);
       }
     }
+  } else {
+    warnings.add('Skipping `adoptedStyleSheets` as it is not supported.');
   }
 }
 


### PR DESCRIPTION
adoptedStyleSheets is supported in Safari versions from v16.4 and in automate, Safari v16.3 is only available for the latest mac os.
So if anyone uses Safari from automate to run a test for percy, the test fails with the following error:
[percy] JavascriptError: A JavaScript exception occured: undefined is not an object (evaluating 'dom.adoptedStyleSheets')

Now a check is added to verify if adoptedStyleSheets is supported. If not supported, it will show a warning and continue processing.