### PR TITLE
🏗️  Upload executables as assets

### DIFF
--- a/.github/workflows/executable.yml
+++ b/.github/workflows/executable.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Verify executable
         run: ./percy --version
       - name: Upload assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@c9b46fe7aad9f02afd89b12450b780f52dacfb2d
         with:
           files: |
             percy-osx.zip

--- a/.github/workflows/executable.yml
+++ b/.github/workflows/executable.yml
@@ -20,23 +20,20 @@ jobs:
           APPLE_DEV_CERT: ${{secrets.APPLE_DEV_CERT}}
           APPLE_ID_USERNAME: ${{secrets.APPLE_ID_USERNAME}}
           APPLE_ID_KEY: ${{secrets.APPLE_ID_KEY}}
-      - name: Create tar files
+      - name: Create zip files
         run: |
-          tar -cvf percy-linux.tar percy
+          zip percy-linux.zip percy
           mv percy-osx percy
-          tar -cvf percy-osx.tar percy
-          tar -cvf percy-win.tar percy.exe
+          zip percy-osx.zip percy
+          zip percy-win.zip percy.exe
       - name: Verify executable
         run: ./percy --version
-      - uses: actions/upload-artifact@v3
+      - name: Upload assets
+        uses: softprops/action-gh-release@v1
         with:
-          name: percy-osx
-          path: percy-osx.tar
-      - uses: actions/upload-artifact@v3
-        with:
-          name: percy-linux
-          path: percy-linux.tar
-      - uses: actions/upload-artifact@v3
-        with:
-          name: percy-win
-          path: percy-win.tar
+          files: |
+            percy-osx.zip
+            percy-linux.zip
+            percy-win.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Upload executables as assets when releasing
- While uploading assets zip also retains executable permissions no need to convert to tar 