### PR TITLE
Updating Github action with appropriate pkg name

### DIFF
--- a/.github/workflows/sdk-regression.yml
+++ b/.github/workflows/sdk-regression.yml
@@ -82,7 +82,7 @@ jobs:
               state,
               target_url
             });
-      - uses: jungwinter/split@v2
+      - uses: winterjung/split@v2
         id: split
         with:
           msg: ${{ matrix.repo }}


### PR DESCRIPTION
- Updating Github action with appropriate pkg name
- Using `winterjung` instead of `jungwinter`