### PR TITLE
Support Old App Percy Tokens

### DIFF
--- a/packages/cli-exec/src/exec.js
+++ b/packages/cli-exec/src/exec.js
@@ -59,8 +59,12 @@ export const exec = command('exec', {
     log.warn('Percy is disabled');
   } else {
     try {
-      percy.projectType = percy.client.tokenType();
-      percy.skipDiscovery = percy.shouldSkipAssetDiscovery(percy.projectType);
+      // Skip this for app because they are triggered as app:exec
+      // Remove this once they move to exec command as well
+      if (percy.projectType !== 'app') {
+        percy.projectType = percy.client.tokenType();
+        percy.skipDiscovery = percy.shouldSkipAssetDiscovery(percy.projectType);
+      }
       yield* percy.yield.start();
     } catch (error) {
       if (error.name === 'AbortError') throw error;

--- a/packages/cli-exec/src/exec.js
+++ b/packages/cli-exec/src/exec.js
@@ -62,9 +62,10 @@ export const exec = command('exec', {
       // Skip this for app because they are triggered as app:exec
       // Remove this once they move to exec command as well
       if (percy.projectType !== 'app') {
-        log.info('Percy project attribute calculation');
         percy.projectType = percy.client.tokenType();
         percy.skipDiscovery = percy.shouldSkipAssetDiscovery(percy.projectType);
+      } else {
+        log.debug('Skipping percy project attribute calculation');
       }
       yield* percy.yield.start();
     } catch (error) {

--- a/packages/cli-exec/src/exec.js
+++ b/packages/cli-exec/src/exec.js
@@ -62,6 +62,7 @@ export const exec = command('exec', {
       // Skip this for app because they are triggered as app:exec
       // Remove this once they move to exec command as well
       if (percy.projectType !== 'app') {
+        log.info('Percy project attribute calculation');
         percy.projectType = percy.client.tokenType();
         percy.skipDiscovery = percy.shouldSkipAssetDiscovery(percy.projectType);
       }

--- a/packages/cli-exec/src/start.js
+++ b/packages/cli-exec/src/start.js
@@ -13,9 +13,10 @@ export const start = command('start', {
   // Skip this for app because they are triggered as app:exec
   // Remove this once they move to exec command as well
   if (percy.projectType !== 'app') {
-    log.info('Percy project attribute calculation');
     percy.projectType = percy.client.tokenType();
     percy.skipDiscovery = percy.shouldSkipAssetDiscovery(percy.projectType);
+  } else {
+    log.debug('Skipping percy project attribute calculation');
   }
 
   // start percy

--- a/packages/cli-exec/src/start.js
+++ b/packages/cli-exec/src/start.js
@@ -7,12 +7,13 @@ export const start = command('start', {
     server: true,
     projectType: 'web'
   }
-}, async function*({ percy, exit }) {
+}, async function*({ percy, log, exit }) {
   if (!percy) exit(0, 'Percy is disabled');
   let { yieldFor } = await import('@percy/cli-command/utils');
   // Skip this for app because they are triggered as app:exec
   // Remove this once they move to exec command as well
   if (percy.projectType !== 'app') {
+    log.info('Percy project attribute calculation');
     percy.projectType = percy.client.tokenType();
     percy.skipDiscovery = percy.shouldSkipAssetDiscovery(percy.projectType);
   }

--- a/packages/cli-exec/src/start.js
+++ b/packages/cli-exec/src/start.js
@@ -10,8 +10,12 @@ export const start = command('start', {
 }, async function*({ percy, exit }) {
   if (!percy) exit(0, 'Percy is disabled');
   let { yieldFor } = await import('@percy/cli-command/utils');
-  percy.projectType = percy.client.tokenType();
-  percy.skipDiscovery = percy.shouldSkipAssetDiscovery(percy.projectType);
+  // Skip this for app because they are triggered as app:exec
+  // Remove this once they move to exec command as well
+  if (percy.projectType !== 'app') {
+    percy.projectType = percy.client.tokenType();
+    percy.skipDiscovery = percy.shouldSkipAssetDiscovery(percy.projectType);
+  }
 
   // start percy
   yield* percy.yield.start();

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -18,6 +18,33 @@ describe('percy exec', () => {
     delete process.env.PERCY_PARTIAL_BUILD;
   });
 
+  describe('projectType is app', () => {
+    const type = exec.definition.percy.projectType;
+    const logInfo = logger.loglevel();
+
+    beforeEach(() => {
+      exec.definition.percy.projectType = 'app';
+      logger.loglevel('debug');
+      process.env.PERCY_LOGLEVEL = 'debug';
+    });
+
+    afterEach(() => {
+      exec.definition.percy.projectType = type;
+      logger.loglevel(logInfo);
+      logger.reset(true);
+      delete process.env.PERCY_LOGLEVEL;
+    });
+
+    it('does not call override function', async () => {
+      await exec(['--', 'node', '--eval', '']);
+      expect(logger.stderr).toEqual(
+        jasmine.arrayContaining([
+          '[percy:cli] Skipping percy project attribute calculation'
+        ])
+      );
+    });
+  });
+
   it('logs an error when no command is provided', async () => {
     await expectAsync(exec()).toBeRejected();
 
@@ -75,27 +102,6 @@ describe('percy exec', () => {
     expect(logger.stdout).toEqual([
       '[percy] Running "node --eval "'
     ]);
-  });
-
-  describe('projectType is app', () => {
-    const type = exec.definition.percy.projectType;
-    beforeAll(() => {
-      exec.definition.percy.projectType = 'app';
-    });
-
-    afterAll(() => {
-      exec.definition.percy.projectType = type;
-    });
-
-    it('does not call override function', async () => {
-      await exec(['--debug', '--', 'node', '--eval', '']);
-
-      expect(logger.stderr).toEqual(
-        jasmine.arrayContaining([
-          '[percy:cli] Skipping percy project attribute calculation'
-        ])
-      );
-    });
   });
 
   it('runs the command even when PERCY_TOKEN is missing', async () => {

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -44,9 +44,9 @@ describe('percy exec', () => {
 
   it('starts and stops the percy process around the command', async () => {
     await exec(['--', 'node', '--eval', '']);
-
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
+      '[percy] Percy project attribute calculation',
       '[percy] Percy has started!',
       '[percy] Running "node --eval "',
       '[percy] Finalized build #1: https://percy.io/test/test/123'
@@ -77,6 +77,15 @@ describe('percy exec', () => {
     ]);
   });
 
+  describe('projectType is not app', () => {
+    it('calls override functions', async () => {
+      await exec(['--', 'node', '--eval', '']);
+      expect(logger.stdout[0]).toEqual(
+        '[percy] Percy project attribute calculation'
+      );
+    });
+  });
+
   it('runs the command even when PERCY_TOKEN is missing', async () => {
     delete process.env.PERCY_TOKEN;
     await exec(['--', 'node', '--eval', '']);
@@ -86,6 +95,7 @@ describe('percy exec', () => {
       '[percy] Error: Missing Percy token'
     ]);
     expect(logger.stdout).toEqual([
+      '[percy] Percy project attribute calculation',
       '[percy] Running "node --eval "'
     ]);
   });
@@ -97,6 +107,7 @@ describe('percy exec', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
+      '[percy] Percy project attribute calculation',
       '[percy] Percy has started!',
       '[percy] Running "node --eval process.exit(3)"',
       '[percy] Finalized build #1: https://percy.io/test/test/123'
@@ -135,6 +146,7 @@ describe('percy exec', () => {
       '[percy] Error: spawn error'
     ]);
     expect(logger.stdout).toEqual([
+      '[percy] Percy project attribute calculation',
       '[percy] Percy has started!',
       '[percy] Running "foobar"',
       '[percy] Stopping percy...',
@@ -176,6 +188,7 @@ describe('percy exec', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
+      '[percy] Percy project attribute calculation',
       '[percy] Percy has started!',
       jasmine.stringMatching('\\[percy] Running "node '),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
@@ -189,6 +202,7 @@ describe('percy exec', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
+      '[percy] Percy project attribute calculation',
       '[percy] Percy has started!',
       jasmine.stringMatching('\\[percy] Running "node '),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
@@ -202,6 +216,7 @@ describe('percy exec', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
+      '[percy] Percy project attribute calculation',
       '[percy] Percy has started!',
       jasmine.stringMatching('\\[percy] Running "node '),
       '[percy] Finalized build #1: https://percy.io/test/test/123'

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -44,6 +44,7 @@ describe('percy exec', () => {
 
   it('starts and stops the percy process around the command', async () => {
     await exec(['--', 'node', '--eval', '']);
+
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
       '[percy] Percy project attribute calculation',
@@ -77,10 +78,18 @@ describe('percy exec', () => {
     ]);
   });
 
-  describe('projectType is not app', () => {
-    it('calls override functions', async () => {
+  describe('projectType is app', () => {
+    let type = exec.definition.percy.projectType;
+    beforeAll(() => {
+      exec.definition.percy.projectType = 'app';
+    });
+
+    afterAll(() => {
+      exec.definition.percy.projectType = type;
+    });
+    it('does not call override function', async () => {
       await exec(['--', 'node', '--eval', '']);
-      expect(logger.stdout[0]).toEqual(
+      expect(logger.stdout[0]).not.toEqual(
         '[percy] Percy project attribute calculation'
       );
     });

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -47,7 +47,6 @@ describe('percy exec', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy project attribute calculation',
       '[percy] Percy has started!',
       '[percy] Running "node --eval "',
       '[percy] Finalized build #1: https://percy.io/test/test/123'
@@ -79,18 +78,22 @@ describe('percy exec', () => {
   });
 
   describe('projectType is app', () => {
-    let type = exec.definition.percy.projectType;
-    beforeAll(() => {
+    const type = exec.definition.percy.projectType;
+    beforeAll(async () => {
       exec.definition.percy.projectType = 'app';
     });
 
     afterAll(() => {
       exec.definition.percy.projectType = type;
     });
+
     it('does not call override function', async () => {
-      await exec(['--', 'node', '--eval', '']);
-      expect(logger.stdout[0]).not.toEqual(
-        '[percy] Percy project attribute calculation'
+      await exec(['--debug', '--', 'node', '--eval', '']);
+
+      expect(logger.stderr).toEqual(
+        jasmine.arrayContaining([
+          '[percy:cli] Skipping percy project attribute calculation'
+        ])
       );
     });
   });
@@ -104,7 +107,6 @@ describe('percy exec', () => {
       '[percy] Error: Missing Percy token'
     ]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy project attribute calculation',
       '[percy] Running "node --eval "'
     ]);
   });
@@ -116,7 +118,6 @@ describe('percy exec', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy project attribute calculation',
       '[percy] Percy has started!',
       '[percy] Running "node --eval process.exit(3)"',
       '[percy] Finalized build #1: https://percy.io/test/test/123'
@@ -155,7 +156,6 @@ describe('percy exec', () => {
       '[percy] Error: spawn error'
     ]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy project attribute calculation',
       '[percy] Percy has started!',
       '[percy] Running "foobar"',
       '[percy] Stopping percy...',
@@ -197,7 +197,6 @@ describe('percy exec', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy project attribute calculation',
       '[percy] Percy has started!',
       jasmine.stringMatching('\\[percy] Running "node '),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
@@ -211,7 +210,6 @@ describe('percy exec', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy project attribute calculation',
       '[percy] Percy has started!',
       jasmine.stringMatching('\\[percy] Running "node '),
       '[percy] Finalized build #1: https://percy.io/test/test/123'
@@ -225,7 +223,6 @@ describe('percy exec', () => {
 
     expect(logger.stderr).toEqual([]);
     expect(logger.stdout).toEqual([
-      '[percy] Percy project attribute calculation',
       '[percy] Percy has started!',
       jasmine.stringMatching('\\[percy] Running "node '),
       '[percy] Finalized build #1: https://percy.io/test/test/123'

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -79,7 +79,7 @@ describe('percy exec', () => {
 
   describe('projectType is app', () => {
     const type = exec.definition.percy.projectType;
-    beforeAll(async () => {
+    beforeAll(() => {
       exec.definition.percy.projectType = 'app';
     });
 

--- a/packages/cli-exec/test/start.test.js
+++ b/packages/cli-exec/test/start.test.js
@@ -32,6 +32,12 @@ describe('percy exec:start', () => {
     await started;
   });
 
+  it('calls percy project attribute calculation', async () => {
+    expect(logger.stdout[0]).toEqual(
+      '[percy] Percy project attribute calculation'
+    );
+  });
+
   it('starts a long-running percy process', async () => {
     let response = await request('http://localhost:5338/percy/healthcheck');
     expect(response).toHaveProperty('success', true);

--- a/packages/cli-exec/test/start.test.js
+++ b/packages/cli-exec/test/start.test.js
@@ -32,6 +32,25 @@ describe('percy exec:start', () => {
     await started;
   });
 
+  describe('projectType is app', () => {
+    let type = start.definition.percy.projectType;
+    beforeAll(async () => {
+      start.definition.percy.projectType = 'app';
+    });
+
+    afterAll(() => {
+      start.definition.percy.projectType = type;
+    });
+
+    it('does not call override function', async () => {
+      await stop();
+
+      expect(logger.stdout[0]).not.toEqual(
+        '[percy] Percy project attribute calculation'
+      );
+    });
+  });
+
   it('calls percy project attribute calculation', async () => {
     expect(logger.stdout[0]).toEqual(
       '[percy] Percy project attribute calculation'

--- a/packages/cli-exec/test/start.test.js
+++ b/packages/cli-exec/test/start.test.js
@@ -34,17 +34,21 @@ describe('percy exec:start', () => {
 
   describe('projectType is app', () => {
     const type = start.definition.percy.projectType;
+    const logInfo = logger.loglevel();
     beforeAll(() => {
       start.definition.percy.projectType = 'app';
+      logger.loglevel('debug');
+      process.env.PERCY_LOGLEVEL = 'debug';
     });
 
     afterAll(() => {
       start.definition.percy.projectType = type;
+      logger.loglevel(logInfo);
+      logger.reset(true);
+      delete process.env.PERCY_LOGLEVEL;
     });
 
-    it('does not call override function', async () => {
-      await stop();
-
+    it('does not call override function', () => {
       expect(logger.stderr).toEqual(
         jasmine.arrayContaining([
           '[percy:cli] Skipping percy project attribute calculation'

--- a/packages/cli-exec/test/start.test.js
+++ b/packages/cli-exec/test/start.test.js
@@ -70,7 +70,9 @@ describe('percy exec:start', () => {
 
     await expectAsync(start()).toBeRejected();
 
-    expect(logger.stdout).toEqual([]);
+    expect(logger.stdout).toEqual([
+      '[percy] Percy project attribute calculation'
+    ]);
     expect(logger.stderr).toEqual([
       '[percy] Error: Percy is already running or the port is in use'
     ]);

--- a/packages/cli-exec/test/start.test.js
+++ b/packages/cli-exec/test/start.test.js
@@ -33,8 +33,8 @@ describe('percy exec:start', () => {
   });
 
   describe('projectType is app', () => {
-    let type = start.definition.percy.projectType;
-    beforeAll(async () => {
+    const type = start.definition.percy.projectType;
+    beforeAll(() => {
       start.definition.percy.projectType = 'app';
     });
 
@@ -45,16 +45,12 @@ describe('percy exec:start', () => {
     it('does not call override function', async () => {
       await stop();
 
-      expect(logger.stdout[0]).not.toEqual(
-        '[percy] Percy project attribute calculation'
+      expect(logger.stderr).toEqual(
+        jasmine.arrayContaining([
+          '[percy:cli] Skipping percy project attribute calculation'
+        ])
       );
     });
-  });
-
-  it('calls percy project attribute calculation', async () => {
-    expect(logger.stdout[0]).toEqual(
-      '[percy] Percy project attribute calculation'
-    );
   });
 
   it('starts a long-running percy process', async () => {
@@ -89,9 +85,7 @@ describe('percy exec:start', () => {
 
     await expectAsync(start()).toBeRejected();
 
-    expect(logger.stdout).toEqual([
-      '[percy] Percy project attribute calculation'
-    ]);
+    expect(logger.stdout).toEqual([]);
     expect(logger.stderr).toEqual([
       '[percy] Error: Percy is already running or the port is in use'
     ]);

--- a/packages/webdriver-utils/src/index.js
+++ b/packages/webdriver-utils/src/index.js
@@ -41,8 +41,8 @@ export default class WebdriverUtils {
       this.log.debug('Created driver ...');
       return await automate.screenshot(this.snapshotName, this.options);
     } catch (e) {
-      this.log.error(`Error: ${e.message}`);
-      this.log.error(`Error Log: ${e.toString()}`);
+      this.log.error(`[${this.snapshotName}] : Error - ${e.message}`);
+      this.log.error(`[${this.snapshotName}] : Error Log - ${e.toString()}`);
     }
   }
 }

--- a/packages/webdriver-utils/src/index.js
+++ b/packages/webdriver-utils/src/index.js
@@ -33,11 +33,16 @@ export default class WebdriverUtils {
   }
 
   async automateScreenshot() {
-    this.log.info('Starting automate screenshot ...');
-    const automate = ProviderResolver.resolve(this.sessionId, this.commandExecutorUrl, this.capabilities, this.sessionCapabilites, this.clientInfo, this.environmentInfo, this.options, this.buildInfo);
-    this.log.debug('Resolved provider ...');
-    await automate.createDriver();
-    this.log.debug('Created driver ...');
-    return await automate.screenshot(this.snapshotName, this.options);
+    try {
+      this.log.info('Starting automate screenshot ...');
+      const automate = ProviderResolver.resolve(this.sessionId, this.commandExecutorUrl, this.capabilities, this.sessionCapabilites, this.clientInfo, this.environmentInfo, this.options, this.buildInfo);
+      this.log.debug('Resolved provider ...');
+      await automate.createDriver();
+      this.log.debug('Created driver ...');
+      return await automate.screenshot(this.snapshotName, this.options);
+    } catch (e) {
+      this.log.error(`Error: ${e.message}`);
+      this.log.error(`Error Log: ${e.toString()}`);
+    }
   }
 }


### PR DESCRIPTION
Support Old App Percy Tokens along with PoA projects.
We have removed the check if the projectType is of `app` for dynamic fetching of projectType. We should re-enable it when we plan from moving away from `app:exec` to `exec` for app projects.