### PR TITLE
Bumping up chromium version to v123

### DIFF
--- a/packages/core/src/install.js
+++ b/packages/core/src/install.js
@@ -175,13 +175,13 @@ export function chromium({
   });
 }
 
-// default chromium revisions corresponds to v96.0.4664.0
+// default chromium revisions corresponds to v123.0.6312.58
 chromium.revisions = {
-  linux: '929511',
-  win64: '929483',
-  win32: '929483',
-  darwin: '929475',
-  darwinArm: '929475'
+  linux: '1262506',
+  win64: '1262500',
+  win32: '1262500',
+  darwin: '1262506',
+  darwinArm: '1262509'
 };
 
 // export the namespace by default


### PR DESCRIPTION
- Bumping up chromium version to v123
- This should update asset-discovery browser and should resolve shadow-root related issues.