### PR TITLE
✨ Add file size logging for tiles and resources

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -274,6 +274,7 @@ export class PercyClient {
     let encodedContent = base64encode(content);
 
     this.log.debug(`Uploading ${formatBytes(encodedContent.length)} resource: ${url}...`);
+    this.mayBeLogUploadSize(encodedContent.length);
 
     return this.post(`builds/${buildId}/resources`, {
       data: {
@@ -447,6 +448,7 @@ export class PercyClient {
     let encodedContent = base64encode(content);
 
     this.log.debug(`Uploading ${formatBytes(encodedContent.length)} comparison tile: ${index + 1}/${total} (${comparisonId})...`);
+    this.mayBeLogUploadSize(encodedContent.length);
 
     return this.post(`comparisons/${comparisonId}/tiles`, {
       data: {
@@ -531,6 +533,14 @@ export class PercyClient {
     return this.post(`builds/${buildId}/send-events`, {
       data: body
     });
+  }
+
+  mayBeLogUploadSize(contentSize) {
+    if (contentSize >= 25 * 1024 * 1024) {
+      this.log.error('Uploading resource above 25MB might fail the build...');
+    } else if (contentSize >= 20 * 1024 * 1024) {
+      this.log.warn('Uploading resource above 20MB might slow the build...');
+    }
   }
 
   // decides project type

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -6,6 +6,7 @@ import logger from '@percy/logger';
 import {
   pool,
   request,
+  formatBytes,
   sha256hash,
   base64encode,
   getPackageJSON,
@@ -269,15 +270,17 @@ export class PercyClient {
   // created from `content` if one is not provided.
   async uploadResource(buildId, { url, sha, filepath, content } = {}) {
     validateId('build', buildId);
-    this.log.debug(`Uploading resource: ${url}...`);
     if (filepath) content = await fs.promises.readFile(filepath);
+    let encodedContent = base64encode(content);
+
+    this.log.debug(`Uploading ${formatBytes(encodedContent.length)} resource: ${url}...`);
 
     return this.post(`builds/${buildId}/resources`, {
       data: {
         type: 'resources',
         id: sha || sha256hash(content),
         attributes: {
-          'base64-content': base64encode(content)
+          'base64-content': encodedContent
         }
       }
     });
@@ -437,17 +440,19 @@ export class PercyClient {
 
   async uploadComparisonTile(comparisonId, { index = 0, total = 1, filepath, content, sha } = {}) {
     validateId('comparison', comparisonId);
-    this.log.debug(`Uploading comparison tile: ${index + 1}/${total} (${comparisonId})...`);
-    if (filepath && !content) content = await fs.promises.readFile(filepath);
     if (sha) {
       return await this.verify(comparisonId, sha);
     }
+    if (filepath && !content) content = await fs.promises.readFile(filepath);
+    let encodedContent = base64encode(content);
+
+    this.log.debug(`Uploading ${formatBytes(encodedContent.length)} comparison tile: ${index + 1}/${total} (${comparisonId})...`);
 
     return this.post(`comparisons/${comparisonId}/tiles`, {
       data: {
         type: 'tiles',
         attributes: {
-          'base64-content': base64encode(content),
+          'base64-content': encodedContent,
           index
         }
       }

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -4,6 +4,17 @@ import url from 'url';
 import path from 'path';
 import crypto from 'crypto';
 
+// Formats a raw byte integer as a string
+export function formatBytes(int) {
+  let units = ['kB', 'MB', 'GB'];
+  let base = 1024;
+  let u = -1;
+
+  if (Math.abs(int) < base) return `${int}B`;
+  while (Math.abs(int) >= base && u++ < 2) int /= base;
+  return `${int.toFixed(1)}${units[u]}`;
+}
+
 // Returns a sha256 hash of a string.
 export function sha256hash(content) {
   return crypto

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -483,7 +483,8 @@ describe('PercyClient', () => {
     });
 
     it('uploads a resource for a build', async () => {
-      await expectAsync(client.uploadResource(123, { content: 'foo' })).toBeResolved();
+      await expectAsync(client.uploadResource(123, { content: 'foo', url: 'foo/bar' })).toBeResolved();
+      expect(logger.stderr).toEqual(jasmine.arrayContaining(['[percy:client] Uploading 4B resource: foo/bar...']));
 
       expect(api.requests['/builds/123/resources'][0].body).toEqual({
         data: {
@@ -1036,6 +1037,8 @@ describe('PercyClient', () => {
       await expectAsync(
         client.uploadComparisonTile(891011, { content: 'foo', index: 3 })
       ).toBeResolved();
+
+      expect(logger.stderr).toEqual(jasmine.arrayContaining(['[percy:client] Uploading 4B comparison tile: 4/1 (891011)...']));
 
       expect(api.requests['/comparisons/891011/tiles'][0].body).toEqual({
         data: {

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -1349,7 +1349,7 @@ describe('PercyClient', () => {
     });
   });
 
-  describe('sendBuildEvents', () => {
+  describe('#sendBuildEvents', () => {
     it('should send build event with default values', async () => {
       await expectAsync(client.sendBuildEvents(123, {
         errorKind: 'cli',
@@ -1370,6 +1370,23 @@ describe('PercyClient', () => {
           message: 'some error'
         }
       });
+    });
+  });
+
+  describe('#mayBeLogUploadSize', () => {
+    it('does not warns when upload size less 20MB/25MB', () => {
+      client.mayBeLogUploadSize(1000);
+      expect(logger.stderr).toEqual([]);
+    });
+
+    it('warns when upload size above 20MB', () => {
+      client.mayBeLogUploadSize(20 * 1024 * 1024);
+      expect(logger.stderr).toEqual(['[percy:client] Uploading resource above 20MB might slow the build...']);
+    });
+
+    it('log error when upload size above 25MB', () => {
+      client.mayBeLogUploadSize(25 * 1024 * 1024);
+      expect(logger.stderr).toEqual(['[percy:client] Uploading resource above 25MB might fail the build...']);
     });
   });
 

--- a/packages/client/test/unit/request.test.js
+++ b/packages/client/test/unit/request.test.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import net from 'net';
 import http from 'http';
 import https from 'https';
-import { request, ProxyHttpAgent } from '@percy/client/utils';
+import { request, ProxyHttpAgent, formatBytes } from '@percy/client/utils';
 import { port, href, proxyAgentFor } from '../../src/proxy.js';
 
 const ssl = {
@@ -506,4 +506,13 @@ describe('Unit / Request', () => {
       });
     });
   }
+});
+
+describe('Unit / formatBytes', () => {
+  it('returns correct format', () => {
+    expect(formatBytes(500)).toBe('500B');
+    expect(formatBytes(1024)).toBe('1.0kB');
+    expect(formatBytes(750 * 1024)).toBe('750.0kB');
+    expect(formatBytes(500 * 1024 * 1024)).toBe('500.0MB');
+  });
 });

--- a/packages/core/src/install.js
+++ b/packages/core/src/install.js
@@ -4,18 +4,7 @@ import path from 'path';
 import https from 'https';
 import logger from '@percy/logger';
 import cp from 'child_process';
-import { ProxyHttpsAgent } from '@percy/client/utils';
-
-// Formats a raw byte integer as a string
-function formatBytes(int) {
-  let units = ['kB', 'MB', 'GB'];
-  let base = 1024;
-  let u = -1;
-
-  if (Math.abs(int) < base) return `${int}B`;
-  while (Math.abs(int) >= base && u++ < 2) int /= base;
-  return `${int.toFixed(1)}${units[u]}`;
-}
+import { ProxyHttpsAgent, formatBytes } from '@percy/client/utils';
 
 // Formats milleseconds as "MM:SS"
 function formatTime(ms) {


### PR DESCRIPTION
* Adds logs of following format for `resources` and `tiles` upload endpoints. 

```
[percy:client] Uploading 692B resource:
```

* Note: it logs file size post `base64` encoding is done, which is 30% increase in file size.
* we've `25mb` file size per resource limit restriction so this log line will further help in identifying the slow uploading resource.