### PR TITLE
🏗️ test fix: dom package test failing in chrome 120+

### DIFF
--- a/packages/dom/test/serialize-frames.test.js
+++ b/packages/dom/test/serialize-frames.test.js
@@ -94,11 +94,12 @@ describe('serializeFrames', () => {
     });
 
     it(`${platform}: serializes iframes created with JS`, () => {
+      let dom = platformDOM(platform);
       expect($('#frame-js')[0].getAttribute('src')).toBeNull();
       expect($('#frame-js')[0].getAttribute('srcdoc')).toMatch(new RegExp([
         '<!DOCTYPE html><html><head>',
         '<script id="__percy_shadowdom_helper" data-percy-injected="true">.*</script>',
-        `<base href="${$('#frame-js')[0].baseURI}">`,
+        `<base href="${dom.querySelector('#frame-js').baseURI}">`,
         '</head><body>',
         '<p>made with js src</p>',
         '</body></html>'
@@ -108,7 +109,7 @@ describe('serializeFrames', () => {
       expect($('#frame-js-no-src')[0].getAttribute('srcdoc')).toMatch([
         '<!DOCTYPE html><html><head>',
         '<script id="__percy_shadowdom_helper" data-percy-injected="true">.*</script>',
-        `<base href="${$('#frame-js-no-src')[0].baseURI}">`,
+        `<base href="${dom.querySelector('#frame-js-no-src').baseURI}">`,
         '</head><body>',
         '<p>generated iframe</p>',
         '<img .*data-percy-canvas-serialized.*>',


### PR DESCRIPTION
* we use `DOMParser` package to deserialize (parse) the serialized dom for testing validations.
* chrome 120 gives `about:blank` for dom parsed from the string, while chrome 119 gives iframe base URI, though serialization result in both browsers give iframe baseURI.
* The expectation of our test used to rely on the parsed dom rather the DOM directly, this PR fixes that.

