### PR TITLE
[PER-2582] Do not execute git commands when `PERCY_SKIP_GIT_CHECK` is set to True

### DIFF
--- a/packages/env/src/utils.js
+++ b/packages/env/src/utils.js
@@ -16,11 +16,10 @@ const GIT_COMMIT_FORMAT = [
 ].join('%n'); // git show format uses %n for newlines.
 
 export function git(args) {
+  if (process.env.PERCY_SKIP_GIT_CHECK === 'true') {
+    return '';
+  }
   try {
-    if (process.env.PERCY_SKIP_GIT_CHECK) {
-      log.debug('Skipping git commands');
-      return '';
-    }
     return cp.execSync(`git ${args}`, {
       stdio: ['ignore', 'pipe', 'ignore'],
       encoding: 'utf-8'

--- a/packages/env/src/utils.js
+++ b/packages/env/src/utils.js
@@ -1,5 +1,8 @@
 import fs from 'fs';
 import cp from 'child_process';
+import logger from '@percy/logger';
+
+let log = logger('cli');
 
 const GIT_COMMIT_FORMAT = [
   'COMMIT_SHA:%H',
@@ -14,6 +17,10 @@ const GIT_COMMIT_FORMAT = [
 
 export function git(args) {
   try {
+    if (process.env.PERCY_SKIP_GIT_CHECK) {
+      log.debug('Skipping git commands');
+      return '';
+    }
     return cp.execSync(`git ${args}`, {
       stdio: ['ignore', 'pipe', 'ignore'],
       encoding: 'utf-8'

--- a/packages/env/src/utils.js
+++ b/packages/env/src/utils.js
@@ -1,8 +1,5 @@
 import fs from 'fs';
 import cp from 'child_process';
-import logger from '@percy/logger';
-
-let log = logger('cli');
 
 const GIT_COMMIT_FORMAT = [
   'COMMIT_SHA:%H',

--- a/packages/env/test/defaults.test.js
+++ b/packages/env/test/defaults.test.js
@@ -173,7 +173,6 @@ describe('Defaults', () => {
   });
 
   describe('env PERCY_SKIP_GIT_CHECK', () => {
-  
     beforeEach(() => {
       process.env.PERCY_SKIP_GIT_CHECK = true;
     });
@@ -188,5 +187,4 @@ describe('Defaults', () => {
       expect(env).toHaveProperty('git.sha', null);
     });
   });
-
 });

--- a/packages/env/test/defaults.test.js
+++ b/packages/env/test/defaults.test.js
@@ -181,7 +181,7 @@ describe('Defaults', () => {
       process.env.PERCY_SKIP_GIT_CHECK = false;
     });
 
-    it('does not make git commands, if there are any', () => {
+    it('does not make git commands when set to true', () => {
       mockgit('mock branch').and.returnValue('');
 
       expect(env).toHaveProperty('git.sha', null);

--- a/packages/env/test/defaults.test.js
+++ b/packages/env/test/defaults.test.js
@@ -171,4 +171,22 @@ describe('Defaults', () => {
 
     expect(env).toHaveProperty('git.sha', null);
   });
+
+  describe('env PERCY_SKIP_GIT_CHECK', () => {
+  
+    beforeEach(() => {
+      process.env.PERCY_SKIP_GIT_CHECK = true;
+    });
+
+    afterAll(() => {
+      process.env.PERCY_SKIP_GIT_CHECK = false;
+    });
+
+    it('does not make git commands, if there are any', () => {
+      mockgit('mock branch').and.returnValue('');
+
+      expect(env).toHaveProperty('git.sha', null);
+    });
+  });
+
 });


### PR DESCRIPTION
When git is not installed locally,  percy-cli triggers git popup.


![image](https://github.com/percy/cli/assets/131665162/5eb370e7-a8b5-47bc-ba41-07314ad91fc6)

We have introduced a env var `PERCY_SKIP_GIT_CHECK`. When this is set to True, git commands will not be executed locally when using percy-cli.