### PR TITLE
Percy on Automate: Check if deviceName was passed

### DIFF
--- a/packages/webdriver-utils/src/metadata/metaDataResolver.js
+++ b/packages/webdriver-utils/src/metadata/metaDataResolver.js
@@ -8,7 +8,8 @@ export default class MetaDataResolver {
     const platform = opts.platformName || opts.platform;
     if (['ios', 'android'].includes(platform.toLowerCase()) ||
       ['ios', 'android'].includes(capabilities?.platformName?.toLowerCase()) ||
-      ['ipad', 'iphone'].includes(capabilities?.device?.toString()?.toLowerCase())) {
+      ['ipad', 'iphone'].includes(capabilities?.device?.toString()?.toLowerCase()) ||
+      opts?.deviceName !== undefined) {
       return new MobileMetaData(driver, capabilities);
     } else {
       return new DesktopMetaData(driver, capabilities);

--- a/packages/webdriver-utils/test/metadata/metaDataResolver.test.js
+++ b/packages/webdriver-utils/test/metadata/metaDataResolver.test.js
@@ -32,5 +32,19 @@ describe('MetaDataResolver', () => {
       expect(metadata.driver).toEqual(driver);
       expect(metadata.capabilities).toEqual({});
     });
+
+    it('resolves MobileMetaData when deviceName is passed', () => {
+      metadata = MetaDataResolver.resolve(driver, capabilities, { platform: 'Linux', deviceName: 'RX224' });
+      expect(metadata).toBeInstanceOf(MobileMetaData);
+      expect(metadata.driver).toEqual(driver);
+      expect(metadata.capabilities).toEqual({});
+    });
+
+    it('resolves DesktopMetaData when no deviceName is passed', () => {
+      metadata = MetaDataResolver.resolve(driver, capabilities, { platform: 'Linux' });
+      expect(metadata).toBeInstanceOf(DesktopMetaData);
+      expect(metadata.driver).toEqual(driver);
+      expect(metadata.capabilities).toEqual({});
+    });
   });
 });


### PR DESCRIPTION
🐛  [Fix] : Pass DeviceName if it is mobile from SDKs so that they can route to mobileResolver properly.