### PR TITLE
Add missing Discovery option types

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -20,6 +20,8 @@ interface DiscoveryOptions {
   disableCache?: boolean;
   captureMockedServiceWorker?: boolean;
   captureSrcset?: boolean;
+  retry?: boolean;
+  userAgent?: string;
 }
 
 interface ScopeOptions {


### PR DESCRIPTION
The `retry` option was recently added in #1529. 

Noticed that the `userAgent` option was also missing from the types.