### PR TITLE
Resolving race condition in snapshots flush

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -247,7 +247,7 @@ export const RESOURCE_CACHE_KEY = Symbol('resource-cache');
 // snapshot which is used to intercept and capture snapshot resource requests.
 export function createDiscoveryQueue(percy) {
   let { concurrency } = percy.config.discovery;
-  let queue = new Queue();
+  let queue = new Queue('discovery');
   let cache;
 
   return queue

--- a/packages/core/src/queue.js
+++ b/packages/core/src/queue.js
@@ -187,6 +187,9 @@ export class Queue {
   // clear and abort any queued tasks
   clear() {
     let tasks = [...this.#queued];
+    if (process.env.PERCY_QUEUE_STATS_LOGS) {
+      this.log.debug(`Clearing ${this.name} queue, queue size ${this.#queued.size}`);
+    }
     this.#queued.clear();
 
     for (let task of tasks) {

--- a/packages/core/src/queue.js
+++ b/packages/core/src/queue.js
@@ -287,7 +287,7 @@ export class Queue {
         // rest of the tasks but ideally it should wait for flushing of all the tasks till the last dequeued task.
         // if (!task?.stop && task?.pending != null) pending = positionOf(this.#pending, task);
         // call the callback and return true when not queued or pending
-        let position = (queued ?? 0) + (pending ?? 0);
+        let position = (queued ?? 0) + pending;
         callback?.(position);
         return !position;
       }, { idle: 10 });

--- a/packages/core/src/queue.js
+++ b/packages/core/src/queue.js
@@ -282,10 +282,6 @@ export class Queue {
         let queued, pending = this.#pending.size;
         // calculate the position within queued when not pending
         if (task && task.pending == null) queued = positionOf(this.#queued, task);
-        // calculate the position within pending when not stopping
-        // Commenting below line reason being currently if the task passed is found we will stop flushing
-        // rest of the tasks but ideally it should wait for flushing of all the tasks till the last dequeued task.
-        // if (!task?.stop && task?.pending != null) pending = positionOf(this.#pending, task);
         // call the callback and return true when not queued or pending
         let position = (queued ?? 0) + pending;
         callback?.(position);

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -284,7 +284,7 @@ function mergeSnapshotOptions(prev = {}, next) {
 // Creates a snapshots queue that manages a Percy build and uploads snapshots.
 export function createSnapshotsQueue(percy) {
   let { concurrency } = percy.config.discovery;
-  let queue = new Queue();
+  let queue = new Queue('snapshot');
   let build;
 
   return queue

--- a/packages/core/test/unit/queue.test.js
+++ b/packages/core/test/unit/queue.test.js
@@ -1,11 +1,13 @@
 import { AbortController, generatePromise, waitForTimeout } from '../../src/utils.js';
 import Queue from '../../src/queue.js';
+import { logger, setupTest } from '../helpers/index.js';
 
 describe('Unit / Tasks Queue', () => {
   let q;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     q = new Queue('test');
+    await setupTest();
   });
 
   it('has a customizable concurrency', () => {
@@ -238,10 +240,10 @@ describe('Unit / Tasks Queue', () => {
     let p1 = q.push('item #1');
     let p2 = q.push('item #2');
     expect(q.size).toBe(2);
-
+    q.log.loglevel('debug');
     q.close(true);
+    expect(logger.stderr).toEqual(jasmine.arrayContaining(['[percy:core:queue] Clearing test queue, queued state: 2, pending state: 0']));
     expect(q.size).toBe(0);
-
     await expectAsync(p1)
       .toBeRejectedWithError('This operation was aborted');
     await expectAsync(p2)
@@ -403,6 +405,7 @@ describe('Unit / Tasks Queue', () => {
 
   it('flushing queued task', async () => {
     q.set({ concurrency: 1 });
+    q.log.loglevel('debug');
     await q.start();
     let resolve, deferred = new Promise(r => (resolve = r));
     q.readyState = 2;
@@ -410,6 +413,7 @@ describe('Unit / Tasks Queue', () => {
     let p1 = q.push(deferred);
     expect(q.size).toBe(2);
     let promise = generatePromise(q.flush());
+    expect(logger.stderr).toEqual(jasmine.arrayContaining(['[percy:core:queue] Flushing test queue, queued state: 1, pending state: 1']));
     await expectAsync(promise).toBePending();
     await expectAsync(p1).toBePending();
     q.process(deferred);
@@ -421,10 +425,12 @@ describe('Unit / Tasks Queue', () => {
 
   it('empty flush', async () => {
     q.set({ concurrency: 1 });
+    q.log.loglevel('debug');
     await q.start();
     q.readyState = 2;
     expect(q.size).toBe(0);
     let promise = generatePromise(q.flush());
+    expect(logger.stderr).toEqual(jasmine.arrayContaining(['[percy:core:queue] Flushing test queue, queued state: 0, pending state: 0']));
     await expectAsync(promise).toBePending();
     await expectAsync(promise).toBeResolved();
   });

--- a/packages/core/test/unit/queue.test.js
+++ b/packages/core/test/unit/queue.test.js
@@ -419,6 +419,23 @@ describe('Unit / Tasks Queue', () => {
     expect(q.size).toBe(0);
   });
 
+  it('flushing pending task', async () => {
+    q.set({ concurrency: 1 });
+    await q.start();
+    let resolve, deferred = new Promise(r => (resolve = r));
+    q.readyState = 2;
+    let p1 = q.push(deferred);
+    expect(q.size).toBe(1);
+    let promise = generatePromise(q.flush());
+    await expectAsync(promise).toBePending();
+    await expectAsync(p1).toBePending();
+    q.process(deferred);
+    resolve();
+    await expectAsync(promise).toBeResolved();
+    await expectAsync(p1).toBeResolved();
+    expect(q.size).toBe(0);
+  });
+
   it('cancels the flush when aborted', async () => {
     let resolve, deferred = new Promise(r => (resolve = r));
     let p1 = q.push(deferred);

--- a/packages/core/test/unit/queue.test.js
+++ b/packages/core/test/unit/queue.test.js
@@ -401,6 +401,13 @@ describe('Unit / Tasks Queue', () => {
     expect(q.size).toBe(2);
   });
 
+  it('can wait for queued item as well', async () => {
+    q.set({ concurrency: 1 });
+    let p = q.push('item_1');
+    q.flush();
+    await expectAsync(p).toBeResolved();
+  });
+
   it('cancels the flush when aborted', async () => {
     let resolve, deferred = new Promise(r => (resolve = r));
     let p1 = q.push(deferred);

--- a/packages/core/test/unit/queue.test.js
+++ b/packages/core/test/unit/queue.test.js
@@ -419,23 +419,6 @@ describe('Unit / Tasks Queue', () => {
     expect(q.size).toBe(0);
   });
 
-  it('flushing pending task', async () => {
-    q.set({ concurrency: 1 });
-    await q.start();
-    let resolve, deferred = new Promise(r => (resolve = r));
-    q.readyState = 2;
-    let p1 = q.push(deferred);
-    expect(q.size).toBe(1);
-    let promise = generatePromise(q.flush());
-    await expectAsync(promise).toBePending();
-    await expectAsync(p1).toBePending();
-    q.process(deferred);
-    resolve();
-    await expectAsync(promise).toBeResolved();
-    await expectAsync(p1).toBeResolved();
-    expect(q.size).toBe(0);
-  });
-
   it('empty flush', async () => {
     q.set({ concurrency: 1 });
     await q.start();

--- a/packages/core/test/unit/queue.test.js
+++ b/packages/core/test/unit/queue.test.js
@@ -5,7 +5,7 @@ describe('Unit / Tasks Queue', () => {
   let q;
 
   beforeEach(() => {
-    q = new Queue();
+    q = new Queue('test');
   });
 
   it('has a customizable concurrency', () => {

--- a/packages/core/test/unit/queue.test.js
+++ b/packages/core/test/unit/queue.test.js
@@ -436,6 +436,16 @@ describe('Unit / Tasks Queue', () => {
     expect(q.size).toBe(0);
   });
 
+  it('empty flush', async () => {
+    q.set({ concurrency: 1 });
+    await q.start();
+    q.readyState = 2;
+    expect(q.size).toBe(0);
+    let promise = generatePromise(q.flush());
+    await expectAsync(promise).toBePending();
+    await expectAsync(promise).toBeResolved();
+  });
+
   it('cancels the flush when aborted', async () => {
     let resolve, deferred = new Promise(r => (resolve = r));
     let p1 = q.push(deferred);

--- a/packages/core/test/unit/queue.test.js
+++ b/packages/core/test/unit/queue.test.js
@@ -401,26 +401,6 @@ describe('Unit / Tasks Queue', () => {
     expect(q.size).toBe(2);
   });
 
-  it('can flush twice without interruption', async () => {
-    let resolve1, deferred1 = new Promise(r => (resolve1 = r));
-    let resolve2, deferred2 = new Promise(r => (resolve2 = r));
-
-    q.push(deferred1);
-    let p1 = generatePromise(q.flush());
-    await expectAsync(p1).toBePending();
-
-    q.push(deferred2);
-    let p2 = generatePromise(q.flush());
-    await expectAsync(p2).toBePending();
-
-    resolve1();
-    await expectAsync(p1).toBeResolved();
-    await expectAsync(p2).toBePending();
-
-    resolve2();
-    await expectAsync(p2).toBeResolved();
-  });
-
   it('cancels the flush when aborted', async () => {
     let resolve, deferred = new Promise(r => (resolve = r));
     let p1 = q.push(deferred);


### PR DESCRIPTION
Current flushing logic wait till only the last dequeued element to be resolve the promise and as soon as that happens we take early exit. Now it can be the case that there are still the snapshots in the queue which did not got flushed. Now if queue is marked as end, we will finalize the build, but as snpashots queue still has some elements it will try to finalize those after build is finalized till the time queue is cleared.