### PR TITLE
🧹 Disabling OptimizationGuideModelDownloading in resource discovery chromium

### DIFF
--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -20,8 +20,8 @@ export class Browser extends EventEmitter {
   #lastid = 0;
 
   args = [
-    // disable the translate popup
-    '--disable-features=Translate',
+    // disable the translate popup and optimization downloads
+    '--disable-features=Translate,OptimizationGuideModelDownloading',
     // disable several subsystems which run network requests in the background
     '--disable-background-networking',
     // disable task throttling of timer tasks from background pages


### PR DESCRIPTION
We got some reports that temp profile directory cleanups are sometimes failing on windows systems. The common reason was `Default\optimization_guide_prediction_model_downloads\<uuid>\visual_model_desktop.tflite` was locked and used and so we rm rf of the directory failed. 

This usually does not matter in *nix systems as you can delete files under use, but on windows the deletion fails if file is under use. So we are disabling the feature hoping that this would not keep profile directory from deletion.

Note: a failed deletion log is usually fine as its a temp dir anyway.