### PR TITLE
Throwing error when sha, filepath or content is not present

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -10,7 +10,8 @@ import {
   sha256hash,
   base64encode,
   getPackageJSON,
-  waitForTimeout
+  waitForTimeout,
+  validateTiles
 } from './utils.js';
 
 // Default client API URL can be set with an env var for API development
@@ -555,6 +556,9 @@ export class PercyClient {
   }
 
   async sendComparison(buildId, options) {
+    if (!validateTiles(options.tiles)) {
+      throw new Error('sha, filepath or content should be present in tiles object');
+    }
     let snapshot = await this.createSnapshot(buildId, options);
     let comparison = await this.createComparison(snapshot.data.id, options);
     await this.uploadComparisonTiles(comparison.data.id, options.tiles);

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -202,6 +202,15 @@ export async function request(url, options = {}, callback) {
   }, { retries, interval });
 }
 
+export function validateTiles(tiles) {
+  for (const tile of tiles) {
+    if (!tile.filepath && !tile.content && !tile.sha) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export {
   hostnameMatches,
   ProxyHttpAgent,

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -1278,99 +1278,111 @@ describe('PercyClient', () => {
   });
 
   describe('#sendComparison()', () => {
-    beforeEach(async () => {
-      await client.sendComparison(123, {
-        name: 'test snapshot name',
-        tag: { name: 'test tag' },
-        tiles: [{ content: base64encode('tile') }]
+    describe('when correct comparison data is sent', () => {
+      beforeEach(async () => {
+        await client.sendComparison(123, {
+          name: 'test snapshot name',
+          tag: { name: 'test tag' },
+          tiles: [{ content: base64encode('tile') }]
+        });
       });
-    });
 
-    it('creates a snapshot', async () => {
-      expect(api.requests['/builds/123/snapshots'][0].body).toEqual({
-        data: {
-          type: 'snapshots',
-          attributes: {
-            name: 'test snapshot name',
-            scope: null,
-            'scope-options': {},
-            'enable-javascript': null,
-            'minimum-height': null,
-            widths: null,
-            sync: false,
-            'enable-layout': false
-          },
-          relationships: {
-            resources: {
-              data: []
-            }
-          }
-        }
-      });
-    });
-
-    it('creates a comparison', async () => {
-      expect(api.requests['/snapshots/4567/comparisons'][0].body).toEqual({
-        data: {
-          type: 'comparisons',
-          attributes: {
-            'external-debug-url': null,
-            'ignore-elements-data': null,
-            'consider-elements-data': null,
-            'dom-info-sha': null,
-            sync: false,
-            metadata: null
-          },
-          relationships: {
-            tag: {
-              data: {
-                type: 'tag',
-                attributes: {
-                  name: 'test tag',
-                  width: null,
-                  height: null,
-                  'os-name': null,
-                  'os-version': null,
-                  orientation: null,
-                  'browser-name': null,
-                  'browser-version': null,
-                  resolution: null
-                }
-              }
+      it('creates a snapshot', async () => {
+        expect(api.requests['/builds/123/snapshots'][0].body).toEqual({
+          data: {
+            type: 'snapshots',
+            attributes: {
+              name: 'test snapshot name',
+              scope: null,
+              'scope-options': {},
+              'enable-javascript': null,
+              'minimum-height': null,
+              widths: null,
+              sync: false,
+              'enable-layout': false
             },
-            tiles: {
-              data: [{
-                type: 'tiles',
-                attributes: {
-                  sha: jasmine.any(String),
-                  'status-bar-height': null,
-                  'nav-bar-height': null,
-                  'header-height': null,
-                  'footer-height': null,
-                  fullscreen: null
-                }
-              }]
+            relationships: {
+              resources: {
+                data: []
+              }
             }
           }
-        }
+        });
       });
-    });
 
-    it('uploads comparison tiles', async () => {
-      expect(api.requests['/comparisons/891011/tiles'][0].body).toEqual({
-        data: {
-          type: 'tiles',
-          attributes: {
-            'base64-content': base64encode(Buffer.from('tile')),
-            index: 0
+      it('creates a comparison', async () => {
+        expect(api.requests['/snapshots/4567/comparisons'][0].body).toEqual({
+          data: {
+            type: 'comparisons',
+            attributes: {
+              'external-debug-url': null,
+              'ignore-elements-data': null,
+              'consider-elements-data': null,
+              'dom-info-sha': null,
+              sync: false,
+              metadata: null
+            },
+            relationships: {
+              tag: {
+                data: {
+                  type: 'tag',
+                  attributes: {
+                    name: 'test tag',
+                    width: null,
+                    height: null,
+                    'os-name': null,
+                    'os-version': null,
+                    orientation: null,
+                    'browser-name': null,
+                    'browser-version': null,
+                    resolution: null
+                  }
+                }
+              },
+              tiles: {
+                data: [{
+                  type: 'tiles',
+                  attributes: {
+                    sha: jasmine.any(String),
+                    'status-bar-height': null,
+                    'nav-bar-height': null,
+                    'header-height': null,
+                    'footer-height': null,
+                    fullscreen: null
+                  }
+                }]
+              }
+            }
           }
-        }
+        });
+      });
+
+      it('uploads comparison tiles', async () => {
+        expect(api.requests['/comparisons/891011/tiles'][0].body).toEqual({
+          data: {
+            type: 'tiles',
+            attributes: {
+              'base64-content': base64encode(Buffer.from('tile')),
+              index: 0
+            }
+          }
+        });
+      });
+
+      it('finalizes a comparison', async () => {
+        expect(api.requests['/snapshots/4567/finalize']).not.toBeDefined();
+        expect(api.requests['/comparisons/891011/finalize']).toBeDefined();
       });
     });
 
-    it('finalizes a comparison', async () => {
-      expect(api.requests['/snapshots/4567/finalize']).not.toBeDefined();
-      expect(api.requests['/comparisons/891011/finalize']).toBeDefined();
+    describe('when incorrect comparison data is sent', () => {
+      it('throws error when tiles object does not contain sha, filepath or content', async () => {
+        await expectAsync(client.sendComparison(123, {
+          name: 'test snapshot name',
+          tag: { name: 'test tag' },
+          tiles: [{}]
+        })).toBeRejectedWithError('sha, filepath or content should be present in tiles object');
+      });
     });
   });
 


### PR DESCRIPTION
Throwing error when sha, filepath or content is not present when creating a comparison.
This fixes the below error, when sha is empty, for app build.
```
Error: Finalizing build 32741978 failed: cannot finalize before all snapshots have comparisons created. This is likely an SDK error, please make sure that comparisons are created before calling finalize.
```