### PR TITLE
Remove `checked` attr for radio-button by default

### DIFF
--- a/packages/dom/src/serialize-inputs.js
+++ b/packages/dom/src/serialize-inputs.js
@@ -7,6 +7,7 @@ export function serializeInputElements({ dom, clone, warnings }) {
     switch (elem.type) {
       case 'checkbox':
       case 'radio':
+        elem.removeAttribute("checked");
         if (elem.checked) {
           cloneEl.setAttribute('checked', '');
         }

--- a/packages/dom/src/serialize-inputs.js
+++ b/packages/dom/src/serialize-inputs.js
@@ -11,10 +11,11 @@ export function serializeInputElements({ dom, clone, warnings }) {
           here we are removing the checked attr if present by default,
           so that only the current selected radio-button will have the checked attr present in the dom
 
-          this happens because in html, when the checked attribute is present in the multiple radio-buttons by default,
-          the browser will only render the last checked radio-button as when the user is selecting any particular button,
-          the checked attribute on other buttons is not removed,
-          hence sometimes it shows inconsistent state even though the `element.checked` attribute returns correct state
+          this happens because in html, 
+          when the checked attribute is present in the multiple radio-buttons for which only one can be selected at a time,
+          the browser will only render the last checked radio-button by default,
+          when a user selects any particular radio-button, the checked attribute on other buttons is not removed,
+          hence sometimes it shows inconsistent state as html will still show the last radio as selected.
         */
         cloneEl.removeAttribute('checked');
         if (elem.checked) {

--- a/packages/dom/src/serialize-inputs.js
+++ b/packages/dom/src/serialize-inputs.js
@@ -7,7 +7,16 @@ export function serializeInputElements({ dom, clone, warnings }) {
     switch (elem.type) {
       case 'checkbox':
       case 'radio':
+        /*
+          here we are removing the checked attr if present by default,
+          so that only the selected radio-button will have the checked attr present in the dom
+
+          we need to removed `checked` from both cloneEl & elem as if it is only removed from cloneEl,
+          then if any radio-button has `checked` attr present by default,
+          then it will be shown as checked even though it was not explicitly selected before taking snapshot
+        */
         elem.removeAttribute('checked');
+        cloneEl.removeAttribute('checked');
         if (elem.checked) {
           cloneEl.setAttribute('checked', '');
         }

--- a/packages/dom/src/serialize-inputs.js
+++ b/packages/dom/src/serialize-inputs.js
@@ -9,13 +9,13 @@ export function serializeInputElements({ dom, clone, warnings }) {
       case 'radio':
         /*
           here we are removing the checked attr if present by default,
-          so that only the selected radio-button will have the checked attr present in the dom
+          so that only the current selected radio-button will have the checked attr present in the dom
 
-          we need to removed `checked` from both cloneEl & elem as if it is only removed from cloneEl,
-          then if any radio-button has `checked` attr present by default,
-          then it will be shown as checked even though it was not explicitly selected before taking snapshot
+          this happens because in html, when the checked attribute is present in the multiple radio-buttons by default,
+          the browser will only render the last checked radio-button as when the user is selecting any particular button,
+          the checked attribute on other buttons is not removed,
+          hence sometimes it shows inconsistent state even though the `element.checked` attribute returns correct state
         */
-        elem.removeAttribute('checked');
         cloneEl.removeAttribute('checked');
         if (elem.checked) {
           cloneEl.setAttribute('checked', '');

--- a/packages/dom/src/serialize-inputs.js
+++ b/packages/dom/src/serialize-inputs.js
@@ -11,7 +11,7 @@ export function serializeInputElements({ dom, clone, warnings }) {
           here we are removing the checked attr if present by default,
           so that only the current selected radio-button will have the checked attr present in the dom
 
-          this happens because in html, 
+          this happens because in html,
           when the checked attribute is present in the multiple radio-buttons for which only one can be selected at a time,
           the browser will only render the last checked radio-button by default,
           when a user selects any particular radio-button, the checked attribute on other buttons is not removed,

--- a/packages/dom/src/serialize-inputs.js
+++ b/packages/dom/src/serialize-inputs.js
@@ -7,7 +7,7 @@ export function serializeInputElements({ dom, clone, warnings }) {
     switch (elem.type) {
       case 'checkbox':
       case 'radio':
-        elem.removeAttribute("checked");
+        elem.removeAttribute('checked');
         if (elem.checked) {
           cloneEl.setAttribute('checked', '');
         }

--- a/packages/dom/test/serialize-inputs.test.js
+++ b/packages/dom/test/serialize-inputs.test.js
@@ -91,7 +91,10 @@ describe('serializeInputs', () => {
     });
 
     it(`${platform}: removes checked attr from radio-buttons if present by default`, () => {
-      expect($('#radio-checked-default')[0]).not.toContain('checked=""');
+      // validate `checked=""` is removed from the dom
+      expect($('#radio-checked-default')[0].outerHTML).not.toContain('checked=""');
+
+      // validate `checked` property is set to false
       expect($('#radio-checked-default')[0].checked).toBe(false);
     });
 
@@ -132,7 +135,7 @@ describe('serializeInputs', () => {
 
     it(`${platform}: adds a guid data-attribute to the original DOM`, () => {
       // plain platform has extra element #test-shadow
-      expect(dom.querySelectorAll('[data-percy-element-id]')).toHaveSize(platform === 'plain' ? 10 : 9);
+      expect(dom.querySelectorAll('[data-percy-element-id]')).toHaveSize(platform === 'plain' ? 11 : 10);
     });
 
     it(`${platform}: adds matching guids to the orignal DOM and cloned DOM`, () => {

--- a/packages/dom/test/serialize-inputs.test.js
+++ b/packages/dom/test/serialize-inputs.test.js
@@ -95,12 +95,21 @@ describe('serializeInputs', () => {
       expect($('#radio')[0].checked).toBe(true);
     });
 
-    it(`${platform}: removes checked attr from radio-buttons if present in dom by default but radio is not checked`, () => {
-      // validates `checked=""` is removed from the dom for option1 as it is not checked
+    it(`${platform}: removes checked attr from radio-button option2 when option1 is explictly selected`, () => {
+      dom.querySelector('#option1').checked = true;
+      $ = parseDOM(serializeDOM(), platform);
+
+      expect($('#option1')[0].outerHTML).toContain('checked=""');
+      expect($('#option1')[0].checked).toBe(true);
+
+      expect($('#option2')[0].outerHTML).not.toContain('checked=""');
+      expect($('#option2')[0].checked).toBe(false);
+    });
+
+    it(`${platform}: removes checked attr from radio-button option1 when option1 is not explictly selected`, () => {
       expect($('#option1')[0].outerHTML).not.toContain('checked=""');
       expect($('#option1')[0].checked).toBe(false);
 
-      // validates `checked=""` is not removed from the dom for option2 as it is in checked state
       expect($('#option2')[0].outerHTML).toContain('checked=""');
       expect($('#option2')[0].checked).toBe(true);
     });

--- a/packages/dom/test/serialize-inputs.test.js
+++ b/packages/dom/test/serialize-inputs.test.js
@@ -95,6 +95,14 @@ describe('serializeInputs', () => {
       expect($('#radio')[0].checked).toBe(true);
     });
 
+    it(`${platform}: removes checked attr from radio-button option1 when option1 is not explictly selected`, () => {
+      expect($('#option1')[0].outerHTML).not.toContain('checked=""');
+      expect($('#option1')[0].checked).toBe(false);
+
+      expect($('#option2')[0].outerHTML).toContain('checked=""');
+      expect($('#option2')[0].checked).toBe(true);
+    });
+
     it(`${platform}: removes checked attr from radio-button option2 when option1 is explictly selected`, () => {
       dom.querySelector('#option1').checked = true;
       $ = parseDOM(serializeDOM(), platform);
@@ -104,14 +112,6 @@ describe('serializeInputs', () => {
 
       expect($('#option2')[0].outerHTML).not.toContain('checked=""');
       expect($('#option2')[0].checked).toBe(false);
-    });
-
-    it(`${platform}: removes checked attr from radio-button option1 when option1 is not explictly selected`, () => {
-      expect($('#option1')[0].outerHTML).not.toContain('checked=""');
-      expect($('#option1')[0].checked).toBe(false);
-
-      expect($('#option2')[0].outerHTML).toContain('checked=""');
-      expect($('#option2')[0].checked).toBe(true);
     });
 
     it(`${platform}: serializes textareas`, () => {

--- a/packages/dom/test/serialize-inputs.test.js
+++ b/packages/dom/test/serialize-inputs.test.js
@@ -16,14 +16,18 @@ describe('serializeInputs', () => {
         <input id="mailing" type="checkbox" />
         <label for="mailing">Subscribe?</label>
 
-        <input id="radio" type="radio" />
+        <input id="radio" type="radio" checked=""/>
         <label for="radio">Radio</label>
 
         <input id="nevercheckedradio" type="radio" />
         <label for="nevercheckedradio">Never checked</label>
 
-        <input id="radio-checked-default" type="radio" checked="" />
-        <label for="radio-checked-default">checked present default</label>
+        <form>
+          <input type="radio" id="option1" name="option" value="option1" checked>
+          <label for="option1">Option 1</label><br>
+          <input type="radio" id="option2" name="option" value="option2" checked>
+          <label for="option2">Option 2</label><br>
+        </form>
 
         <label for="singleSelect">Does this work?</label>
         <select id="singleSelect">
@@ -87,15 +91,18 @@ describe('serializeInputs', () => {
     });
 
     it(`${platform}: serializes checked radio buttons`, () => {
+      expect($('#radio')[0].outerHTML).toContain('checked=""');
       expect($('#radio')[0].checked).toBe(true);
     });
 
-    it(`${platform}: removes checked attr from radio-buttons if present by default`, () => {
-      // validate `checked=""` is removed from the dom
-      expect($('#radio-checked-default')[0].outerHTML).not.toContain('checked=""');
+    it(`${platform}: removes checked attr from radio-buttons if present in dom by default but radio is not checked`, () => {
+      // validates `checked=""` is removed from the dom for option1 as it is not checked
+      expect($('#option1')[0].outerHTML).not.toContain('checked=""');
+      expect($('#option1')[0].checked).toBe(false);
 
-      // validate `checked` property is set to false
-      expect($('#radio-checked-default')[0].checked).toBe(false);
+      // validates `checked=""` is not removed from the dom for option2 as it is in checked state
+      expect($('#option2')[0].outerHTML).toContain('checked=""');
+      expect($('#option2')[0].checked).toBe(true);
     });
 
     it(`${platform}: serializes textareas`, () => {
@@ -135,7 +142,7 @@ describe('serializeInputs', () => {
 
     it(`${platform}: adds a guid data-attribute to the original DOM`, () => {
       // plain platform has extra element #test-shadow
-      expect(dom.querySelectorAll('[data-percy-element-id]')).toHaveSize(platform === 'plain' ? 11 : 10);
+      expect(dom.querySelectorAll('[data-percy-element-id]')).toHaveSize(platform === 'plain' ? 12 : 11);
     });
 
     it(`${platform}: adds matching guids to the orignal DOM and cloned DOM`, () => {

--- a/packages/dom/test/serialize-inputs.test.js
+++ b/packages/dom/test/serialize-inputs.test.js
@@ -22,6 +22,9 @@ describe('serializeInputs', () => {
         <input id="nevercheckedradio" type="radio" />
         <label for="nevercheckedradio">Never checked</label>
 
+        <input id="radio-checked-default" type="radio" checked="" />
+        <label for="radio-checked-default">checked present default</label>
+
         <label for="singleSelect">Does this work?</label>
         <select id="singleSelect">
           <option value="yes">Yes</option>
@@ -85,6 +88,11 @@ describe('serializeInputs', () => {
 
     it(`${platform}: serializes checked radio buttons`, () => {
       expect($('#radio')[0].checked).toBe(true);
+    });
+
+    it(`${platform}: removes checked attr from radio-buttons if present by default`, () => {
+      expect($('#radio-checked-default')[0]).not.toContain('checked=""');
+      expect($('#radio-checked-default')[0].checked).toBe(false);
     });
 
     it(`${platform}: serializes textareas`, () => {


### PR DESCRIPTION
In the new behaviour, if any of the radio-button have checked attribute present in the dom by default, 
it will be removed by default.

Only those radio-buttons will have `checked` attribute present in their rendered dom which are currently in checked state i.e. `element.checked` returning `true`