### PR TITLE
Fixing ignoreRegions for POA Full Page

### DIFF
--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -38,7 +38,7 @@ export default class GenericProvider {
     this.pageYShiftFactor = 0;
     this.currentTag = null;
     this.removeElementShiftFactor = 50000;
-    this.initialScrollFactor = null;
+    this.initialScrollLocation = null;
   }
 
   addDefaultOptions() {
@@ -73,23 +73,23 @@ export default class GenericProvider {
     return await this.driver.executeScript({ script: 'return [parseInt(window.scrollX), parseInt(window.scrollY)];', args: [] });
   }
 
-  async getInitialScrollFactor() {
-    if (this.initialScrollFactor) {
-      return this.initialScrollFactor;
+  async getInitialScrollPosition() {
+    if (this.initialScrollLocation) {
+      return this.initialScrollLocation;
     }
-    this.initialScrollFactor = await this.getScrollDetails();
-    return this.initialScrollFactor;
+    this.initialScrollLocation = await this.getScrollDetails();
+    return this.initialScrollLocation;
   }
 
   async getInitialPosition() {
     if (this.currentTag.osName === 'iOS') {
-      this.initialScrollFactor = await this.getInitialScrollFactor();
+      this.initialScrollLocation = await this.getInitialScrollPosition();
     }
   }
 
   async scrollToInitialPosition() {
     if (this.currentTag.osName === 'iOS') {
-      await this.driver.executeScript({ script: `window.scrollTo(${this.initialScrollFactor.value[0]}, ${this.initialScrollFactor.value[1]})`, args: [] });
+      await this.driver.executeScript({ script: `window.scrollTo(${this.initialScrollLocation.value[0]}, ${this.initialScrollLocation.value[1]})`, args: [] });
     }
   }
 
@@ -259,7 +259,7 @@ export default class GenericProvider {
     const scaleFactor = await this.metaData.devicePixelRatio();
     let scrollX = 0, scrollY = 0;
     if (this.options?.fullPage) {
-      const scrollParams = await this.getInitialScrollFactor();
+      const scrollParams = await this.getInitialScrollPosition();
       scrollX = scrollParams.value[0];
       scrollY = scrollParams.value[1];
     }
@@ -307,7 +307,7 @@ export default class GenericProvider {
     }
     this.pageXShiftFactor = this.currentTag.osName === 'iOS' ? 0 : (-(scrollFactors.value[0] * scaleFactor));
     if (this.currentTag.osName === 'iOS' && !this.options?.fullPage) {
-      if (scrollFactors.value[0] !== this.initialScrollFactor.value[0] || scrollFactors.value[1] !== this.initialScrollFactor.value[1]) {
+      if (scrollFactors.value[0] !== this.initialScrollLocation.value[0] || scrollFactors.value[1] !== this.initialScrollLocation.value[1]) {
         this.pageXShiftFactor = (-1 * this.removeElementShiftFactor);
         this.pageYShiftFactor = (-1 * this.removeElementShiftFactor);
       } else if (location.y === 0) {

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -454,152 +454,23 @@ describe('GenericProvider', () => {
     let provider;
     let mockLocation = { x: 10, y: 20, width: 100, height: 200 };
     let scrollFactors = { value: [0, 0] };
-    describe('When singlepage screenshot', () => {
-      describe('When on Tile 0', () => {
-        beforeEach(async () => {
-          // mock metadata
-          provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
-          provider.currentTag = { osName: 'Windows' };
-          await provider.createDriver();
-          spyOn(DesktopMetaData.prototype, 'devicePixelRatio')
-            .and.returnValue(1);
-          spyOn(GenericProvider.prototype, 'getScrollDetails')
-            .and.returnValue(scrollFactors);
-          spyOn(Driver.prototype, 'rect').and.returnValue(Promise.resolve(mockLocation));
-        });
 
-        it('should return a JSON object with the correct selector and coordinates for tile 0', async () => {
-          await provider.createDriver();
+    function expectRegionObject(scrollX, scrollY) {
+      it('should return a JSON object with the correct selector and coordinates for tile', async () => {
+        // Call function with mock data
+        const selector = 'mock-selector';
+        const result = await provider.getRegionObject(selector, 'mockElementId');
 
-          // Call function with mock data
-          const selector = 'mock-selector';
-          const result = await provider.getRegionObject(selector, 'mockElementId');
-
-          // Assert expected result
-          expect(result.selector).toEqual(selector);
-          expect(result.coOrdinates).toEqual({
-            top: mockLocation.y,
-            bottom: mockLocation.y + mockLocation.height,
-            left: mockLocation.x,
-            right: mockLocation.x + mockLocation.width
-          });
+        // Assert expected result
+        expect(result.selector).toEqual(selector);
+        expect(result.coOrdinates).toEqual({
+          top: mockLocation.y + scrollY + provider.pageYShiftFactor,
+          bottom: mockLocation.y + mockLocation.height + scrollY + provider.pageYShiftFactor,
+          left: mockLocation.x + scrollX + provider.pageXShiftFactor,
+          right: mockLocation.x + mockLocation.width + scrollX + provider.pageXShiftFactor
         });
       });
-
-      describe('When on Tile 1', () => {
-        beforeEach(async () => {
-          // mock metadata
-          provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
-          provider.currentTag = { osName: 'iOS' };
-          await provider.createDriver();
-          spyOn(DesktopMetaData.prototype, 'devicePixelRatio')
-            .and.returnValue(1);
-          spyOn(GenericProvider.prototype, 'getScrollDetails')
-            .and.returnValue(scrollFactors);
-          spyOn(Driver.prototype, 'rect').and.returnValue(Promise.resolve(mockLocation));
-          provider.pageYShiftFactor = -10;
-          provider.initialScrollFactor = scrollFactors;
-        });
-
-        afterEach(() => {
-          provider.pageYShiftFactor = 0;
-          provider.currentTag = null;
-        });
-        it('should return a JSON object with the correct selector and coordinates', async () => {
-          await provider.createDriver();
-
-          // Call function with mock data
-          const selector = 'mock-selector';
-          const result = await provider.getRegionObject(selector, 'mockElementId');
-
-          // Assert expected result
-          expect(result.selector).toEqual(selector);
-          expect(result.coOrdinates).toEqual({
-            top: mockLocation.y + provider.pageYShiftFactor,
-            bottom: mockLocation.y + mockLocation.height + provider.pageYShiftFactor,
-            left: mockLocation.x,
-            right: mockLocation.x + mockLocation.width
-          });
-        });
-      });
-    });
-
-    describe('When fullpage screenshot', () => {
-      describe('When no scroll', () => {
-        beforeEach(async () => {
-          // mock metadata
-          provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'client', 'environment', { fullPage: true });
-          provider.currentTag = { osName: 'Windows' };
-          await provider.createDriver();
-          spyOn(DesktopMetaData.prototype, 'devicePixelRatio')
-            .and.returnValue(1);
-          spyOn(Driver.prototype, 'executeScript')
-            .and.returnValue({ value: [0, 0] });
-          spyOn(Driver.prototype, 'rect').and.returnValue(Promise.resolve(mockLocation));
-        });
-
-        it('should return a JSON object with the correct selector and coordinates for tile 0', async () => {
-          await provider.createDriver();
-
-          // Call function with mock data
-          const selector = 'mock-selector';
-          const result = await provider.getRegionObject(selector, 'mockElementId');
-
-          // Assert expected result
-          expect(result.selector).toEqual(selector);
-          expect(result.coOrdinates).toEqual({
-            top: mockLocation.y,
-            bottom: mockLocation.y + mockLocation.height,
-            left: mockLocation.x,
-            right: mockLocation.x + mockLocation.width
-          });
-        });
-      });
-
-      describe('When there is a scroll', () => {
-        let scrollX = 10;
-        let scrollY = 20;
-        beforeEach(async () => {
-          // mock metadata
-          provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'client', 'environment', { fullPage: true });
-          provider.currentTag = { osName: 'iOS' };
-          await provider.createDriver();
-          spyOn(DesktopMetaData.prototype, 'devicePixelRatio')
-            .and.returnValue(1);
-          spyOn(GenericProvider.prototype, 'getScrollDetails')
-            .and.returnValue({ value: [scrollX, scrollY] });
-          spyOn(Driver.prototype, 'rect').and.returnValue(Promise.resolve(mockLocation));
-          provider.pageYShiftFactor = -10;
-        });
-
-        afterEach(() => {
-          provider.pageYShiftFactor = 0;
-          provider.currentTag = null;
-        });
-        it('should return a JSON object with the correct selector and coordinates', async () => {
-          await provider.createDriver();
-
-          // Call function with mock data
-          const selector = 'mock-selector';
-          const result = await provider.getRegionObject(selector, 'mockElementId');
-
-          // Assert expected result
-          expect(result.selector).toEqual(selector);
-          expect(result.coOrdinates).toEqual({
-            top: mockLocation.y + scrollY + provider.pageYShiftFactor,
-            bottom: mockLocation.y + mockLocation.height + scrollY + provider.pageYShiftFactor,
-            left: mockLocation.x + scrollX,
-            right: mockLocation.x + mockLocation.width + scrollX
-          });
-        });
-      });
-    });
-  });
-
-  describe('getRegionObjectFromBoundingBox', () => {
-    let provider;
-    let mockLocation = { x: 10, y: 20, width: 100, height: 200 };
-
+    }
     describe('When singlepage screenshot', () => {
       beforeEach(async () => {
         // mock metadata
@@ -608,46 +479,23 @@ describe('GenericProvider', () => {
         await provider.createDriver();
         spyOn(DesktopMetaData.prototype, 'devicePixelRatio')
           .and.returnValue(1);
-        provider.statusBarHeight = 0;
+        spyOn(GenericProvider.prototype, 'getScrollDetails')
+          .and.returnValue(scrollFactors);
+        spyOn(Driver.prototype, 'rect').and.returnValue(Promise.resolve(mockLocation));
       });
 
-      describe('When not an iOS', () => {
-        it('should return a JSON object with the correct selector and coordinates', async () => {
-          // Call function with mock data
-          const selector = 'mock-selector';
-          const result = await provider.getRegionObjectFromBoundingBox(selector, mockLocation);
-          // Assert expected result
-          expect(result.selector).toEqual(selector);
-          expect(result.coOrdinates).toEqual({
-            top: mockLocation.y,
-            bottom: mockLocation.y + mockLocation.height,
-            left: mockLocation.x,
-            right: mockLocation.x + mockLocation.width
-          });
-        });
+      describe('When on Tile 0', () => {
+        expectRegionObject(0, 0);
       });
 
-      describe('When iOS', () => {
-        beforeEach(() => {
+      describe('When on Tile 1', () => {
+        beforeEach(async () => {
+          // mock metadata
           provider.currentTag = { osName: 'iOS' };
-          provider.statusBarHeight = 132;
+          provider.pageYShiftFactor = -10;
+          provider.initialScrollFactor = scrollFactors;
         });
-        it('should return a JSON object with the correct selector and coordinates with added statusBarHeight', async () => {
-          await provider.createDriver();
-
-          // Call function with mock data
-          const selector = 'mock-selector';
-          const result = await provider.getRegionObjectFromBoundingBox(selector, mockLocation);
-
-          // Assert expected result
-          expect(result.selector).toEqual(selector);
-          expect(result.coOrdinates).toEqual({
-            top: mockLocation.y + provider.statusBarHeight,
-            bottom: mockLocation.y + mockLocation.height + provider.statusBarHeight,
-            left: mockLocation.x,
-            right: mockLocation.x + mockLocation.width
-          });
-        });
+        expectRegionObject(0, 0);
       });
     });
 
@@ -657,54 +505,98 @@ describe('GenericProvider', () => {
         provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'client', 'environment', { fullPage: true });
         provider.currentTag = { osName: 'Windows' };
         await provider.createDriver();
-        spyOn(GenericProvider.prototype, 'getInitialScrollFactor')
-          .and.returnValue({ value: [0, 0] });
         spyOn(DesktopMetaData.prototype, 'devicePixelRatio')
           .and.returnValue(1);
-        provider.statusBarHeight = 0;
+        spyOn(Driver.prototype, 'executeScript')
+          .and.returnValue({ value: [0, 0] });
+        spyOn(Driver.prototype, 'rect').and.returnValue(Promise.resolve(mockLocation));
       });
 
-      describe('When not an iOS', () => {
-        it('should return a JSON object with the correct selector and coordinates', async () => {
-          // Call function with mock data
-          const selector = 'mock-selector';
-          const result = await provider.getRegionObjectFromBoundingBox(selector, mockLocation);
-          // Assert expected result
-          expect(result.selector).toEqual(selector);
-          expect(result.coOrdinates).toEqual({
-            top: mockLocation.y,
-            bottom: mockLocation.y + mockLocation.height,
-            left: mockLocation.x,
-            right: mockLocation.x + mockLocation.width
-          });
+      describe('When no scroll', () => {
+        expectRegionObject(0, 0);
+      });
+
+      describe('When there is a scroll', () => {
+        let scrollX = 10;
+        let scrollY = 20;
+        beforeEach(async () => {
+          // mock metadata
+          provider.currentTag = { osName: 'iOS' };
+          spyOn(GenericProvider.prototype, 'getScrollDetails')
+            .and.returnValue({ value: [scrollX, scrollY] });
+          provider.pageYShiftFactor = -10;
         });
+        expectRegionObject(scrollX, scrollY);
+      });
+    });
+  });
+
+  describe('getRegionObjectFromBoundingBox', () => {
+    let provider;
+    let mockLocation = { x: 10, y: 20, width: 100, height: 200 };
+    beforeEach(async () => {
+      // mock metadata
+      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider.currentTag = { osName: 'Windows' };
+      await provider.createDriver();
+      spyOn(DesktopMetaData.prototype, 'devicePixelRatio')
+        .and.returnValue(1);
+      provider.statusBarHeight = 0;
+    });
+
+    function expectRegionObjectFromBoundingBox(scrollX, scrollY) {
+      // Call function with mock data
+      it('should return a JSON object with the correct selector and coordinates', async () => {
+        const selector = 'mock-selector';
+        const result = await provider.getRegionObjectFromBoundingBox(selector, mockLocation);
+        // Assert expected result
+        expect(result.selector).toEqual(selector);
+        expect(result.coOrdinates).toEqual({
+          top: mockLocation.y + scrollY + provider.statusBarHeight,
+          bottom: mockLocation.y + mockLocation.height + scrollY + provider.statusBarHeight,
+          left: mockLocation.x + scrollX,
+          right: mockLocation.x + mockLocation.width + scrollX
+        });
+      });
+    }
+
+    describe('When singlepage screenshot', () => {
+      describe('When not an iOS', () => {
+        expectRegionObjectFromBoundingBox(0, 0);
       });
 
       describe('When iOS', () => {
-        let scrollX = 10;
-        let scrollY = 20;
         beforeEach(() => {
           provider.currentTag = { osName: 'iOS' };
           provider.statusBarHeight = 132;
-          spyOn(GenericProvider.prototype, 'getInitialScrollFactor')
-            .and.returnValue({ value: [scrollX, scrollY] });
         });
-        it('should return a JSON object with the correct selector and coordinates with added statusBarHeight', async () => {
-          await provider.createDriver();
 
-          // Call function with mock data
-          const selector = 'mock-selector';
-          const result = await provider.getRegionObjectFromBoundingBox(selector, mockLocation);
+        expectRegionObjectFromBoundingBox(0, 0);
+      });
+    });
 
-          // Assert expected result
-          expect(result.selector).toEqual(selector);
-          expect(result.coOrdinates).toEqual({
-            top: mockLocation.y + scrollY + provider.statusBarHeight,
-            bottom: mockLocation.y + mockLocation.height + scrollY + provider.statusBarHeight,
-            left: mockLocation.x + scrollX,
-            right: mockLocation.x + mockLocation.width + scrollX
-          });
+    describe('When fullpage screenshot', () => {
+      let scrollX = 10;
+      let scrollY = 20;
+      beforeEach(async () => {
+        // mock metadata
+        provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'client', 'environment', { fullPage: true });
+        provider.currentTag = { osName: 'Windows' };
+        await provider.createDriver();
+        spyOn(GenericProvider.prototype, 'getInitialScrollFactor')
+          .and.returnValue({ value: [scrollX, scrollY] });
+      });
+
+      describe('When not an iOS', () => {
+        expectRegionObjectFromBoundingBox(scrollX, scrollY);
+      });
+
+      describe('When iOS', () => {
+        beforeEach(() => {
+          provider.currentTag = { osName: 'iOS' };
+          provider.statusBarHeight = 132;
         });
+        expectRegionObjectFromBoundingBox(scrollX, scrollY);
       });
     });
   });

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -279,7 +279,7 @@ describe('GenericProvider', () => {
 
       describe('when element is visible in viewport', () => {
         beforeEach(() => {
-          provider.initialScrollFactor = { value: [0, 10] };
+          provider.initialScrollLocation = { value: [0, 10] };
         });
         it('should update pageYShiftFactor for iOS when location.y is 0', async () => {
           await provider.updatePageShiftFactor({ y: 0 }, 2, scrollFactors);
@@ -295,7 +295,7 @@ describe('GenericProvider', () => {
 
       describe('when element is not visible in viewport and iOS scrolls automatically', () => {
         beforeEach(() => {
-          provider.initialScrollFactor = { value: [0, 30] };
+          provider.initialScrollLocation = { value: [0, 30] };
         });
         it('should update pageYShiftFactor to negative value even if location.y is 0', async () => {
           await provider.updatePageShiftFactor({ y: 0 }, 2, scrollFactors);
@@ -343,7 +343,7 @@ describe('GenericProvider', () => {
       describe('When Safari browserVersion > 13', () => {
         describe('when element is visible in viewport', () => {
           beforeEach(() => {
-            provider.initialScrollFactor = { value: [0, 10] };
+            provider.initialScrollLocation = { value: [0, 10] };
             provider.currentTag.browserName = 'safari';
             provider.currentTag.browserVersion = 15;
           });
@@ -358,7 +358,7 @@ describe('GenericProvider', () => {
       describe('When Safari browserVersion <= 13', () => {
         describe('when element is visible in viewport', () => {
           beforeEach(() => {
-            provider.initialScrollFactor = { value: [0, 10] };
+            provider.initialScrollLocation = { value: [0, 10] };
             provider.currentTag.browserName = 'safari';
             provider.currentTag.browserVersion = 13;
           });
@@ -493,7 +493,7 @@ describe('GenericProvider', () => {
           // mock metadata
           provider.currentTag = { osName: 'iOS' };
           provider.pageYShiftFactor = -10;
-          provider.initialScrollFactor = scrollFactors;
+          provider.initialScrollLocation = scrollFactors;
         });
         expectRegionObject(0, 0);
       });
@@ -583,7 +583,7 @@ describe('GenericProvider', () => {
         provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'client', 'environment', { fullPage: true });
         provider.currentTag = { osName: 'Windows' };
         await provider.createDriver();
-        spyOn(GenericProvider.prototype, 'getInitialScrollFactor')
+        spyOn(GenericProvider.prototype, 'getInitialScrollPosition')
           .and.returnValue({ value: [scrollX, scrollY] });
       });
 
@@ -678,7 +678,7 @@ describe('GenericProvider', () => {
     describe('when not IOS', () => {
       it('should not get the initial scroll position', async () => {
         await provider.getInitialPosition();
-        expect(provider.initialScrollFactor).toEqual(null);
+        expect(provider.initialScrollLocation).toEqual(null);
       });
     });
 
@@ -691,9 +691,9 @@ describe('GenericProvider', () => {
         provider.currentTag = null;
       });
       it('should get the initial scroll position', async () => {
-        spyOn(GenericProvider.prototype, 'getInitialScrollFactor').and.returnValue({ value: [0, 200] });
+        spyOn(GenericProvider.prototype, 'getInitialScrollPosition').and.returnValue({ value: [0, 200] });
         await provider.getInitialPosition();
-        expect(provider.initialScrollFactor).toEqual({ value: [0, 200] });
+        expect(provider.initialScrollLocation).toEqual({ value: [0, 200] });
       });
     });
   });
@@ -716,7 +716,7 @@ describe('GenericProvider', () => {
       let executeScriptSpy;
       beforeEach(() => {
         provider.currentTag = { osName: 'iOS' };
-        provider.initialScrollFactor = { value: [0, 50] };
+        provider.initialScrollLocation = { value: [0, 50] };
         executeScriptSpy = spyOn(Driver.prototype, 'executeScript');
       });
 
@@ -926,7 +926,7 @@ describe('GenericProvider', () => {
     });
   });
 
-  describe('getInitialScrollFactor', () => {
+  describe('getInitialScrollPosition', () => {
     let provider;
     let getScrollDetailsSpy;
 
@@ -934,16 +934,16 @@ describe('GenericProvider', () => {
       provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
       await provider.createDriver();
       getScrollDetailsSpy = spyOn(GenericProvider.prototype, 'getScrollDetails');
-      provider.initialScrollFactor = { value: [1, 1] };
+      provider.initialScrollLocation = { value: [1, 1] };
     });
 
     it('do not get scroll details if already present', async () => {
-      provider.getInitialScrollFactor();
+      provider.getInitialScrollPosition();
       expect(getScrollDetailsSpy).not.toHaveBeenCalled();
     });
     it('gets scroll details if not present', async () => {
-      provider.initialScrollFactor = null;
-      provider.getInitialScrollFactor();
+      provider.initialScrollLocation = null;
+      provider.getInitialScrollPosition();
       expect(getScrollDetailsSpy).toHaveBeenCalled();
     });
   });

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -1017,4 +1017,42 @@ describe('GenericProvider', () => {
       expect(executeScriptSpy).toHaveBeenCalledWith({ script: jsScript, args: [] });
     });
   });
+
+  describe('getScrollDetails', () => {
+    let provider;
+    let executeScriptSpy;
+
+    beforeEach(async () => {
+      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      await provider.createDriver();
+      executeScriptSpy = spyOn(Driver.prototype, 'executeScript');
+    });
+
+    it('should return scroll params', async () => {
+      await provider.getScrollDetails();
+      expect(executeScriptSpy).toHaveBeenCalledWith({ script: 'return [parseInt(window.scrollX), parseInt(window.scrollY)];', args: [] });
+    });
+  });
+
+  describe('getInitialScrollFactor', () => {
+    let provider;
+    let getScrollDetailsSpy;
+
+    beforeEach(async () => {
+      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      await provider.createDriver();
+      getScrollDetailsSpy = spyOn(GenericProvider.prototype, 'getScrollDetails');
+      provider.initialScrollFactor = { value: [1, 1] };
+    });
+
+    it('do not get scroll details if already present', async () => {
+      provider.getInitialScrollFactor();
+      expect(getScrollDetailsSpy).not.toHaveBeenCalled();
+    });
+    it('gets scroll details if not present', async () => {
+      provider.initialScrollFactor = null;
+      provider.getInitialScrollFactor();
+      expect(getScrollDetailsSpy).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Refactoring code to support ignoreRegions for Full Page Screenshot.
In full page screenshot Webpage can be at any scrolling state like (x,y), but the screenshot comes from the top (0,0), in that case proper scrolling factor need to be added in coordinates to get them wrt top of the DOM.