### PR TITLE
Adding check for correct SDK for percy product

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -58,6 +58,8 @@ export class PercyClient {
     Object.assign(this, { token, config: config || {}, apiUrl });
     this.addClientInfo(clientInfo);
     this.addEnvironmentInfo(environmentInfo);
+    this.buildType = null;
+    this.screenshotFlow = null;
   }
 
   // Adds additional unique client info.

--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -105,10 +105,10 @@ export function createPercyServer(percy, port) {
     .route('post', '/percy/comparison', async (req, res) => {
       let data;
       if (percy.syncMode(req.body)) {
-        const snapshotPromise = new Promise((resolve, reject) => percy.upload(req.body, { resolve, reject }));
+        const snapshotPromise = new Promise((resolve, reject) => percy.upload(req.body, { resolve, reject }, 'app'));
         data = await handleSyncJob(snapshotPromise, percy, 'comparison');
       } else {
-        let upload = percy.upload(req.body);
+        let upload = percy.upload(req.body, null, 'app');
         if (req.url.searchParams.has('await')) await upload;
       }
 
@@ -139,10 +139,10 @@ export function createPercyServer(percy, port) {
       percyAutomateRequestHandler(req, percy);
       let comparisonData = await WebdriverUtils.automateScreenshot(req.body);
       if (percy.syncMode(comparisonData)) {
-        const snapshotPromise = new Promise((resolve, reject) => percy.upload(comparisonData, { resolve, reject }));
+        const snapshotPromise = new Promise((resolve, reject) => percy.upload(comparisonData, { resolve, reject }, 'automate'));
         data = await handleSyncJob(snapshotPromise, percy, 'comparison');
       } else {
-        percy.upload(comparisonData);
+        percy.upload(comparisonData, null, 'automate');
       }
 
       res.json(200, { success: true, data: data });

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -332,7 +332,7 @@ export class Percy {
   }
 
   // Uploads one or more snapshots directly to the current Percy build
-  upload(options, callback = null) {
+  upload(options, callback = null, screenshotFlow = null) {
     if (this.readyState !== 1) {
       throw new Error('Not running');
     } else if (Array.isArray(options)) {
@@ -359,6 +359,7 @@ export class Percy {
     // add client & environment info
     this.client.addClientInfo(options.clientInfo);
     this.client.addEnvironmentInfo(options.environmentInfo);
+    this.client.screenshotFlow = screenshotFlow;
 
     // Sync CLI support, attached resolve, reject promise
     if (this.syncMode(options)) {

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -362,9 +362,10 @@ export function createSnapshotsQueue(percy) {
     .handle('task', async function*({ resources, ...snapshot }) {
       let { name, meta } = snapshot;
 
-      const errorMessage = percy.client.screenshotFlow === 'automate' ? 'automate' : 'App Percy';
-      if (percy.client.buildType !== percy.client.screenshotFlow) {
-        throw new Error(`Cannot run ${errorMessage} screenshots in ${percy.client.buildType} project. Please use ${errorMessage} project token`);
+      if (percy.client.screenshotFlow === 'automate' && percy.client.buildType !== 'automate') {
+        throw new Error(`Cannot run automate screenshots in ${percy.client.buildType} project. Please use automate project token`);
+      } else if (percy.client.screenshotFlow === 'app' && percy.client.buildType !== 'app') {
+        throw new Error(`Cannot run App Percy screenshots in ${percy.client.buildType} project. Please use App Percy project token`);
       }
       // yield to evaluated snapshot resources
       snapshot.resources = typeof resources === 'function'

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -362,10 +362,9 @@ export function createSnapshotsQueue(percy) {
     .handle('task', async function*({ resources, ...snapshot }) {
       let { name, meta } = snapshot;
 
-      if (percy.client.screenshotFlow === 'automate' && percy.client.buildType !== 'automate') {
-        throw new Error(`Cannot run automate screenshots in ${percy.client.buildType} project. Please use automate project token`);
-      } else if (percy.client.screenshotFlow === 'app' && percy.client.buildType !== 'app') {
-        throw new Error(`Cannot run App Percy screenshots in ${percy.client.buildType} project. Please use App Percy project token`);
+      const errorMessage = percy.client.screenshotFlow === 'automate' ? 'automate' : 'App Percy';
+      if (percy.client.buildType !== percy.client.screenshotFlow) {
+        throw new Error(`Cannot run ${errorMessage} screenshots in ${percy.client.buildType} project. Please use ${errorMessage} project token`);
       }
       // yield to evaluated snapshot resources
       snapshot.resources = typeof resources === 'function'

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -208,7 +208,9 @@ describe('API Server', () => {
     }));
 
     expect(percy.upload).toHaveBeenCalledOnceWith(
-      { 'test-me': true, me_too: true }
+      { 'test-me': true, me_too: true },
+      null,
+      'app'
     );
 
     await expectAsync(test).toBePending();
@@ -376,7 +378,7 @@ describe('API Server', () => {
       }
     }));
 
-    expect(percy.upload).toHaveBeenCalledOnceWith(mockWebdriverUtilResponse);
+    expect(percy.upload).toHaveBeenCalledOnceWith(mockWebdriverUtilResponse, null, 'automate');
     await expectAsync(test).toBePending();
     resolve(); // no hanging promises
   });
@@ -433,7 +435,7 @@ describe('API Server', () => {
     }));
 
     expect(percy.client.getComparisonDetails).toHaveBeenCalled();
-    expect(percy.upload).toHaveBeenCalledOnceWith({ sync: true }, jasmine.objectContaining({}));
+    expect(percy.upload).toHaveBeenCalledOnceWith({ sync: true }, jasmine.objectContaining({}), 'automate');
   });
 
   it('has a /events endpoint that calls #sendBuildEvents() async with provided options with clientInfo present', async () => {

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -1384,7 +1384,7 @@ describe('Snapshot', () => {
         tiles: [{ content: 'foo' }, { content: 'vbv' }]
       }, null, 'automate');
 
-      expect(logger.stderr).toEqual(jasmine.arrayContaining([jasmine.stringContaining('[percy:core] Error: Cannot run automate screenshots in app project. Please use automate project token')]));
+      expect(logger.stderr).toEqual(jasmine.arrayContaining([jasmine.stringContaining('[percy] Error: Cannot run automate screenshots in app project. Please use automate project token')]));
     });
 
     it('should throw error if automate build is ran using app percy SDK', async () => {
@@ -1405,7 +1405,7 @@ describe('Snapshot', () => {
         tiles: [{ content: 'foo' }, { content: 'vbv' }]
       }, null, 'app');
 
-      expect(logger.stderr).toEqual(jasmine.arrayContaining([jasmine.stringContaining('[percy:core] Error: Cannot run App Percy screenshots in automate project. Please use App Percy project token')]));
+      expect(logger.stderr).toEqual(jasmine.arrayContaining([jasmine.stringContaining('[percy] Error: Cannot run App Percy screenshots in automate project. Please use App Percy project token')]));
     });
   });
 

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -1365,6 +1365,50 @@ describe('Snapshot', () => {
     });
   });
 
+  describe('invalid screenshot flow', () => {
+    it('should throw error if app percy build is ran using automate SDK', async () => {
+      await percy.stop(true);
+      await api.mock();
+
+      percy = await Percy.start({
+        token: 'PERCY_TOKEN',
+        projectType: 'app'
+      });
+
+      percy.client.buildType = 'app';
+      await percy.upload({
+        name: 'Snapshot',
+        external_debug_url: 'localhost',
+        some_other_rand_prop: 'random value',
+        tag: { name: 'device', foobar: 'baz' },
+        tiles: [{ content: 'foo' }, { content: 'vbv' }]
+      }, null, 'automate');
+
+      expect(logger.stderr).toEqual(jasmine.arrayContaining([jasmine.stringContaining('[percy:core] Error: Cannot run automate screenshots in app project. Please use automate project token')]));
+    });
+
+    it('should throw error if automate build is ran using app percy SDK', async () => {
+      await percy.stop(true);
+      await api.mock();
+
+      percy = await Percy.start({
+        token: 'PERCY_TOKEN',
+        projectType: 'automate'
+      });
+
+      percy.client.buildType = 'automate';
+      await percy.upload({
+        name: 'Snapshot',
+        external_debug_url: 'localhost',
+        some_other_rand_prop: 'random value',
+        tag: { name: 'device', foobar: 'baz' },
+        tiles: [{ content: 'foo' }, { content: 'vbv' }]
+      }, null, 'app');
+
+      expect(logger.stderr).toEqual(jasmine.arrayContaining([jasmine.stringContaining('[percy:core] Error: Cannot run App Percy screenshots in automate project. Please use App Percy project token')]));
+    });
+  });
+
   describe('with percy-css', () => {
     let getResourceData = () => (
       api.requests['/builds/123/snapshots'][0].body.data.relationships.resources.data


### PR DESCRIPTION
Added validation for the case where the correct token and cli flow is used but sdk used is wrong.
For exp: -> App Percy Token is used and cli server is also started using app:exec which will create correct App Percy Build but as percy_screenshot is common in both App Percy and Percy on Automate it can be possible to trigger percy_screenshot using Automate SDK which should not be the case ideally.

We are relying on build type and the endpoint called to determine which SDK would have been used and in which build