### PR TITLE
🧹 Added logging of body for failed requests

### DIFF
--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -178,7 +178,9 @@ export async function request(url, options = {}, callback) {
           resolve(await callback?.(body, res) ?? body);
         } else {
           let err = body?.errors?.find(e => e.detail)?.detail;
-          throw new Error(err || `${statusCode} ${res.statusMessage || raw}`);
+          let statusMessage = `${statusCode} ${(res.statusMessage || '')}`;
+          let bodyText = (raw?.length > 0) ? `\n${raw}` : '';
+          throw new Error(err || `${statusMessage}${bodyText}`);
         }
       } catch (error) {
         let response = { statusCode, headers, body };

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -179,7 +179,7 @@ export async function request(url, options = {}, callback) {
         } else {
           let err = body?.errors?.find(e => e.detail)?.detail;
           let statusMessage = `${statusCode} ${(res.statusMessage || '')}`;
-          let bodyText = (raw?.length > 0) ? `\n${raw}` : '';
+          let bodyText = (raw?.length > 0 && res.statusMessage !== raw) ? `\n${raw}` : '';
           throw new Error(err || `${statusMessage}${bodyText}`);
         }
       } catch (error) {

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -311,7 +311,7 @@ describe('PercyClient', () => {
 
     it('gets comparison data throw 500', async () => {
       api.reply('/comparisons/104?sync=true&response_format=sync-cli', () => [500, { error: '<<comparison-data-failure>>' }]);
-      await expectAsync(client.getComparisonDetails(104)).toBeRejectedWithError('500 {"error":"<<comparison-data-failure>>"}');
+      await expectAsync(client.getComparisonDetails(104)).toBeRejectedWithError('500 \n{"error":"<<comparison-data-failure>>"}');
     });
   });
 
@@ -333,7 +333,7 @@ describe('PercyClient', () => {
 
     it('gets snapshot data throw 500', async () => {
       api.reply('/snapshots/104?sync=true&response_format=sync-cli', () => [500, { error: '<<snapshot-data-failure>>' }]);
-      await expectAsync(client.getSnapshotDetails(104)).toBeRejectedWithError('500 {"error":"<<snapshot-data-failure>>"}');
+      await expectAsync(client.getSnapshotDetails(104)).toBeRejectedWithError('500 \n{"error":"<<snapshot-data-failure>>"}');
     });
   });
 

--- a/packages/client/test/unit/request.test.js
+++ b/packages/client/test/unit/request.test.js
@@ -192,7 +192,7 @@ describe('Unit / Request', () => {
     server.reply('/status', () => [403]);
 
     await expectAsync(server.request('/status'))
-      .toBeRejectedWithError('403 Forbidden');
+      .toBeRejectedWithError('403 Forbidden\ntest');
 
     // empty status message
     server.reply('/raw', (req, res) => {
@@ -200,7 +200,7 @@ describe('Unit / Request', () => {
     });
 
     await expectAsync(server.request('/raw'))
-      .toBeRejectedWithError('403 STOP');
+      .toBeRejectedWithError('403 \nSTOP');
   });
 
   describe('retries', () => {
@@ -235,7 +235,7 @@ describe('Unit / Request', () => {
       server.reply('/test', () => responses.splice(0, 1)[0]);
 
       await expectAsync(server.request('/test'))
-        .toBeRejectedWithError('404 Not Found');
+        .toBeRejectedWithError('404 Not Found\ntest');
 
       expect(responses).toEqual([[500], [404], [200]]);
       expect(server.received.length).toBe(2);
@@ -261,7 +261,7 @@ describe('Unit / Request', () => {
     it('fails after 5 additional retries', async () => {
       server.reply('/fail', () => [502]);
       await expectAsync(server.request('/fail'))
-        .toBeRejectedWithError('502 Bad Gateway');
+        .toBeRejectedWithError('502 Bad Gateway\ntest');
       expect(server.received.length).toBe(6);
     });
   });

--- a/packages/core/test/unit/server.test.js
+++ b/packages/core/test/unit/server.test.js
@@ -266,7 +266,7 @@ describe('Unit / Server', () => {
     it('handles server errors', async () => {
       server.route('/e/foo', () => { throw new Error('foo'); });
       server.route('/e/bar', () => { throw new Server.Error(418); });
-      await expectAsync(request('/e/foo')).toBeRejectedWithError('500 Internal Server Error');
+      await expectAsync(request('/e/foo')).toBeRejectedWithError('500 Internal Server Error\nfoo');
       await expectAsync(request('/e/bar')).toBeRejectedWithError('418 I\'m a Teapot');
     });
 


### PR DESCRIPTION
We are seeing cases when a mitm proxy in between is either sending 403s or just blocking directly. Currently due to insufficient logging it becomes hard to understand if the 403 was due to incorrect/invalid percy token or due to a proxy in between, we are adding response body to the logs so that logs can be used to debug error right away. 