### PR TITLE
Move zip logic to executable script

### DIFF
--- a/.github/workflows/executable.yml
+++ b/.github/workflows/executable.yml
@@ -20,12 +20,6 @@ jobs:
           APPLE_DEV_CERT: ${{secrets.APPLE_DEV_CERT}}
           APPLE_ID_USERNAME: ${{secrets.APPLE_ID_USERNAME}}
           APPLE_ID_KEY: ${{secrets.APPLE_ID_KEY}}
-      - name: Create zip files
-        run: |
-          zip percy-linux.zip percy
-          mv percy-osx percy
-          zip percy-osx.zip percy
-          zip percy-win.zip percy.exe
       - name: Verify executable
         run: ./percy --version
       - name: Upload assets

--- a/scripts/executable.sh
+++ b/scripts/executable.sh
@@ -66,7 +66,12 @@ security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k percy ~/Li
 
 codesign  --force --verbose=4 -s "Developer ID Application: BrowserStack Inc (763K6K6H44)" --options runtime --entitlements scripts/files/entitlement.plist --keychain ~/Library/Keychains/percy.keychain percy-osx
 
-zip percy-osx.zip percy-osx
+# Create zip file for uploading as assets
+zip percy-linux.zip percy
+mv percy-osx percy
+zip percy-osx.zip percy
+zip percy-win.zip percy.exe
+
 cat scripts/files/notarize_config.json.tmpl | sed -e "s/{{APPLE_ID_USERNAME}}/$APPLE_ID_USERNAME/" | sed -e "s/{{APPLE_ID_KEY}}/$APPLE_ID_KEY/" > notarize_config.json
 gon -log-level=error -log-json notarize_config.json
 


### PR DESCRIPTION
- Move zip logic to executable script and removing from github action
- Fixes macos zip extracted as folder with 2 binaries.