### PR TITLE
fix: always set percy-data attributes when serializing

### DIFF
--- a/packages/dom/src/prepare-dom.js
+++ b/packages/dom/src/prepare-dom.js
@@ -6,18 +6,13 @@ export function uid() {
 export function markElement(domElement, disableShadowDOM) {
   // Mark elements that are to be serialized later with a data attribute.
   if (['input', 'textarea', 'select', 'iframe', 'canvas', 'video', 'style'].includes(domElement.tagName?.toLowerCase())) {
-    if (!domElement.getAttribute('data-percy-element-id')) {
-      domElement.setAttribute('data-percy-element-id', uid());
-    }
+    domElement.setAttribute('data-percy-element-id', uid());
   }
 
   // add special marker for shadow host
   if (!disableShadowDOM && domElement.shadowRoot) {
     domElement.setAttribute('data-percy-shadow-host', '');
-
-    if (!domElement.getAttribute('data-percy-element-id')) {
-      domElement.setAttribute('data-percy-element-id', uid());
-    }
+    domElement.setAttribute('data-percy-element-id', uid());
   }
 }
 

--- a/packages/dom/test/helpers.js
+++ b/packages/dom/test/helpers.js
@@ -120,7 +120,7 @@ export function getTestBrowser() {
 
 export const platforms = (() => {
   if (getTestBrowser() === chromeBrowser) {
-    return ['shadow', 'plain'];
+    return ['plain', 'shadow'];
   }
   return ['plain'];
 })();

--- a/packages/dom/test/helpers.js
+++ b/packages/dom/test/helpers.js
@@ -120,7 +120,7 @@ export function getTestBrowser() {
 
 export const platforms = (() => {
   if (getTestBrowser() === chromeBrowser) {
-    return ['plain', 'shadow'];
+    return ['shadow', 'plain'];
   }
   return ['plain'];
 })();

--- a/packages/dom/test/serialize-inputs.test.js
+++ b/packages/dom/test/serialize-inputs.test.js
@@ -62,7 +62,7 @@ describe('serializeInputs', () => {
         }
       });
       cache[platform].$ = parseDOM(serializeDOM(), platform);
-      cache[platform].dom = platform === 'shadow' ? dom : dom.cloneNode(true)
+      cache[platform].dom = platform === 'shadow' ? dom : dom.cloneNode(true);
     });
     // interact with the inputs to update properties (does not update attributes)
   });

--- a/packages/dom/test/serialize-inputs.test.js
+++ b/packages/dom/test/serialize-inputs.test.js
@@ -4,9 +4,8 @@ import serializeDOM from '@percy/dom';
 describe('serializeInputs', () => {
   let cache = { shadow: {}, plain: {} };
 
-  beforeAll(async () => {
-    platforms.forEach((platform) => {
-      withExample(`
+  beforeEach(async () => {
+    withExample(`
       <form>
         <label for="name">Name</label>
         <input id="name" type="text" />
@@ -43,6 +42,7 @@ describe('serializeInputs', () => {
         <textarea id="feedback"></textarea>
       </form>
     `);
+    platforms.forEach((platform) => {
       const dom = platformDOM(platform);
       dom.querySelector('#name').value = 'Bob Boberson';
       dom.querySelector('#valueAttr').value = 'Replacement Value!';

--- a/packages/dom/test/serialize-inputs.test.js
+++ b/packages/dom/test/serialize-inputs.test.js
@@ -126,17 +126,9 @@ describe('serializeInputs', () => {
       expect(dom.querySelectorAll('[data-percy-element-id]')).toHaveSize(platform === 'plain' ? 10 : 9);
     });
 
-    fit(`${platform}: adds matching guids to the orignal DOM and cloned DOM`, () => {
+    it(`${platform}: adds matching guids to the orignal DOM and cloned DOM`, () => {
       let og = dom.querySelector('[data-percy-element-id]').getAttribute('data-percy-element-id');
       expect(og).toEqual($('[data-percy-element-id]')[0].getAttribute('data-percy-element-id'));
-    });
-
-    it(`${platform}: does not override previous guids when reserializing`, () => {
-      let getUid = () => dom.querySelector('[data-percy-element-id]').getAttribute('data-percy-element-id');
-      let first = getUid();
-
-      serializeDOM();
-      expect(getUid()).toEqual(first);
     });
 
     it(`${platform}: does not mutate values in origial DOM`, () => {

--- a/packages/dom/test/serialize-inputs.test.js
+++ b/packages/dom/test/serialize-inputs.test.js
@@ -42,6 +42,7 @@ describe('serializeInputs', () => {
         <textarea id="feedback"></textarea>
       </form>
     `);
+
     platforms.forEach((platform) => {
       const dom = platformDOM(platform);
       dom.querySelector('#name').value = 'Bob Boberson';
@@ -62,6 +63,8 @@ describe('serializeInputs', () => {
         }
       });
       cache[platform].$ = parseDOM(serializeDOM(), platform);
+      // save DOM, only after serializing it
+      // clone DOM, so that during next platform iteration, serializeDOM doesn't change current original DOM
       cache[platform].dom = platform === 'shadow' ? dom : dom.cloneNode(true);
     });
     // interact with the inputs to update properties (does not update attributes)

--- a/packages/dom/test/serialize-inputs.test.js
+++ b/packages/dom/test/serialize-inputs.test.js
@@ -4,8 +4,9 @@ import serializeDOM from '@percy/dom';
 describe('serializeInputs', () => {
   let cache = { shadow: {}, plain: {} };
 
-  beforeEach(async () => {
-    withExample(`
+  beforeAll(async () => {
+    platforms.forEach((platform) => {
+      withExample(`
       <form>
         <label for="name">Name</label>
         <input id="name" type="text" />
@@ -42,8 +43,6 @@ describe('serializeInputs', () => {
         <textarea id="feedback"></textarea>
       </form>
     `);
-
-    platforms.forEach((platform) => {
       const dom = platformDOM(platform);
       dom.querySelector('#name').value = 'Bob Boberson';
       dom.querySelector('#valueAttr').value = 'Replacement Value!';
@@ -127,7 +126,7 @@ describe('serializeInputs', () => {
       expect(dom.querySelectorAll('[data-percy-element-id]')).toHaveSize(platform === 'plain' ? 10 : 9);
     });
 
-    it(`${platform}: adds matching guids to the orignal DOM and cloned DOM`, () => {
+    fit(`${platform}: adds matching guids to the orignal DOM and cloned DOM`, () => {
       let og = dom.querySelector('[data-percy-element-id]').getAttribute('data-percy-element-id');
       expect(og).toEqual($('[data-percy-element-id]')[0].getAttribute('data-percy-element-id'));
     });

--- a/packages/dom/test/serialize-inputs.test.js
+++ b/packages/dom/test/serialize-inputs.test.js
@@ -61,8 +61,8 @@ describe('serializeInputs', () => {
           option.selected = false;
         }
       });
-      cache[platform].dom = dom;
       cache[platform].$ = parseDOM(serializeDOM(), platform);
+      cache[platform].dom = platform === 'shadow' ? dom : dom.cloneNode(true)
     });
     // interact with the inputs to update properties (does not update attributes)
   });


### PR DESCRIPTION
**context-**
- when we serialize dom, we check if `data-percy-element-id` is already available, if yes we do not add a new one.
- this `data-percy-element-id` attribute is used to create url's for serialized canvas.
- in defer-uploads, we might end up serializing same dom twice, after resizing it.
- hence, in current implementation below is the flow of events -
- - resize page to 1200 and seriaze dom and generate `data-percy-element-id` for canvas as - `abcd` 
- - resize dom to 500px, and trigger seriaize dom again.
- - since canvas attribute already has `data-percy-element-id` therefore, we do not assign a new one.
- - hence, we serialize the canvas to image at 500px, and use the same url - `abcd` for this
- - hence, we captured canvas at 1200px and 500px, and both the times we named it the exact same value of `abcd` which was derived from `data-percy-element-id` which we have not updated when seriazing 500px dome.

**related pr's-**
- https://github.com/percy/percy-storybook/pull/847