### PR TITLE
Added env var support to control duplicate snapshot warnings

### DIFF
--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -375,6 +375,15 @@ export function createSnapshotsQueue(percy) {
         queue.close(true);
       }
 
+      let errors = error.response?.body?.errors;
+      let duplicate = errors?.length > 1 && errors[1].detail.includes('must be unique');
+      if (duplicate) {
+        if (process.env.PERCY_IGNORE_DUPLICATES !== 'true') {
+          percy.log.warn(`Ignored duplicate snapshot. ${errors[1].detail}`);
+        }
+        return result;
+      }
+
       percy.log.error(`Encountered an error uploading snapshot: ${name}`, meta);
       percy.log.error(error, meta);
       return result;


### PR DESCRIPTION
What?
- By default duplicate snapshot is warning now, not error
- This warning can be suppressed with environment variable `PERCY_IGNORE_DUPLICATES` when set to true

Why?
- Some customers use `percySnapshot` in parallel tests where it gets called multiple times on multiple browsers. 
- Ideally we want customers to fix one browser and only take `percySnapshot` on that. Not multiple. But we allow customers to suppress warning as well [ we only consider first posted snapshot ]