### PR TITLE
[PER-2574] Icons not loading when `noscript` tags are present.

### DIFF
--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -15,7 +15,7 @@ export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
   let cloneNode = (node, parent) => {
     let walkTree = (nextn, nextp) => {
       while (nextn) {
-        if (nextn.nodeName != "NOSCRIPT"){
+        if (nextn.nodeName !== 'NOSCRIPT') {
           cloneNode(nextn, nextp);
         }
         nextn = nextn.nextSibling;

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -15,7 +15,9 @@ export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
   let cloneNode = (node, parent) => {
     let walkTree = (nextn, nextp) => {
       while (nextn) {
-        cloneNode(nextn, nextp);
+        if (nextn.nodeName != "NOSCRIPT"){
+          cloneNode(nextn, nextp);
+        }
         nextn = nextn.nextSibling;
       }
     };

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -10,12 +10,15 @@ import applyElementTransformations from './transform-dom';
  * Deep clone a document while also preserving shadow roots
  * returns document fragment
  */
+
+const ignoreTags = ['NOSCRIPT'];
+
 export function cloneNodeAndShadow({ dom, disableShadowDOM }) {
   // clones shadow DOM and light DOM for a given node
   let cloneNode = (node, parent) => {
     let walkTree = (nextn, nextp) => {
       while (nextn) {
-        if (nextn.nodeName !== 'NOSCRIPT') {
+        if (!ignoreTags.includes(nextn.nodeName)) {
           cloneNode(nextn, nextp);
         }
         nextn = nextn.nextSibling;

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -17,6 +17,14 @@ describe('serializeDOM', () => {
     expect(result.html).toContain('Hey Percy $&');
   });
 
+  it('excludes noscript tags when present', () => {
+    withExample('<p>Hey Percy $&</p><noscript>Your browser does not support JavaScript!</noscript>');
+
+    const result = serializeDOM();
+    expect(result.html).not.toContain('<noscript>');
+    expect(result.html).toContain('Hey Percy $&');
+  });
+
   it('optionally returns a stringified response', () => {
     expect(serializeDOM({ stringifyResponse: true }))
       .toMatch('{"html":".*","warnings":\\[\\],"resources":\\[\\]}');


### PR DESCRIPTION
We observed that when there are `noscript` tags are present in dom and using percy with sdk's, some icons were not getting loaded.
Asset discovery itself was not making requests to particular icon file.

This is fixed by excluding the `noscript` tags during cloning the dom.