### PR TITLE
Add FullPage in global config for PoA

### DIFF
--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -1202,7 +1202,8 @@ describe('PercyConfig', () => {
         'disable-shadow-dom': true,
         'cli-enable-javascript': true,
         'ignore-region-xpaths': [''],
-        'enable-layout': false
+        'enable-layout': false,
+        'full-page': false
       })).toEqual({
         fooBar: 'baz',
         foo: { barBaz: 'qux' },
@@ -1213,7 +1214,8 @@ describe('PercyConfig', () => {
         disableShadowDOM: true,
         cliEnableJavaScript: true,
         ignoreRegionXpaths: [''],
-        enableLayout: false
+        enableLayout: false,
+        fullPage: false
       });
     });
 
@@ -1227,7 +1229,8 @@ describe('PercyConfig', () => {
         disableShadowDOM: true,
         cliEnableJavaScript: true,
         ignoreRegionXpaths: [''],
-        enableLayout: false
+        enableLayout: false,
+        fullPage: false
       }, { kebab: true })).toEqual({
         'foo-bar': 'baz',
         foo: { 'bar-baz': 'qux' },
@@ -1237,7 +1240,8 @@ describe('PercyConfig', () => {
         'disable-shadow-dom': true,
         'cli-enable-javascript': true,
         'ignore-region-xpaths': [''],
-        'enable-layout': false
+        'enable-layout': false,
+        'full-page': false
       });
     });
 
@@ -1251,7 +1255,8 @@ describe('PercyConfig', () => {
         disableShadowDOM: true,
         cliEnableJavaScript: true,
         ignoreRegionXpaths: [''],
-        enableLayout: false
+        enableLayout: false,
+        fullPage: false
       }, { snake: true })).toEqual({
         foo_bar: 'baz',
         foo: { bar_baz: 'qux' },
@@ -1261,7 +1266,8 @@ describe('PercyConfig', () => {
         disable_shadow_dom: true,
         cli_enable_javascript: true,
         ignore_region_xpaths: [''],
-        enable_layout: false
+        enable_layout: false,
+        full_page: false
       });
     });
 

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -68,6 +68,10 @@ export const configSchema = {
           }
         }
       },
+      fullPage: {
+        type: 'boolean',
+        onlyAutomate: true
+      },
       freezeAnimation: { // for backward compatibility
         type: 'boolean',
         onlyAutomate: true

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -41,6 +41,7 @@ export function percyAutomateRequestHandler(req, percy) {
   });
 
   req.body.options = merge([{
+    fullPage: percy.config.snapshot.fullPage,
     percyCSS: percy.config.snapshot.percyCSS,
     freezeAnimatedImage: percy.config.snapshot.freezeAnimatedImage || percy.config.snapshot.freezeAnimation,
     freezeImageBySelectors: percy.config.snapshot.freezeAnimatedImageOptions?.freezeImageBySelectors,

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -287,6 +287,7 @@ describe('API Server', () => {
         client_info: 'client',
         environment_info: 'environment',
         options: {
+          fullPage: true,
           percyCSS: '.percy-screenshot: { color: red }',
           freeze_animated_image: true,
           freezeImageBySelectors: ['.selector-per-screenshot'],
@@ -302,7 +303,7 @@ describe('API Server', () => {
       environmentInfo: 'environment',
       buildInfo: { id: '123', url: 'https://percy.io/test/test/123', number: 1 },
       options: {
-        fullPage: false,
+        fullPage: true,
         freezeAnimatedImage: true,
         freezeImageBySelectors: ['.selector-per-screenshot'],
         freezeImageByXpaths: ['/xpath-global'],

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -274,6 +274,7 @@ describe('API Server', () => {
 
     await percy.start();
 
+    percy.config.snapshot.fullPage = false;
     percy.config.snapshot.percyCSS = '.global { color: blue }';
     percy.config.snapshot.freezeAnimatedImage = false;
     percy.config.snapshot.freezeAnimatedImageOptions = { freezeImageByXpaths: ['/xpath-global'] };
@@ -301,6 +302,7 @@ describe('API Server', () => {
       environmentInfo: 'environment',
       buildInfo: { id: '123', url: 'https://percy.io/test/test/123', number: 1 },
       options: {
+        fullPage: false,
         freezeAnimatedImage: true,
         freezeImageBySelectors: ['.selector-per-screenshot'],
         freezeImageByXpaths: ['/xpath-global'],


### PR DESCRIPTION
- Add FullPage Screenshot to global config for PoA.
- This should allow to run all PoA screenshots in full page screenshots if mentioned in config file.