### PR TITLE
✨ Adds Percy on Automate specific configs as global config

### DIFF
--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -19,6 +19,17 @@ const ajv = new AJV({
     getDefaultSchema()
   ],
   keywords: [{
+    keyword: 'onlyAutomate',
+    error: {
+      message: 'Only valid for Automate type projects'
+    },
+    code: cxt => {
+      let isAutomateProjectToken = (process.env.PERCY_TOKEN || '').split('_')[0] === 'auto';
+      if (!isAutomateProjectToken) {
+        cxt.error();
+      }
+    }
+  }, {
     // custom instanceof schema validation
     keyword: 'instanceof',
     metaSchema: {

--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -117,7 +117,7 @@ export function createPercyServer(percy, port) {
       success: await percy.flush(req.body).then(() => true)
     }))
     .route('post', '/percy/automateScreenshot', async (req, res) => {
-      req = percyAutomateRequestHandler(req, percy.build);
+      req = percyAutomateRequestHandler(req, percy);
       res.json(200, {
         success: await (percy.upload(await new WebdriverUtils(req.body).automateScreenshot())).then(() => true)
       });

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -49,6 +49,53 @@ export const configSchema = {
       },
       scope: {
         type: 'string'
+      },
+      freezeAnimation: {
+        type: 'boolean',
+        default: false,
+        onlyAutomate: true
+      },
+      ignoreRegions: {
+        type: 'object',
+        additionalProperties: false,
+        onlyAutomate: true,
+        properties: {
+          ignoreRegionSelectors: {
+            type: 'array',
+            default: [],
+            items: {
+              type: 'string'
+            }
+          },
+          ignoreRegionXpaths: {
+            type: 'array',
+            default: [],
+            items: {
+              type: 'string'
+            }
+          }
+        }
+      },
+      considerRegions: {
+        type: 'object',
+        additionalProperties: false,
+        onlyAutomate: true,
+        properties: {
+          considerRegionSelectors: {
+            type: 'array',
+            default: [],
+            items: {
+              type: 'string'
+            }
+          },
+          considerRegionXPaths: {
+            type: 'array',
+            default: [],
+            items: {
+              type: 'string'
+            }
+          }
+        }
       }
     }
   },

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 import { sha256hash } from '@percy/client/utils';
+import { camelcase, merge } from '@percy/config/utils';
 
 export {
   request,
@@ -24,17 +25,32 @@ export function normalizeURL(url) {
 }
 
 // Returns the body for automateScreenshot in structure
-export function percyAutomateRequestHandler(req, buildInfo) {
+export function percyAutomateRequestHandler(req, percy) {
   if (req.body.client_info) {
     req.body.clientInfo = req.body.client_info;
   }
   if (req.body.environment_info) {
     req.body.environmentInfo = req.body.environment_info;
   }
-  if (!req.body.options) {
-    req.body.options = {};
-  }
-  req.body.buildInfo = buildInfo;
+
+  // combines array and overrides global config with per-screenshot config
+  let camelCasedOptions = {};
+  Object.entries(req.body.options || {}).forEach(([key, value]) => {
+    camelCasedOptions[camelcase(key)] = value;
+  });
+
+  req.body.options = merge([{
+    percyCSS: percy.config.snapshot.percyCSS,
+    freezeAnimation: percy.config.snapshot.freezeAnimation,
+    ignoreRegionSelectors: percy.config.snapshot.ignoreRegions.ignoreRegionSelectors,
+    ignoreRegionXpaths: percy.config.snapshot.ignoreRegions.ignoreRegionXpaths,
+    considerRegionSelectors: percy.config.snapshot.considerRegions.considerRegionSelectors,
+    considerRegionXPaths: percy.config.snapshot.considerRegions.considerRegionXPaths
+  },
+  camelCasedOptions
+  ]);
+
+  req.body.buildInfo = percy.build;
   return req;
 }
 

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -48,7 +48,12 @@ export function percyAutomateRequestHandler(req, percy) {
     considerRegionXPaths: percy.config.snapshot.considerRegions.considerRegionXPaths
   },
   camelCasedOptions
-  ]);
+  ], (path, prev, next) => {
+    switch (path.map(k => k.toString()).join('.')) {
+      case 'percyCSS': // concatenate percy css
+        return [path, [prev, next].filter(Boolean).join('\n')];
+    }
+  });
 
   req.body.buildInfo = percy.build;
   return req;

--- a/packages/webdriver-utils/src/index.js
+++ b/packages/webdriver-utils/src/index.js
@@ -1,6 +1,5 @@
 import ProviderResolver from './providers/providerResolver.js';
 import utils from '@percy/sdk-utils';
-import { camelcase } from '@percy/config/utils';
 
 export default class WebdriverUtils {
   log = utils.logger('webdriver-utils:main');
@@ -21,12 +20,7 @@ export default class WebdriverUtils {
     this.capabilities = capabilities;
     this.sessionCapabilites = sessionCapabilites;
     this.snapshotName = snapshotName;
-    const camelCasedOptions = {};
-    Object.keys(options).forEach((key) => {
-      let newKey = camelcase(key);
-      camelCasedOptions[newKey] = options[key];
-    });
-    this.options = camelCasedOptions;
+    this.options = options;
     this.clientInfo = clientInfo;
     this.environmentInfo = environmentInfo;
     this.buildInfo = buildInfo;


### PR DESCRIPTION
* Adding following to global config
  * `percyCSS` _(existing config)_
  * `freezeAnimation`
  *  `ignoreRegions` > `ignoreRegionSelectors`, `ignoreRegionXpaths` 
  * `considerRegions` >   `considerRegionSelectors`, `considerRegionXPaths`
* we'll combine `percyCSS`, `ignoreRegions`, `considerRegions`  `per-screenshot` config with global config if found, and override `freezeAnimation` value.