### PR TITLE
Capture service worker intercepted requests

### DIFF
--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -167,7 +167,7 @@ export const configSchema = {
       disableCache: {
         type: 'boolean'
       },
-      captureServiceWorker: {
+      captureMockedServiceWorker: {
         type: 'boolean',
         default: false
       },
@@ -253,7 +253,7 @@ export const snapshotSchema = {
             requestHeaders: { $ref: '/config/discovery#/properties/requestHeaders' },
             authorization: { $ref: '/config/discovery#/properties/authorization' },
             disableCache: { $ref: '/config/discovery#/properties/disableCache' },
-            captureServiceWorker: { $ref: '/config/discovery#/properties/captureServiceWorker' },
+            captureMockedServiceWorker: { $ref: '/config/discovery#/properties/captureMockedServiceWorker' },
             userAgent: { $ref: '/config/discovery#/properties/userAgent' },
             devicePixelRatio: { $ref: '/config/discovery#/properties/devicePixelRatio' }
           }

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -167,6 +167,10 @@ export const configSchema = {
       disableCache: {
         type: 'boolean'
       },
+      captureServiceWorker: {
+        type: 'boolean',
+        default: false
+      },
       requestHeaders: {
         type: 'object',
         normalize: false,
@@ -249,6 +253,7 @@ export const snapshotSchema = {
             requestHeaders: { $ref: '/config/discovery#/properties/requestHeaders' },
             authorization: { $ref: '/config/discovery#/properties/authorization' },
             disableCache: { $ref: '/config/discovery#/properties/disableCache' },
+            captureServiceWorker: { $ref: '/config/discovery#/properties/captureServiceWorker' },
             userAgent: { $ref: '/config/discovery#/properties/userAgent' },
             devicePixelRatio: { $ref: '/config/discovery#/properties/devicePixelRatio' }
           }

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -52,6 +52,7 @@ function debugSnapshotOptions(snapshot) {
   debugProp(snapshot, 'discovery.requestHeaders', JSON.stringify);
   debugProp(snapshot, 'discovery.authorization', JSON.stringify);
   debugProp(snapshot, 'discovery.disableCache');
+  debugProp(snapshot, 'discovery.captureServiceWorker');
   debugProp(snapshot, 'discovery.userAgent');
   debugProp(snapshot, 'clientInfo');
   debugProp(snapshot, 'environmentInfo');

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -289,6 +289,7 @@ export function createDiscoveryQueue(percy) {
         requestHeaders: snapshot.discovery.requestHeaders,
         authorization: snapshot.discovery.authorization,
         userAgent: snapshot.discovery.userAgent,
+        captureServiceWorker: snapshot.discovery.captureServiceWorker,
         meta: snapshot.meta,
 
         // enable network inteception

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -52,7 +52,7 @@ function debugSnapshotOptions(snapshot) {
   debugProp(snapshot, 'discovery.requestHeaders', JSON.stringify);
   debugProp(snapshot, 'discovery.authorization', JSON.stringify);
   debugProp(snapshot, 'discovery.disableCache');
-  debugProp(snapshot, 'discovery.captureServiceWorker');
+  debugProp(snapshot, 'discovery.captureMockedServiceWorker');
   debugProp(snapshot, 'discovery.userAgent');
   debugProp(snapshot, 'clientInfo');
   debugProp(snapshot, 'environmentInfo');
@@ -289,7 +289,7 @@ export function createDiscoveryQueue(percy) {
         requestHeaders: snapshot.discovery.requestHeaders,
         authorization: snapshot.discovery.authorization,
         userAgent: snapshot.discovery.userAgent,
-        captureServiceWorker: snapshot.discovery.captureServiceWorker,
+        captureMockedServiceWorker: snapshot.discovery.captureMockedServiceWorker,
         meta: snapshot.meta,
 
         // enable network inteception

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -37,7 +37,7 @@ export class Network {
     this.timeout = options.networkIdleTimeout ?? 100;
     this.authorization = options.authorization;
     this.requestHeaders = options.requestHeaders ?? {};
-    this.captureServiceWorker = options.captureServiceWorker ?? false;
+    this.captureMockedServiceWorker = options.captureMockedServiceWorker ?? false;
     this.userAgent = options.userAgent ??
       // by default, emulate a non-headless browser
       page.session.browser.version.userAgent.replace('Headless', '');
@@ -55,7 +55,7 @@ export class Network {
 
     let commands = [
       session.send('Network.enable'),
-      session.send('Network.setBypassServiceWorker', { bypass: !this.captureServiceWorker }),
+      session.send('Network.setBypassServiceWorker', { bypass: !this.captureMockedServiceWorker }),
       session.send('Network.setCacheDisabled', { cacheDisabled: true }),
       session.send('Network.setUserAgentOverride', { userAgent: this.userAgent }),
       session.send('Network.setExtraHTTPHeaders', { headers: this.requestHeaders })
@@ -186,7 +186,7 @@ export class Network {
 
     if (this.intercept) {
       this.#pending.set(requestId, event);
-      if (this.captureServiceWorker) {
+      if (this.captureMockedServiceWorker) {
         await this._handleRequest(undefined, { ...event, resourceType: type, interceptId: requestId }, true);
       }
     }

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -55,7 +55,7 @@ export class Network {
 
     let commands = [
       session.send('Network.enable'),
-      session.send('Network.setBypassServiceWorker', { bypass: !this.captureServiceWorker}),
+      session.send('Network.setBypassServiceWorker', { bypass: !this.captureServiceWorker }),
       session.send('Network.setCacheDisabled', { cacheDisabled: true }),
       session.send('Network.setUserAgentOverride', { userAgent: this.userAgent }),
       session.send('Network.setExtraHTTPHeaders', { headers: this.requestHeaders })
@@ -187,7 +187,7 @@ export class Network {
     if (this.intercept) {
       this.#pending.set(requestId, event);
       if (this.captureServiceWorker) {
-        await this._handleRequest(undefined, {...event, resourceType: type, interceptId: requestId}, true);
+        await this._handleRequest(undefined, { ...event, resourceType: type, interceptId: requestId }, true);
       }
     }
     // release request
@@ -217,7 +217,7 @@ export class Network {
     request.redirectChain = redirectChain;
     this.#requests.set(requestId, request);
 
-    if(!serviceWorker){
+    if (!serviceWorker) {
       await sendResponseResource(this, request, session);
     }
   }

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -114,6 +114,7 @@ function getSnapshotOptions(options, { config, meta }) {
       requestHeaders: config.discovery.requestHeaders,
       authorization: config.discovery.authorization,
       disableCache: config.discovery.disableCache,
+      captureServiceWorker: config.discovery.captureServiceWorker,
       userAgent: config.discovery.userAgent
     }
   }, options], (path, prev, next) => {

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -114,7 +114,7 @@ function getSnapshotOptions(options, { config, meta }) {
       requestHeaders: config.discovery.requestHeaders,
       authorization: config.discovery.authorization,
       disableCache: config.discovery.disableCache,
-      captureServiceWorker: config.discovery.captureServiceWorker,
+      captureMockedServiceWorker: config.discovery.captureMockedServiceWorker,
       userAgent: config.discovery.userAgent
     }
   }, options], (path, prev, next) => {

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -2016,7 +2016,7 @@ describe('Discovery', () => {
         url: 'http://localhost:8000',
         waitForSelector: '#injected-image',
         discovery: {
-          captureServiceWorker: true
+          captureMockedServiceWorker: true
         }
       });
 

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -18,7 +18,7 @@ interface DiscoveryOptions {
   authorization?: AuthCredentials;
   allowedHostnames?: string[];
   disableCache?: boolean;
-  captureServiceWorker?: boolean;
+  captureMockedServiceWorker?: boolean;
 }
 
 interface DiscoveryLaunchOptions {

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -18,6 +18,7 @@ interface DiscoveryOptions {
   authorization?: AuthCredentials;
   allowedHostnames?: string[];
   disableCache?: boolean;
+  captureServiceWorker?: boolean;
 }
 
 interface DiscoveryLaunchOptions {


### PR DESCRIPTION
**Changes**:
- [x] Added `captureMockedServiceWorker` flag under `discovery` for capturing service worker requests
- [x]  Set `bypass: false` for `Network.setBypassServiceWorker`  so that service-worker controller can be added and we can access the MSW mocks customer has added.
- [x] Added `serviceWorker` parameter, to handleRequests that are not intercepted _(since service worker intercepted and will resolve them)_

**Detailed Changes & Reasoning**:
- Added `Network.setBypassServiceWorker` to `bypass: false` so that we can add service-worker controller and access service worker that mocks customer's data.
- Initially tried to access service-worker requests using `Network.getResponseBody`, but over here `body` is returned as `""` _(empty string)_ randomly.
- - Tried to look on the internet about why this happens, but no luck :(
- Finally, decided to call `Network.getResponseBody` on the original request which service-worker intercepted.
- - `Network.getResponseBody` is same as what appears in the `Response` tab in Network section in devtools.
- - For requests that were intercepted by service-worker, the `Response` tab is **always** populated.
- - But the service-worker which makes the request upstream or returns mocked data randomly returns `body: ""` when `Network.getResponseBody` is called on it.
- - Hence, relying on calling `Network.getResponseBody` on the original request itself.

**Related PRs**:
https://github.com/percy/percy-storybook/pull/845