### PR TITLE
Added graceful handling of aborted requests

### DIFF
--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -292,7 +292,7 @@ async function sendResponseResource(network, request, session) {
   let log = network.log;
   let url = originURL(request);
   let meta = { ...network.meta, url };
-  let send = async (method, params) => await network.send(session, method, params);
+  let send = (method, params) => network.send(session, method, params);
 
   try {
     let resource = network.intercept.getResource(url);

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -2,6 +2,7 @@ import { sha256hash } from '@percy/client/utils';
 import { logger, api, setupTest, createTestServer, dedent } from './helpers/index.js';
 import Percy from '@percy/core';
 import { RESOURCE_CACHE_KEY } from '../src/discovery.js';
+import Session from '../src/session.js';
 
 describe('Discovery', () => {
   let percy, server, captured;
@@ -540,18 +541,20 @@ describe('Discovery', () => {
 
   it('logs failed request errors with a debug loglevel', async () => {
     percy.loglevel('debug');
+
     await percy.snapshot({
       name: 'test snapshot',
       url: 'http://localhost:8000',
-      domSnapshot: testDOM.replace('style.css', '/404/style.css')
+      domSnapshot: testDOM.replace('style.css', 'http://localhost:404/style.css')
     });
+    // with an unknown port number, we should get connection refused error
 
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
       '[percy:core] Snapshot taken: test snapshot'
     ]));
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
       jasmine.stringMatching(new RegExp( // eslint-disable-line prefer-regex-literals
-        '^\\[percy:core:discovery\\] Request failed for http://localhost:8000/404/style\\.css: net::'
+        '^\\[percy:core:discovery\\] Request failed for http://localhost:404/style\\.css: net::ERR_CONNECTION_REFUSED'
       ))
     ]));
   });
@@ -745,6 +748,81 @@ describe('Discovery', () => {
           'resource-url': 'http://localhost:8000/img.gif'
         })
       })
+    ]));
+  });
+
+  it('does not error on cancelled requests', async () => {
+    percy.loglevel('debug');
+
+    let url = 'http://localhost:8000/test';
+    let doc = dedent`
+      <!DOCTYPE html><html><head></head><body><script>
+        async function fetchWithTimeout(resource, options = {}) {
+          const { timeout = 8000 } = options;
+          const controller = new AbortController();
+          const id = setTimeout(() => controller.abort(), timeout);
+          const response = await fetch(resource, {
+            ...options,
+            signal: controller.signal
+          });
+          clearTimeout(id);
+          return response;
+        }
+        setTimeout(() => fetchWithTimeout("${url}", { timeout: 50 }), 10);
+      </script></body></html>
+    `;
+    // above request is cancelled in 50ms, and it will not resolve in 50ms as per following
+    // mock so we can reproduce browser cancelling the request post requesting it
+
+    spyOn(Session.prototype, 'send').and.callFake(function(method, params) {
+      if (method === 'Fetch.continueRequest') {
+        this.log.debug(`Got Fetch.continueRequest ${params.requestId}`);
+        this.log.debug(`Waiting for request to get aborted ${params.requestId}`);
+
+        // waste 1 sec
+        let startTime = new Date().getSeconds();
+        while (startTime === new Date().getSeconds()) {
+          // waste time
+          // We cant use jasmine timer tick here as thats simulated time vs we want to actually
+          // wait for 1 sec
+          // We are waiting for js fetch call in above doc to get cancelled as we have set timeout
+          // of 50ms there
+          // Current real time wait would stall the request for a second so that it cant resolve in
+          // 50 ms. Allowing us to reproduce the race condition
+        }
+        // note, while we wait 1 sec on primary page load request as well, that will not get
+        // aborted so we are good, even if request is delayed
+      }
+      return this.send.and.originalFn.call(this, method, params);
+    });
+
+    server.reply('/', () => [200, 'text/html', doc]);
+
+    server.reply('/test', () => [200, 'text/plain', 'abc']);
+
+    await percy.snapshot({
+      name: 'cancelled request',
+      url: 'http://localhost:8000',
+      enableJavaScript: true
+    });
+
+    await percy.idle();
+
+    expect(logger.stdout).toEqual(jasmine.arrayContaining([
+      '[percy:core] Snapshot taken: cancelled request'
+    ]));
+    expect(logger.stderr).toEqual(jasmine.arrayContaining([
+      jasmine.stringMatching(new RegExp( // eslint-disable-line prefer-regex-literals
+        `^\\[percy:core:discovery\\] Request aborted for ${url}: net::ERR_ABORTED`
+      )),
+      jasmine.stringMatching(new RegExp( // eslint-disable-line prefer-regex-literals
+        `^\\[percy:core:discovery\\] Ignoring further steps for ${url} as request was aborted by the browser.`
+      ))
+    ]));
+    expect(logger.stderr).not.toEqual(jasmine.arrayContaining([
+      jasmine.stringMatching(new RegExp( // eslint-disable-line prefer-regex-literals
+        '^\\[percy:core:discovery\\] Error: Protocol error (Fetch.fulfillRequest): Invalid InterceptionId.'
+      ))
     ]));
   });
 


### PR DESCRIPTION
What ?
- Added graceful handling of aborted requests
- Now we keep track of aborted requests and whenever we are going to make a `session.send` call we check if we have already received abortion event for same request id 
- If request was already aborted we dont print it out as `Error: Protocol error (Fetch.fulfillRequest): Invalid InterceptionId.`
- We now print two new logs under debug mode, one for aborted request event and once when we ignore error above due to the same.

Why?
- There are cases when a browser triggers a network request and cancels it before its resolved. It usually happens when a resource was originally required, but is now not required [ say you have an `srcset` with multiple entries and you change the width of the browser fast enough such that it starts loading one of the resources, but now it doesn't need it ]
- In this case we would first receive `Network.requestWillBeSent` event, which we would eventually respond with `Fetch.continueRequest` or `Fetch.fulfillRequest` etc, but before we respond if the request gets cancelled [which invalidates `Interception Id`] we get above Protocol error. 

Test:
- This was hard to write test for as its hard to reproduce this race [ or browser cancelling a request ] to begin with
- So we are using `fetchWithTimeout` helper so that we can mimic a cancellation from browser
- In order to reproduce the race condition we specifically delay `Fetch.continueRequest` response by 1 sec so that request triggered by `fetch` is cancelled
- Which is equivalent to calling a `Fetch.*` method with a request/interception Id of a request thats already cancelled