### PR TITLE
♻️  Refactor: added defaultmap + locking mechanism for intercepts queue

### DIFF
--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -167,6 +167,10 @@ export const configSchema = {
       disableCache: {
         type: 'boolean'
       },
+      captureMockedServiceWorker: {
+        type: 'boolean',
+        default: false
+      },
       requestHeaders: {
         type: 'object',
         normalize: false,
@@ -249,6 +253,7 @@ export const snapshotSchema = {
             requestHeaders: { $ref: '/config/discovery#/properties/requestHeaders' },
             authorization: { $ref: '/config/discovery#/properties/authorization' },
             disableCache: { $ref: '/config/discovery#/properties/disableCache' },
+            captureMockedServiceWorker: { $ref: '/config/discovery#/properties/captureMockedServiceWorker' },
             userAgent: { $ref: '/config/discovery#/properties/userAgent' },
             devicePixelRatio: { $ref: '/config/discovery#/properties/devicePixelRatio' }
           }

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -52,6 +52,7 @@ function debugSnapshotOptions(snapshot) {
   debugProp(snapshot, 'discovery.requestHeaders', JSON.stringify);
   debugProp(snapshot, 'discovery.authorization', JSON.stringify);
   debugProp(snapshot, 'discovery.disableCache');
+  debugProp(snapshot, 'discovery.captureMockedServiceWorker');
   debugProp(snapshot, 'discovery.userAgent');
   debugProp(snapshot, 'clientInfo');
   debugProp(snapshot, 'environmentInfo');
@@ -288,6 +289,7 @@ export function createDiscoveryQueue(percy) {
         requestHeaders: snapshot.discovery.requestHeaders,
         authorization: snapshot.discovery.authorization,
         userAgent: snapshot.discovery.userAgent,
+        captureMockedServiceWorker: snapshot.discovery.captureMockedServiceWorker,
         meta: snapshot.meta,
 
         // enable network inteception

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -1,34 +1,12 @@
 import { request as makeRequest } from '@percy/client/utils';
 import logger from '@percy/logger';
 import mime from 'mime-types';
-import { createResource, hostnameMatches, normalizeURL, waitFor } from './utils.js';
+import { DefaultMap, createResource, hostnameMatches, normalizeURL, waitFor } from './utils.js';
 
 const MAX_RESOURCE_SIZE = 25 * (1024 ** 2); // 25MB
 const ALLOWED_STATUSES = [200, 201, 301, 302, 304, 307, 308];
 const ALLOWED_RESOURCES = ['Document', 'Stylesheet', 'Image', 'Media', 'Font', 'Other'];
 const ABORTED_MESSAGE = 'Request was aborted by browser';
-
-// DefaultMap, which returns a default value for an uninitialized key
-// Similar to defaultDict in python
-class DefaultMap extends Map {
-  constructor(getDefaultValue, ...mapConstructorArgs) {
-    super(...mapConstructorArgs);
-
-    if (typeof getDefaultValue !== 'function') {
-      throw new Error('getDefaultValue must be a function');
-    }
-
-    this.getDefaultValue = getDefaultValue;
-  }
-
-  get = (key) => {
-    if (!this.has(key)) {
-      this.set(key, this.getDefaultValue(key));
-    }
-
-    return super.get(key);
-  };
-};
 
 // RequestLifeCycleHandler handles life cycle of a requestId
 // Ideal flow:          requestWillBeSent -> requestPaused -> responseReceived -> loadingFinished / loadingFailed

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -29,7 +29,6 @@ export class Network {
   #requestsLifeCycleHandler = new DefaultMap(() => new RequestLifeCycleHandler());
   #pending = new Map();
   #requests = new Map();
-  // #intercepts = new Map();
   #authentications = new Set();
   #aborted = new Set();
 
@@ -137,7 +136,6 @@ export class Network {
 
     if (!keepPending) {
       this.#pending.delete(requestId);
-      // this.#intercepts.delete(requestId);
     }
   }
 

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -271,7 +271,7 @@ export class Network {
     // note: we are waiting on requestWillBeSent and NOT responseReceived
     // since, requests can be cancelled in-flight without Network.responseReceived having been triggered
     // and in any case, order of processing for responseReceived and loadingFailed does not matter, as response capturing is done in loadingFinished
-    await this.#requestsLifeCycleHandler.get(requestId).requestWillBeSent
+    await this.#requestsLifeCycleHandler.get(requestId).requestWillBeSent;
     let request = this.#requests.get(event.requestId);
     /* istanbul ignore if: race condition paranioa */
     if (!request) return;

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -37,6 +37,7 @@ export class Network {
     this.timeout = options.networkIdleTimeout ?? 100;
     this.authorization = options.authorization;
     this.requestHeaders = options.requestHeaders ?? {};
+    this.captureMockedServiceWorker = options.captureMockedServiceWorker ?? false;
     this.userAgent = options.userAgent ??
       // by default, emulate a non-headless browser
       page.session.browser.version.userAgent.replace('Headless', '');
@@ -54,7 +55,7 @@ export class Network {
 
     let commands = [
       session.send('Network.enable'),
-      session.send('Network.setBypassServiceWorker', { bypass: true }),
+      session.send('Network.setBypassServiceWorker', { bypass: !this.captureMockedServiceWorker }),
       session.send('Network.setCacheDisabled', { cacheDisabled: true }),
       session.send('Network.setUserAgentOverride', { userAgent: this.userAgent }),
       session.send('Network.setExtraHTTPHeaders', { headers: this.requestHeaders })
@@ -178,13 +179,16 @@ export class Network {
   // Called when a request will be sent. If the request has already been intercepted, handle it;
   // otherwise set it to be pending until it is paused.
   _handleRequestWillBeSent = async event => {
-    let { requestId, request } = event;
+    let { requestId, request, type } = event;
 
     // do not handle data urls
     if (request.url.startsWith('data:')) return;
 
     if (this.intercept) {
       this.#pending.set(requestId, event);
+      if (this.captureMockedServiceWorker) {
+        await this._handleRequest(undefined, { ...event, resourceType: type, interceptId: requestId }, true);
+      }
     }
     // release request
     // note: we are releasing this, even if intercept is not set for network.js
@@ -195,7 +199,7 @@ export class Network {
   // Called when a pending request is paused. Handles associating redirected requests with
   // responses and calls this.onrequest with request info and callbacks to continue, respond,
   // or abort a request. One of the callbacks is required to be called and only one.
-  _handleRequest = async (session, event) => {
+  _handleRequest = async (session, event, serviceWorker = false) => {
     let { request, requestId, interceptId, resourceType } = event;
     let redirectChain = [];
 
@@ -213,7 +217,9 @@ export class Network {
     request.redirectChain = redirectChain;
     this.#requests.set(requestId, request);
 
-    await sendResponseResource(this, request, session);
+    if (!serviceWorker) {
+      await sendResponseResource(this, request, session);
+    }
   }
 
   // Called when a response has been received for a specific request. Associates the response with

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -172,10 +172,9 @@ export class Network {
     this.#pending.delete(requestId);
 
     // guard against redirects with the same requestId
-    if (pending?.request.url === event.request.url &&
-        pending.request.method === event.request.method) {
-      await this._handleRequest(session, { ...pending, resourceType, interceptId });
-    }
+    pending?.request.url === event.request.url &&
+    pending.request.method === event.request.method &&
+    await this._handleRequest(session, { ...pending, resourceType, interceptId });
   }
 
   // Called when a request will be sent. If the request has already been intercepted, handle it;

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -114,6 +114,7 @@ function getSnapshotOptions(options, { config, meta }) {
       requestHeaders: config.discovery.requestHeaders,
       authorization: config.discovery.authorization,
       disableCache: config.discovery.disableCache,
+      captureMockedServiceWorker: config.discovery.captureMockedServiceWorker,
       userAgent: config.discovery.userAgent
     }
   }, options], (path, prev, next) => {

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -320,3 +320,25 @@ export function serializeFunction(fn) {
 
   return fnbody;
 }
+
+// DefaultMap, which returns a default value for an uninitialized key
+// Similar to defaultDict in python
+export class DefaultMap extends Map {
+  constructor(getDefaultValue, ...mapConstructorArgs) {
+    super(...mapConstructorArgs);
+
+    if (typeof getDefaultValue !== 'function') {
+      throw new Error('getDefaultValue must be a function');
+    }
+
+    this.getDefaultValue = getDefaultValue;
+  }
+
+  get = (key) => {
+    if (!this.has(key)) {
+      this.set(key, this.getDefaultValue(key));
+    }
+
+    return super.get(key);
+  };
+};

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -1970,4 +1970,68 @@ describe('Discovery', () => {
       });
     });
   });
+
+  describe('Service Worker =>', () => {
+    it('captures original request', async () => {
+      server.reply('/sw.js', () => [200, 'text/javascript', dedent`
+      const fetchUpstream = async(request) => {
+        return await fetch(request.clone());
+      }
+      
+      self.addEventListener('fetch', (event) => {
+        const { request } = event
+        event.respondWith(fetchUpstream(request));
+      });
+      
+      self.addEventListener("activate", (event) => {
+        event.waitUntil(clients.claim());
+      });
+      `]);
+
+      server.reply('/app.js', () => [200, 'text/javascript', dedent`
+      const registerServiceWorker = async () => {
+        await navigator.serviceWorker.register('sw.js',{ scope: './', });
+      };
+      
+      await registerServiceWorker();
+      
+      // create and insert image element which will be intercepted and resolved by service worker
+      // adding a sleep of 1s for service worker to get activated
+      await new Promise(r => setTimeout(r, 1000));
+      var img = document.createElement('img');
+      img.id = 'injected-image';
+      img.src = './img.gif';
+      document.getElementById('container').appendChild(img);
+      `]);
+
+      server.reply('/', () => [200, 'text/html', dedent`
+      <!DOCTYPE html><html><head></head><body>
+        <div id="container"></div>
+        <script type="module" src="app.js"></script>
+      </body></html>
+      `]);
+
+      await percy.snapshot({
+        name: 'first service worker snapshot',
+        url: 'http://localhost:8000',
+        waitForSelector: '#injected-image',
+        discovery: {
+          captureMockedServiceWorker: true
+        }
+      });
+
+      await percy.idle();
+
+      let paths = server.requests.map(r => r[0]);
+      expect(paths).toContain('/img.gif');
+      expect(captured).toContain(jasmine.arrayContaining([
+        jasmine.objectContaining({
+          id: sha256hash(pixel),
+          attributes: jasmine.objectContaining({
+            'resource-url': 'http://localhost:8000/img.gif'
+          })
+        })
+      ]));
+    });
+  });
 });

--- a/packages/core/test/unit/utils.test.js
+++ b/packages/core/test/unit/utils.test.js
@@ -2,7 +2,8 @@ import {
   generatePromise,
   AbortController,
   yieldTo,
-  yieldAll
+  yieldAll,
+  DefaultMap
 } from '../../src/utils.js';
 
 describe('Unit / Utils', () => {
@@ -163,6 +164,23 @@ describe('Unit / Utils', () => {
       await expectAsync(promise).toBeResolved();
       await expectAsync(gen.next()).toBeResolvedTo(
         { done: true, value: [2, 4, null, 3, 6] });
+    });
+  });
+
+  describe('DefaultMap', () => {
+    it('should throw an error if getDefaultValue is not a function', () => {
+      expect(() => new DefaultMap('not a function')).toThrow(new Error('getDefaultValue must be a function'));
+    });
+
+    it('should return the default value for a key that has not been set', () => {
+      const map = new DefaultMap((key) => `default value for ${key}`);
+      expect(map.get('testKey')).toEqual('default value for testKey');
+    });
+
+    it('should return the correct value for a key that has been set', () => {
+      const map = new DefaultMap((key) => `default value for ${key}`);
+      map.set('testKey', 'testValue');
+      expect(map.get('testKey')).toEqual('testValue');
     });
   });
 });

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -18,6 +18,7 @@ interface DiscoveryOptions {
   authorization?: AuthCredentials;
   allowedHostnames?: string[];
   disableCache?: boolean;
+  captureMockedServiceWorker?: boolean;
 }
 
 interface DiscoveryLaunchOptions {


### PR DESCRIPTION
**Context-**
- Percy relies on CDP messages to intercept and capture network requests.
- CDP uses websockets, and since websockets run on TCP, at network layer it is guaranteed that the packets will always be transmitted in order.
- But at application level, packets can be processed out of order which can cause issues.
- Hence, adding a locking mechanism so that events are always processed in order at Application layer as well.
- The ideal flow of messages should be -
- - `requestWillBeSent` -> `requestPaused` -> `responseReceived` -> `loadingFinished` / `loadingFailed`

**Note:** Also merged #1443 in this PR.