### PR TITLE
Replace 127.0.0.1 with render.percy.local

### DIFF
--- a/packages/dom/src/utils.js
+++ b/packages/dom/src/utils.js
@@ -42,5 +42,5 @@ export function styleSheetFromNode(node) {
 }
 
 export function rewriteLocalhostURL(url) {
-  return url.replace(/(http[s]{0,1}:\/\/)localhost[:\d+]*/, '$1render.percy.local');
+  return url.replace(/(http[s]{0,1}:\/\/)(localhost|127.0.0.1)[:\d+]*/, '$1render.percy.local');
 }

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -27,6 +27,18 @@ describe('utils', () => {
         mimetype: 'image/png'
       });
     });
+    it('If URL is 127.0.0.1, replace it to render.percy.local', () => {
+      Object.defineProperty(window.document, 'URL', {
+        writable: true,
+        value: 'http://127.0.0.1'
+      });
+      const result = resourceFromDataURL(uid, dataURL);
+      expect(result).toEqual({
+        url: `http://render.percy.local/__serialized__/${uid}.png`,
+        content: 'iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAAA5ZDbSAAAAAXNSR0IArs4c6QAACbVJREFUeF7tXAWoFVEQnW+',
+        mimetype: 'image/png'
+      });
+    });
     it('If URL is not localhost, return as is', () => {
       Object.defineProperty(window.document, 'URL', {
         writable: true,

--- a/packages/dom/test/utils.test.js
+++ b/packages/dom/test/utils.test.js
@@ -67,6 +67,18 @@ describe('utils', () => {
         mimetype: 'image/png'
       });
     });
+    it('Replace 127.0.0.1 to render.percy.local', () => {
+      Object.defineProperty(window.document, 'URL', {
+        writable: true,
+        value: 'http://127.0.0.1'
+      });
+      const result = resourceFromText(uid, 'image/png', dataURL);
+      expect(result).toEqual({
+        url: `http://render.percy.local/__serialized__/${uid}.png`,
+        content: dataURL,
+        mimetype: 'image/png'
+      });
+    });
     it('If URL is not localhost, return as is', () => {
       Object.defineProperty(window.document, 'URL', {
         writable: true,


### PR DESCRIPTION
Github Issue: https://github.com/percy/cli/issues/1568
We can across an issue where when server defined with `127.0.0.1` instead of localhost on rails application was throwing unknown route error.
This was due to replacement of Url was not happening for it. Ficed this to replace domain with render.percy.local in both cases.