### PR TITLE
POA Playwright changes

### DIFF
--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -136,14 +136,9 @@ export function createPercyServer(percy, port) {
     }))
     .route('post', '/percy/automateScreenshot', async (req, res) => {
       let data;
-      let comparisonData;
       percyAutomateRequestHandler(req, percy);
-      if(req.body.framework == 'playwright') {
-        comparisonData = await WebdriverUtils.playwrightScreenshot(req.body);
-      } else {
-        comparisonData = await WebdriverUtils.automateScreenshot(req.body);
-      }
-      
+      let comparisonData = await WebdriverUtils.captureScreenshot(req.body);
+
       if (percy.syncMode(comparisonData)) {
         const snapshotPromise = new Promise((resolve, reject) => percy.upload(comparisonData, { resolve, reject }, 'automate'));
         data = await handleSyncJob(snapshotPromise, percy, 'comparison');

--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -136,8 +136,14 @@ export function createPercyServer(percy, port) {
     }))
     .route('post', '/percy/automateScreenshot', async (req, res) => {
       let data;
+      let comparisonData;
       percyAutomateRequestHandler(req, percy);
-      let comparisonData = await WebdriverUtils.automateScreenshot(req.body);
+      if(req.body.framework == 'playwright') {
+        comparisonData = await WebdriverUtils.playwrightScreenshot(req.body);
+      } else {
+        comparisonData = await WebdriverUtils.automateScreenshot(req.body);
+      }
+      
       if (percy.syncMode(comparisonData)) {
         const snapshotPromise = new Promise((resolve, reject) => percy.upload(comparisonData, { resolve, reject }, 'automate'));
         data = await handleSyncJob(snapshotPromise, percy, 'comparison');

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -333,7 +333,7 @@ describe('API Server', () => {
     let resolve, test = new Promise(r => (resolve = r));
     spyOn(percy, 'upload').and.returnValue(test);
     let mockWebdriverUtilResponse = 'TODO: mocked response';
-    let automateScreenshotSpy = spyOn(WebdriverUtils, 'automateScreenshot').and.resolveTo(mockWebdriverUtilResponse);
+    let captureScreenshotSpy = spyOn(WebdriverUtils, 'captureScreenshot').and.resolveTo(mockWebdriverUtilResponse);
 
     await percy.start();
 
@@ -363,7 +363,7 @@ describe('API Server', () => {
       method: 'post'
     })).toBeResolvedTo({ success: true });
 
-    expect(automateScreenshotSpy).toHaveBeenCalledOnceWith(jasmine.objectContaining({
+    expect(captureScreenshotSpy).toHaveBeenCalledOnceWith(jasmine.objectContaining({
       clientInfo: 'client',
       environmentInfo: 'environment',
       buildInfo: { id: '123', url: 'https://percy.io/test/test/123', number: 1 },
@@ -390,7 +390,7 @@ describe('API Server', () => {
   it('has a /automateScreenshot endpoint that calls #upload() async with provided options', async () => {
     spyOn(percy.client, 'getComparisonDetails').and.returnValue(getSnapshotDetailsResponse);
     spyOn(percy, 'upload').and.callFake((_, callback) => callback.resolve());
-    let automateScreenshotSpy = spyOn(WebdriverUtils, 'automateScreenshot').and.returnValue({ sync: true });
+    let captureScreenshotSpy = spyOn(WebdriverUtils, 'captureScreenshot').and.returnValue({ sync: true });
 
     await percy.start();
 
@@ -420,7 +420,7 @@ describe('API Server', () => {
       method: 'post'
     })).toBeResolvedTo({ success: true, data: getSnapshotDetailsResponse });
 
-    expect(automateScreenshotSpy).toHaveBeenCalledOnceWith(jasmine.objectContaining({
+    expect(captureScreenshotSpy).toHaveBeenCalledOnceWith(jasmine.objectContaining({
       clientInfo: 'client',
       environmentInfo: 'environment',
       buildInfo: { id: '123', url: 'https://percy.io/test/test/123', number: 1 },

--- a/packages/webdriver-utils/src/index.js
+++ b/packages/webdriver-utils/src/index.js
@@ -23,7 +23,7 @@ export default class WebdriverUtils {
       log.info(`[${snapshotName}] : Starting automate screenshot capture ...`);
 
       let provider;
-      switch (framework) {
+      switch (framework ? framework.toLowerCase() : null) {
         case 'playwright':
           provider = new PlaywrightProvider(sessionId, frameGuid, pageGuid, clientInfo, environmentInfo, options, buildInfo);
           break;

--- a/packages/webdriver-utils/src/index.js
+++ b/packages/webdriver-utils/src/index.js
@@ -3,58 +3,38 @@ import utils from '@percy/sdk-utils';
 import PlaywrightProvider from './providers/playwrightProvider.js';
 
 export default class WebdriverUtils {
-  static async automateScreenshot({
+  static async captureScreenshot({
     sessionId,
     commandExecutorUrl,
     capabilities,
-    sessionCapabilites,
-    snapshotName,
-    clientInfo,
-    environmentInfo,
-    options = {},
-    buildInfo = {}
-  }) {
-    const log = utils.logger('webdriver-utils:automateScreenshot');
-    try {
-      const startTime = Date.now();
-      log.info(`[${snapshotName}] : Starting automate screenshot ...`);
-      const automate = ProviderResolver.resolve(sessionId, commandExecutorUrl, capabilities, sessionCapabilites, clientInfo, environmentInfo, options, buildInfo);
-      log.debug(`[${snapshotName}] : Resolved provider ...`);
-      await automate.createDriver();
-      log.debug(`[${snapshotName}] : Created driver ...`);
-      const comparisonData = await automate.screenshot(snapshotName, options);
-      comparisonData.metadata.cliScreenshotStartTime = startTime;
-      comparisonData.metadata.cliScreenshotEndTime = Date.now();
-      comparisonData.sync = options.sync;
-      comparisonData.testCase = options.testCase;
-      comparisonData.thTestCaseExecutionId = options.thTestCaseExecutionId;
-      log.debug(`[${snapshotName}] : Comparison Data: ${JSON.stringify(comparisonData)}`);
-      return comparisonData;
-    } catch (e) {
-      log.error(`[${snapshotName}] : Error - ${e.message}`);
-      log.error(`[${snapshotName}] : Error Log - ${e.toString()}`);
-    }
-  }
-
-  static async playwrightScreenshot({
-    sessionId,
+    sessionCapabilities,
     frameGuid,
     pageGuid,
+    framework,
     snapshotName,
     clientInfo,
     environmentInfo,
     options = {},
     buildInfo = {}
   }) {
-    const log = utils.logger('webdriver-utils:automateScreenshot');
+    const log = utils.logger('webdriver-utils:captureScreenshot');
     try {
       const startTime = Date.now();
-      log.info(`[${snapshotName}] : Starting playwright screenshot ...`);
-      const playwright = new PlaywrightProvider(sessionId, frameGuid, pageGuid, clientInfo, environmentInfo, options, buildInfo);
-      log.debug(`[${snapshotName}] : Resolved provider ...`);
-      await playwright.createDriver();
+      log.info(`[${snapshotName}] : Starting automate screenshot capture ...`);
+
+      let provider;
+      switch (framework) {
+        case 'playwright':
+          provider = new PlaywrightProvider(sessionId, frameGuid, pageGuid, clientInfo, environmentInfo, options, buildInfo);
+          break;
+        default:
+          provider = ProviderResolver.resolve(sessionId, commandExecutorUrl, capabilities, sessionCapabilities, clientInfo, environmentInfo, options, buildInfo);
+      }
+
+      await provider.createDriver();
       log.debug(`[${snapshotName}] : Created driver ...`);
-      const comparisonData = await playwright.screenshot(snapshotName, options);
+
+      const comparisonData = await provider.screenshot(snapshotName, options);
       comparisonData.metadata.cliScreenshotStartTime = startTime;
       comparisonData.metadata.cliScreenshotEndTime = Date.now();
       comparisonData.sync = options.sync;
@@ -65,6 +45,7 @@ export default class WebdriverUtils {
     } catch (e) {
       log.error(`[${snapshotName}] : Error - ${e.message}`);
       log.error(`[${snapshotName}] : Error Log - ${e.toString()}`);
+      throw e; // Re-throw the error to maintain consistency in error handling
     }
   }
 }

--- a/packages/webdriver-utils/src/index.js
+++ b/packages/webdriver-utils/src/index.js
@@ -1,5 +1,6 @@
 import ProviderResolver from './providers/providerResolver.js';
 import utils from '@percy/sdk-utils';
+import PlaywrightProvider from './providers/playwrightProvider.js';
 
 export default class WebdriverUtils {
   static async automateScreenshot({
@@ -22,6 +23,38 @@ export default class WebdriverUtils {
       await automate.createDriver();
       log.debug(`[${snapshotName}] : Created driver ...`);
       const comparisonData = await automate.screenshot(snapshotName, options);
+      comparisonData.metadata.cliScreenshotStartTime = startTime;
+      comparisonData.metadata.cliScreenshotEndTime = Date.now();
+      comparisonData.sync = options.sync;
+      comparisonData.testCase = options.testCase;
+      comparisonData.thTestCaseExecutionId = options.thTestCaseExecutionId;
+      log.debug(`[${snapshotName}] : Comparison Data: ${JSON.stringify(comparisonData)}`);
+      return comparisonData;
+    } catch (e) {
+      log.error(`[${snapshotName}] : Error - ${e.message}`);
+      log.error(`[${snapshotName}] : Error Log - ${e.toString()}`);
+    }
+  }
+
+  static async playwrightScreenshot({
+    sessionId,
+    frameGuid,
+    pageGuid,
+    snapshotName,
+    clientInfo,
+    environmentInfo,
+    options = {},
+    buildInfo = {}
+  }) {
+    const log = utils.logger('webdriver-utils:automateScreenshot');
+    try {
+      const startTime = Date.now();
+      log.info(`[${snapshotName}] : Starting playwright screenshot ...`);
+      const playwright = new PlaywrightProvider(sessionId, frameGuid, pageGuid, clientInfo, environmentInfo, options, buildInfo);
+      log.debug(`[${snapshotName}] : Resolved provider ...`);
+      await playwright.createDriver();
+      log.debug(`[${snapshotName}] : Created driver ...`);
+      const comparisonData = await playwright.screenshot(snapshotName, options);
       comparisonData.metadata.cliScreenshotStartTime = startTime;
       comparisonData.metadata.cliScreenshotEndTime = Date.now();
       comparisonData.sync = options.sync;

--- a/packages/webdriver-utils/src/playwrightDriver.js
+++ b/packages/webdriver-utils/src/playwrightDriver.js
@@ -1,0 +1,35 @@
+import utils from '@percy/sdk-utils';
+const { request } = utils;
+const log = utils.logger('webdriver-utils:playwrightDriver');
+
+export default class PlaywrightDriver {
+  constructor(sessionId) {
+    this.sessionId = sessionId;
+  }
+
+  requestPostOptions(command) {
+    return {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json;charset=utf-8'
+      },
+      body: JSON.stringify(command)
+    };
+  }
+
+    // command => {script: "", args: []}
+  async executeScript(command) {
+    if (!command.constructor === Object || !(Object.keys(command).length === 2 && Object.keys(command).includes("script") && Object.keys(command).includes("args"))) {
+    throw new Error('Please pass command as {script: "", args: []}');
+    }
+    // browser_executor is custom BS executor script, if there is anything extra it breaks
+    // percy_automate_script is an anchor comment to identify percy automate scripts
+    if (!command.script.includes("browserstack_executor")) {
+    command.script = `/* percy_automate_script */ \n ${command.script}`;
+    }
+    const options = this.requestPostOptions(command);
+    const baseUrl = `https://cdp-k8s-devpercyplat.bsstag.com/wd/hub/session/${this.sessionId}/execute`;
+    const response = JSON.parse((await request(baseUrl, options)).body);
+    return response;
+  }
+}

--- a/packages/webdriver-utils/src/playwrightDriver.js
+++ b/packages/webdriver-utils/src/playwrightDriver.js
@@ -1,6 +1,5 @@
 import utils from '@percy/sdk-utils';
 const { request } = utils;
-const log = utils.logger('webdriver-utils:playwrightDriver');
 
 export default class PlaywrightDriver {
   constructor(sessionId) {
@@ -17,18 +16,18 @@ export default class PlaywrightDriver {
     };
   }
 
-    // command => {script: "", args: []}
+  // command => {script: "", args: []}
   async executeScript(command) {
-    if (!command.constructor === Object || !(Object.keys(command).length === 2 && Object.keys(command).includes("script") && Object.keys(command).includes("args"))) {
-    throw new Error('Please pass command as {script: "", args: []}');
+    if (!command.constructor === Object || !(Object.keys(command).length === 2 && Object.keys(command).includes('script') && Object.keys(command).includes('args'))) {
+      throw new Error('Please pass command as {script: "", args: []}');
     }
     // browser_executor is custom BS executor script, if there is anything extra it breaks
     // percy_automate_script is an anchor comment to identify percy automate scripts
-    if (!command.script.includes("browserstack_executor")) {
-    command.script = `/* percy_automate_script */ \n ${command.script}`;
+    if (!command.script.includes('browserstack_executor')) {
+      command.script = `/* percy_automate_script */ \n ${command.script}`;
     }
     const options = this.requestPostOptions(command);
-    const baseUrl = `https://cdp-k8s-devpercyplat.bsstag.com/wd/hub/session/${this.sessionId}/execute`;
+    const baseUrl = `https://cdp.browserstack.com/wd/hub/session/${this.sessionId}/execute`;
     const response = JSON.parse((await request(baseUrl, options)).body);
     return response;
   }

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -21,16 +21,16 @@ export default class AutomateProvider extends GenericProvider {
     buildInfo
   ) {
     super(
-     {
-      sessionId,
-      commandExecutorUrl,
-      capabilities,
-      sessionCapabilites,
-      clientInfo,
-      environmentInfo,
-      options,
-      buildInfo
-     }
+      {
+        sessionId,
+        commandExecutorUrl,
+        capabilities,
+        sessionCapabilites,
+        clientInfo,
+        environmentInfo,
+        options,
+        buildInfo
+      }
     );
   }
 
@@ -43,7 +43,7 @@ export default class AutomateProvider extends GenericProvider {
     log.debug(`Passed capabilities -> ${JSON.stringify(this.capabilities)}`);
     const caps = await this.driver.getCapabilites();
     log.debug(`Fetched capabilities -> ${JSON.stringify(caps)}`);
-    this.metaData = await MetaDataResolver.resolve(this.driver, caps, this.capabilities);
+    this.metaData = MetaDataResolver.resolve(this.driver, caps, this.capabilities);
   }
 
   async screenshot(name, {
@@ -88,14 +88,13 @@ export default class AutomateProvider extends GenericProvider {
     if (!this.driver) throw new Error('Driver is null, please initialize driver with createDriver().');
     log.debug('Starting actual screenshotting phase');
     const dpr = await this.metaData.devicePixelRatio();
-    const screenshotType = 'fullpage';
+    const screenshotType = this.options?.fullPage ? 'fullpage' : 'singlepage';
     const response = await TimeIt.run('percyScreenshot:screenshot', async () => {
       return await this.browserstackExecutor('percyScreenshot', {
         state: 'screenshot',
         percyBuildId: this.buildInfo.id,
         screenshotType: screenshotType,
         scaleFactor: dpr,
-        projectId: 'percy-dev',
         options: this.options
       });
     });

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -2,7 +2,6 @@ import utils from '@percy/sdk-utils';
 import GenericProvider from './genericProvider.js';
 import Cache from '../util/cache.js';
 import Tile from '../util/tile.js';
-import NormalizeData from '../metadata/normalizeData.js';
 import TimeIt from '../util/timing.js';
 import MetaDataResolver from '../metadata/metaDataResolver.js';
 import Driver from '../driver.js';
@@ -110,35 +109,17 @@ export default class AutomateProvider extends GenericProvider {
 
   async getTag() {
     if (!this.driver) throw new Error('Driver is null, please initialize driver with createDriver().');
-    if (!this.automateResults) throw new Error('Comparison tag details not available');
-
-    const automateCaps = this.automateResults.capabilities;
-    const normalizeTags = new NormalizeData();
-
-    let deviceName = this.automateResults.deviceName;
-    const osName = normalizeTags.osRollUp(automateCaps.os);
-    const osVersion = automateCaps.os_version?.split('.')[0];
-    const browserName = normalizeTags.browserRollUp(automateCaps.browserName, this.metaData.device());
-    const browserVersion = normalizeTags.browserVersionOrDeviceNameRollup(automateCaps.browserVersion, deviceName, this.metaData.device());
-
-    if (!this.metaData.device()) {
-      deviceName = `${osName}_${osVersion}_${browserName}_${browserVersion}`;
-    }
-
     let { width, height } = await this.metaData.windowSize();
     const resolution = await this.metaData.screenResolution();
-    const orientation = (this.metaData.orientation() || automateCaps.deviceOrientation)?.toLowerCase();
-
-    return {
-      name: deviceName,
-      osName,
-      osVersion,
+    const orientation = (this.metaData.orientation())?.toLowerCase();
+    const device = this.metaData.device();
+    const tagData = {
       width,
       height,
+      resolution,
       orientation,
-      browserName,
-      browserVersion,
-      resolution
+      device
     };
+    return await super.getTag(tagData);
   }
 }

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -10,30 +10,6 @@ import Driver from '../driver.js';
 const log = utils.logger('webdriver-utils:automateProvider');
 
 export default class AutomateProvider extends GenericProvider {
-  constructor(
-    sessionId,
-    commandExecutorUrl,
-    capabilities,
-    sessionCapabilites,
-    clientInfo,
-    environmentInfo,
-    options,
-    buildInfo
-  ) {
-    super(
-      {
-        sessionId,
-        commandExecutorUrl,
-        capabilities,
-        sessionCapabilites,
-        clientInfo,
-        environmentInfo,
-        options,
-        buildInfo
-      }
-    );
-  }
-
   static supports(commandExecutorUrl) {
     return commandExecutorUrl.includes(process.env.AA_DOMAIN || 'browserstack');
   }

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -35,7 +35,7 @@ export default class AutomateProvider extends GenericProvider {
   }
 
   static supports(commandExecutorUrl) {
-    return true || commandExecutorUrl.includes(process.env.AA_DOMAIN || 'browserstack');
+    return commandExecutorUrl.includes(process.env.AA_DOMAIN || 'browserstack');
   }
 
   async createDriver() {

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -2,7 +2,6 @@ import utils from '@percy/sdk-utils';
 import TimeIt from '../util/timing.js';
 import Tile from '../util/tile.js';
 
-
 const log = utils.logger('webdriver-utils:genericProvider');
 
 export default class GenericProvider {
@@ -10,13 +9,13 @@ export default class GenericProvider {
   environmentInfoDetails = new Set();
   constructor(args) {
     Object.assign(this, args);
-    console.log(JSON.stringify(args))
+    console.log(JSON.stringify(args));
     this.addClientInfo(this.clientInfo);
     this.addEnvironmentInfo(this.environmentInfo);
     this._markedPercy = false;
     this.metaData = null;
     this.debugUrl = null;
-    this.driver = null
+    this.driver = null;
     this.header = 0;
     this.footer = 0;
     this.statusBarHeight = 0;
@@ -75,19 +74,17 @@ export default class GenericProvider {
   }
 
   async percyScreenshotBegin(name) {
-    return await TimeIt.run("percyScreenshotBegin", async () => {
+    return await TimeIt.run('percyScreenshotBegin', async () => {
       try {
-        let result = await this.browserstackExecutor("percyScreenshot", {
+        let result = await this.browserstackExecutor('percyScreenshot', {
           name,
           percyBuildId: this.buildInfo.id,
           percyBuildUrl: this.buildInfo.url,
-          projectId: 'percy-dev',
-          state: "begin",
+          state: 'begin'
         });
         // Selenium Hub, set status error Code to 13 if an error is thrown
         // Handling error with Selenium dialect is != W3C
-        if (result?.status === 13)
-          throw new Error(result?.value || "Got invalid error response");
+        if (result?.status === 13) { throw new Error(result?.value || 'Got invalid error response'); }
         this._markedPercy = result.success;
         return result;
       } catch (e) {

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -9,7 +9,6 @@ export default class GenericProvider {
   environmentInfoDetails = new Set();
   constructor(args) {
     Object.assign(this, args);
-    console.log(JSON.stringify(args));
     this.addClientInfo(this.clientInfo);
     this.addEnvironmentInfo(this.environmentInfo);
     this._markedPercy = false;

--- a/packages/webdriver-utils/src/providers/playwrightProvider.js
+++ b/packages/webdriver-utils/src/providers/playwrightProvider.js
@@ -142,15 +142,16 @@ export default class PlaywrightProvider extends GenericProvider {
 
   async getTag(tagData) {
     if (!this.automateResults) throw new Error('Comparison tag details not available');
-
+    const mobileOS = ['ANDROID']
     const automateCaps = this.automateResults.capabilities;
     const normalizeTags = new NormalizeData();
 
     let deviceName = this.automateResults.deviceName;
     const osName = normalizeTags.osRollUp(automateCaps.os);
     const osVersion = automateCaps.os_version?.split('.')[0];
-    const browserName = normalizeTags.browserRollUp(automateCaps.browserName, false);
-    const browserVersion = normalizeTags.browserVersionOrDeviceNameRollup(automateCaps.browserVersion, deviceName, false);
+    const device = mobileOS.includes(osName.toUpperCase())
+    const browserName = normalizeTags.browserRollUp(automateCaps.browserName, device);
+    const browserVersion = normalizeTags.browserVersionOrDeviceNameRollup(automateCaps.browserVersion, deviceName, device);
 
     let { width, height } = { width: tagData.width, height: tagData.height };
     const resolution = tagData.resolution;

--- a/packages/webdriver-utils/src/providers/playwrightProvider.js
+++ b/packages/webdriver-utils/src/providers/playwrightProvider.js
@@ -62,10 +62,10 @@ export default class PlaywrightProvider extends GenericProvider{
         // TODO: Fetch this one for bs automate, check appium sdk
         externalDebugUrl: this.debugUrl,
         ignoredElementsData: {
-          ignoreElementsData: []
+          ignoreElementsData: tiles.ignoreRegionsData
         },
         consideredElementsData: {
-          considerElementsData: []
+          considerElementsData: tiles.considerRegionsData
         },
         environmentInfo: [...this.environmentInfo].join('; '),
         clientInfo: [...this.clientInfo].join(' '),
@@ -122,14 +122,24 @@ export default class PlaywrightProvider extends GenericProvider{
       }));
     }
     const tagData = {
-      width: tileResponse.tag_data.width,
-      height: tileResponse.tag_data.height,
-      resolution: tileResponse.tag_data.resolution,
+      width: tileResponse.comparison_tag_data.width,
+      height: tileResponse.comparison_tag_data.height,
+      resolution: tileResponse.comparison_tag_data.resolution,
     }
+
+    const ignoreRegionsData = tileResponse.ignore_regions_data || []
+    const considerRegionsData = tileResponse.consider_regions_data || []
     const metadata = {
       screenshotType: screenshotType
     };
-    return { tiles: tiles, domInfoSha: tileResponse.dom_sha, metadata: metadata, tagData: tagData };
+    return { 
+      tiles: tiles, 
+      domInfoSha: tileResponse.dom_sha, 
+      metadata: metadata, 
+      tagData: tagData,
+      ignoreRegionsData: ignoreRegionsData,
+      considerRegionsData: considerRegionsData
+    };
   }
 
   async getTag(tagData) {

--- a/packages/webdriver-utils/src/providers/playwrightProvider.js
+++ b/packages/webdriver-utils/src/providers/playwrightProvider.js
@@ -1,0 +1,164 @@
+import utils from '@percy/sdk-utils';
+import TimeIt from "../util/timing.js";
+import NormalizeData from '../metadata/normalizeData.js';
+import Tile from '../util/tile.js';
+import GenericProvider from './genericProvider.js';
+import PlaywrightDriver from '../playwrightDriver.js';
+
+const log = utils.logger("webdriver-utils:genericProvider");
+
+export default class PlaywrightProvider extends GenericProvider{
+  constructor(
+    sessionId,
+    frameGuid,
+    pageGuid,
+    clientInfo,
+    environmentInfo,
+    options,
+    buildInfo
+  ) {
+    super(
+      {
+      sessionId,
+      frameGuid,
+      pageGuid,
+      clientInfo,
+      environmentInfo,
+      options,
+      buildInfo,
+    }
+    );
+  }
+
+  async createDriver() {
+    this.driver = new PlaywrightDriver(this.sessionId)
+  }
+
+  async setDebugUrl() {
+    this.debugUrl = `https://automate.browserstack.com/builds/${this.automateResults.buildHash}/sessions/${this.automateResults.sessionHash}`;
+  }
+
+  async screenshot(name, {
+  }) {
+    let response = null;
+    let error;
+    log.debug(`[${name}] : Preparing to capture screenshots on playwrght with automate ...`);
+    try {
+      log.debug(`[${name}] : Marking automate session as percy ...`);
+      const result = await this.percyScreenshotBegin(name);
+      this.automateResults = JSON.parse(result.value);
+      log.debug(`[${name}] : Begin response ${this.automateResults}`);
+      log.debug(`[${name}] : Fetching the debug url ...`);
+      this.setDebugUrl();
+      const tiles = await this.getTiles();
+      log.debug(`[${name}] : Tiles ${JSON.stringify(tiles)}`);
+      log.debug('Fetching comparisong tag ...');
+      const tag = await this.getTag(tiles.tagData);
+      log.debug(`[${name}] : Tag ${JSON.stringify(tag)}`);
+      response = {
+        name,
+        tag,
+        tiles: tiles.tiles,
+        // TODO: Fetch this one for bs automate, check appium sdk
+        externalDebugUrl: this.debugUrl,
+        ignoredElementsData: {
+          ignoreElementsData: []
+        },
+        consideredElementsData: {
+          considerElementsData: []
+        },
+        environmentInfo: [...this.environmentInfo].join('; '),
+        clientInfo: [...this.clientInfo].join(' '),
+        domInfoSha: tiles.domInfoSha,
+        metadata: tiles.metadata || null
+      };
+    } catch (e) {
+      console.trace(e)
+      error = e;
+      throw e;
+    } finally {
+      await this.percyScreenshotEnd(name, error);
+    }
+    return response;
+  }
+
+  async getTiles(fullscreen = true) {
+    log.debug('Starting actual screenshotting phase');
+    const screenshotType = 'fullpage';
+    const response = await TimeIt.run('percyScreenshot:screenshot', async () => {
+      return await this.browserstackExecutor('percyScreenshot', {
+        state: 'screenshot',
+        percyBuildId: this.buildInfo.id,
+        screenshotType: screenshotType,
+        scaleFactor: 1,
+        options: this.options,
+        projectId: 'percy-dev',
+        frameworkData: {
+          frameGuid: this.frameGuid,
+          pageGuid: this.pageGuid,
+        },
+        framework: 'playwright'
+      });
+    });
+    log.debug(`Response ${JSON.stringify(response)}`);
+    const responseValue = JSON.parse(response.value);
+    if (!responseValue.success) {
+      throw new Error('Failed to get screenshots from Automate.' +
+      ' Check dashboard for error.');
+    }
+
+    const tiles = [];
+    log.debug('Capturing tiles');
+    const tileResponse = JSON.parse(responseValue.result);
+    log.debug(`Tiles captured successfully ${JSON.stringify(tileResponse)}`);
+    for (let tileData of tileResponse.tiles) {
+      tiles.push(new Tile({
+        statusBarHeight: tileData.status_bar || 0,
+        navBarHeight: tileData.nav_bar || 0,
+        headerHeight: tileData.header_height || 0,
+        footerHeight: tileData.footer_height || 0,
+        fullscreen,
+        sha: tileData.sha.split('-')[0] // drop build id
+      }));
+    }
+    const tagData = {
+      width: tileResponse.tag_data.width,
+      height: tileResponse.tag_data.height,
+      resolution: tileResponse.tag_data.resolution,
+    }
+    const metadata = {
+      screenshotType: screenshotType
+    };
+    return { tiles: tiles, domInfoSha: tileResponse.dom_sha, metadata: metadata, tagData: tagData };
+  }
+
+  async getTag(tagData) {
+    if (!this.automateResults) throw new Error('Comparison tag details not available');
+
+    const automateCaps = this.automateResults.capabilities;
+    const normalizeTags = new NormalizeData();
+
+    let deviceName = this.automateResults.deviceName;
+    const osName = normalizeTags.osRollUp(automateCaps.os);
+    const osVersion = automateCaps.os_version?.split('.')[0];
+    const browserName = normalizeTags.browserRollUp(automateCaps.browserName, false);
+    const browserVersion = normalizeTags.browserVersionOrDeviceNameRollup(automateCaps.browserVersion, deviceName, false);
+
+    let { width, height } = {width: tagData.width, height: tagData.height}
+    const resolution = tagData.resolution;
+    log.debug(`orientation ${automateCaps.deviceOrientation}`);
+    const orientation = automateCaps.deviceOrientation || 'landscape'
+
+    return {
+      name: deviceName,
+      osName,
+      osVersion,
+      width,
+      height,
+      orientation,
+      browserName,
+      browserVersion,
+      resolution
+    };
+  }
+}

--- a/packages/webdriver-utils/src/providers/playwrightProvider.js
+++ b/packages/webdriver-utils/src/providers/playwrightProvider.js
@@ -142,14 +142,14 @@ export default class PlaywrightProvider extends GenericProvider {
 
   async getTag(tagData) {
     if (!this.automateResults) throw new Error('Comparison tag details not available');
-    const mobileOS = ['ANDROID']
+    const mobileOS = ['ANDROID'];
     const automateCaps = this.automateResults.capabilities;
     const normalizeTags = new NormalizeData();
 
     let deviceName = this.automateResults.deviceName;
     const osName = normalizeTags.osRollUp(automateCaps.os);
     const osVersion = automateCaps.os_version?.split('.')[0];
-    const device = mobileOS.includes(osName.toUpperCase())
+    const device = mobileOS.includes(osName.toUpperCase());
     const browserName = normalizeTags.browserRollUp(automateCaps.browserName, device);
     const browserVersion = normalizeTags.browserVersionOrDeviceNameRollup(automateCaps.browserVersion, deviceName, device);
 

--- a/packages/webdriver-utils/src/providers/playwrightProvider.js
+++ b/packages/webdriver-utils/src/providers/playwrightProvider.js
@@ -1,13 +1,13 @@
 import utils from '@percy/sdk-utils';
-import TimeIt from "../util/timing.js";
+import TimeIt from '../util/timing.js';
 import NormalizeData from '../metadata/normalizeData.js';
 import Tile from '../util/tile.js';
 import GenericProvider from './genericProvider.js';
 import PlaywrightDriver from '../playwrightDriver.js';
 
-const log = utils.logger("webdriver-utils:genericProvider");
+const log = utils.logger('webdriver-utils:genericProvider');
 
-export default class PlaywrightProvider extends GenericProvider{
+export default class PlaywrightProvider extends GenericProvider {
   constructor(
     sessionId,
     frameGuid,
@@ -19,27 +19,26 @@ export default class PlaywrightProvider extends GenericProvider{
   ) {
     super(
       {
-      sessionId,
-      frameGuid,
-      pageGuid,
-      clientInfo,
-      environmentInfo,
-      options,
-      buildInfo,
-    }
+        sessionId,
+        frameGuid,
+        pageGuid,
+        clientInfo,
+        environmentInfo,
+        options,
+        buildInfo
+      }
     );
   }
 
   async createDriver() {
-    this.driver = new PlaywrightDriver(this.sessionId)
+    this.driver = new PlaywrightDriver(this.sessionId);
   }
 
   async setDebugUrl() {
     this.debugUrl = `https://automate.browserstack.com/builds/${this.automateResults.buildHash}/sessions/${this.automateResults.sessionHash}`;
   }
 
-  async screenshot(name, {
-  }) {
+  async screenshot(name, options) {
     let response = null;
     let error;
     log.debug(`[${name}] : Preparing to capture screenshots on playwrght with automate ...`);
@@ -73,7 +72,7 @@ export default class PlaywrightProvider extends GenericProvider{
         metadata: tiles.metadata || null
       };
     } catch (e) {
-      console.trace(e)
+      console.trace(e);
       error = e;
       throw e;
     } finally {
@@ -84,7 +83,7 @@ export default class PlaywrightProvider extends GenericProvider{
 
   async getTiles(fullscreen = true) {
     log.debug('Starting actual screenshotting phase');
-    const screenshotType = 'fullpage';
+    const screenshotType = this.options?.fullPage ? 'fullpage' : 'singlepage';
     const response = await TimeIt.run('percyScreenshot:screenshot', async () => {
       return await this.browserstackExecutor('percyScreenshot', {
         state: 'screenshot',
@@ -92,10 +91,9 @@ export default class PlaywrightProvider extends GenericProvider{
         screenshotType: screenshotType,
         scaleFactor: 1,
         options: this.options,
-        projectId: 'percy-dev',
         frameworkData: {
           frameGuid: this.frameGuid,
-          pageGuid: this.pageGuid,
+          pageGuid: this.pageGuid
         },
         framework: 'playwright'
       });
@@ -124,18 +122,18 @@ export default class PlaywrightProvider extends GenericProvider{
     const tagData = {
       width: tileResponse.comparison_tag_data.width,
       height: tileResponse.comparison_tag_data.height,
-      resolution: tileResponse.comparison_tag_data.resolution,
-    }
+      resolution: tileResponse.comparison_tag_data.resolution
+    };
 
-    const ignoreRegionsData = tileResponse.ignore_regions_data || []
-    const considerRegionsData = tileResponse.consider_regions_data || []
+    const ignoreRegionsData = tileResponse.ignore_regions_data || [];
+    const considerRegionsData = tileResponse.consider_regions_data || [];
     const metadata = {
       screenshotType: screenshotType
     };
-    return { 
-      tiles: tiles, 
-      domInfoSha: tileResponse.dom_sha, 
-      metadata: metadata, 
+    return {
+      tiles: tiles,
+      domInfoSha: tileResponse.dom_sha,
+      metadata: metadata,
       tagData: tagData,
       ignoreRegionsData: ignoreRegionsData,
       considerRegionsData: considerRegionsData
@@ -154,10 +152,10 @@ export default class PlaywrightProvider extends GenericProvider{
     const browserName = normalizeTags.browserRollUp(automateCaps.browserName, false);
     const browserVersion = normalizeTags.browserVersionOrDeviceNameRollup(automateCaps.browserVersion, deviceName, false);
 
-    let { width, height } = {width: tagData.width, height: tagData.height}
+    let { width, height } = { width: tagData.width, height: tagData.height };
     const resolution = tagData.resolution;
     log.debug(`orientation ${automateCaps.deviceOrientation}`);
-    const orientation = automateCaps.deviceOrientation || 'landscape'
+    const orientation = automateCaps.deviceOrientation || 'landscape';
 
     return {
       name: deviceName,

--- a/packages/webdriver-utils/src/providers/playwrightProvider.js
+++ b/packages/webdriver-utils/src/providers/playwrightProvider.js
@@ -66,8 +66,8 @@ export default class PlaywrightProvider extends GenericProvider {
         consideredElementsData: {
           considerElementsData: tiles.considerRegionsData
         },
-        environmentInfo: [...this.environmentInfo].join('; '),
-        clientInfo: [...this.clientInfo].join(' '),
+        environmentInfo: this.environmentInfo,
+        clientInfo: this.clientInfo,
         domInfoSha: tiles.domInfoSha,
         metadata: tiles.metadata || null
       };

--- a/packages/webdriver-utils/src/providers/playwrightProvider.js
+++ b/packages/webdriver-utils/src/providers/playwrightProvider.js
@@ -82,7 +82,7 @@ export default class PlaywrightProvider extends GenericProvider {
   }
 
   async getTiles(fullscreen = true) {
-    log.debug('Starting actual screenshotting phase');
+    log.debug(`Starting actual screenshotting phase with Page GUID: ${this.pageGuid}, Frame GUID: ${this.frameGuid}`);
     const screenshotType = this.options?.fullPage ? 'fullpage' : 'singlepage';
     const response = await TimeIt.run('percyScreenshot:screenshot', async () => {
       return await this.browserstackExecutor('percyScreenshot', {
@@ -143,31 +143,12 @@ export default class PlaywrightProvider extends GenericProvider {
   async getTag(tagData) {
     if (!this.automateResults) throw new Error('Comparison tag details not available');
     const mobileOS = ['ANDROID'];
-    const automateCaps = this.automateResults.capabilities;
     const normalizeTags = new NormalizeData();
-
-    let deviceName = this.automateResults.deviceName;
+    const automateCaps = this.automateResults.capabilities;
     const osName = normalizeTags.osRollUp(automateCaps.os);
-    const osVersion = automateCaps.os_version?.split('.')[0];
     const device = mobileOS.includes(osName.toUpperCase());
-    const browserName = normalizeTags.browserRollUp(automateCaps.browserName, device);
-    const browserVersion = normalizeTags.browserVersionOrDeviceNameRollup(automateCaps.browserVersion, deviceName, device);
-
-    let { width, height } = { width: tagData.width, height: tagData.height };
-    const resolution = tagData.resolution;
-    log.debug(`orientation ${automateCaps.deviceOrientation}`);
-    const orientation = automateCaps.deviceOrientation || 'landscape';
-
-    return {
-      name: deviceName,
-      osName,
-      osVersion,
-      width,
-      height,
-      orientation,
-      browserName,
-      browserVersion,
-      resolution
-    };
+    tagData.device = device;
+    console.log(`Device: ${device}`);
+    return await super.getTag(tagData);
   }
 }

--- a/packages/webdriver-utils/src/providers/providerResolver.js
+++ b/packages/webdriver-utils/src/providers/providerResolver.js
@@ -2,9 +2,30 @@ import GenericProvider from './genericProvider.js';
 import AutomateProvider from './automateProvider.js';
 
 export default class ProviderResolver {
-  static resolve(sessionId, commandExecutorUrl, capabilities, sessionCapabilities, clientInfo, environmentInfo, options, buildInfo) {
+  static resolve(
+    sessionId,
+    commandExecutorUrl,
+    capabilities,
+    sessionCapabilities,
+    clientInfo,
+    environmentInfo,
+    options,
+    buildInfo
+  ) {
     // We can safely do [0] because GenericProvider is catch all
-    const Klass = [AutomateProvider, GenericProvider].filter(x => x.supports(commandExecutorUrl))[0];
-    return new Klass(sessionId, commandExecutorUrl, capabilities, sessionCapabilities, clientInfo, environmentInfo, options, buildInfo);
+    const Klass = [AutomateProvider, GenericProvider].filter((x) =>
+      x.supports(commandExecutorUrl)
+    )[0];
+    const args = {
+      sessionId,
+      commandExecutorUrl,
+      capabilities,
+      sessionCapabilities,
+      clientInfo,
+      environmentInfo,
+      options,
+      buildInfo
+    };
+    return new Klass(args);
   }
 }

--- a/packages/webdriver-utils/src/providers/providerResolver.js
+++ b/packages/webdriver-utils/src/providers/providerResolver.js
@@ -13,8 +13,8 @@ export default class ProviderResolver {
     buildInfo
   ) {
     // We can safely do [0] because GenericProvider is catch all
-    const Klass = [AutomateProvider, GenericProvider].filter((x) =>
-      x.supports(commandExecutorUrl)
+    const Klass = [AutomateProvider, GenericProvider].filter((provider) =>
+      provider.supports(commandExecutorUrl)
     )[0];
     const args = {
       sessionId,

--- a/packages/webdriver-utils/test/playwrightDriver.test.js
+++ b/packages/webdriver-utils/test/playwrightDriver.test.js
@@ -64,6 +64,28 @@ describe('PlaywrightDriver', () => {
       expect(response).toEqual({ value: 'mockVal' });
     });
 
+    it('should execute script without percy_automate_script', async () => {
+      const command = { script: 'browserstack_executor: console.log("Hello, World!")', args: [] };
+
+      const response = await driver.executeScript(command);
+
+      const expectedCommand = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json;charset=utf-8'
+        },
+        body: JSON.stringify({
+          script: 'browserstack_executor: console.log("Hello, World!")',
+          args: []
+        })
+      };
+
+      const baseUrl = `https://cdp.browserstack.com/wd/hub/session/${sessionId}/execute`;
+
+      expect(requestSpy).toHaveBeenCalledWith(baseUrl, expectedCommand);
+      expect(response).toEqual({ value: 'mockVal' });
+    });
+
     it('should handle request error and re-throw', async () => {
       requestSpy.and.returnValue(Promise.reject(new Error('Request failed')));
       const command = { script: 'console.log("Hello, World!")', args: [] };

--- a/packages/webdriver-utils/test/playwrightDriver.test.js
+++ b/packages/webdriver-utils/test/playwrightDriver.test.js
@@ -1,0 +1,121 @@
+import PlaywrightDriver from '../src/playwrightDriver.js';
+import utils from '@percy/sdk-utils';
+
+describe('PlaywrightDriver', () => {
+  let requestSpy;
+  let mockResponseObject = {
+    body: '{"value": "mockVal"}',
+    status: 200,
+    headers: { 'content-type': 'application/text' }
+  };
+  let sessionId = '123';
+  let driver;
+
+  beforeEach(() => {
+    requestSpy = spyOn(utils.request, 'fetch').and.returnValue(
+      Promise.resolve(mockResponseObject)
+    );
+    driver = new PlaywrightDriver(sessionId);
+  });
+
+  describe('constructor', () => {
+    it('should set sessionId correctly', () => {
+      expect(driver.sessionId).toEqual(sessionId);
+    });
+  });
+
+  describe('requestPostOptions', () => {
+    it('should return correct options for a given command', () => {
+      const command = { script: 'console.log("Hello, World!")', args: [] };
+      const expectedOptions = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json;charset=utf-8'
+        },
+        body: JSON.stringify(command)
+      };
+
+      const options = driver.requestPostOptions(command);
+
+      expect(options).toEqual(expectedOptions);
+    });
+  });
+
+  describe('executeScript', () => {
+    it('should execute script and handle response correctly', async () => {
+      const command = { script: 'console.log("Hello, World!")', args: [] };
+
+      const response = await driver.executeScript(command);
+
+      const expectedCommand = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json;charset=utf-8'
+        },
+        body: JSON.stringify({
+          script: '/* percy_automate_script */ \n console.log("Hello, World!")',
+          args: []
+        })
+      };
+
+      const baseUrl = `https://cdp.browserstack.com/wd/hub/session/${sessionId}/execute`;
+
+      expect(requestSpy).toHaveBeenCalledWith(baseUrl, expectedCommand);
+      expect(response).toEqual({ value: 'mockVal' });
+    });
+
+    it('should handle request error and re-throw', async () => {
+      requestSpy.and.returnValue(Promise.reject(new Error('Request failed')));
+      const command = { script: 'console.log("Hello, World!")', args: [] };
+
+      await expectAsync(driver.executeScript(command)).toBeRejectedWithError(
+        'Request failed'
+      );
+    });
+
+    it('should handle JSON parsing error', async () => {
+      requestSpy.and.returnValue(Promise.resolve({ body: 'invalid-json' }));
+      const command = { script: 'console.log("Hello, World!")', args: [] };
+
+      await expectAsync(driver.executeScript(command)).toBeRejectedWithError(
+        TypeError
+      );
+    });
+
+    it('should throw error if command is not an object', async () => {
+      const command = 'invalid-command';
+
+      await expectAsync(driver.executeScript(command)).toBeRejectedWithError(
+        'Please pass command as {script: "", args: []}'
+      );
+    });
+
+    it('should throw error if command does not contain script key', async () => {
+      const command = { args: [] };
+
+      await expectAsync(driver.executeScript(command)).toBeRejectedWithError(
+        'Please pass command as {script: "", args: []}'
+      );
+    });
+
+    it('should throw error if command does not contain args key', async () => {
+      const command = { script: 'console.log("Hello, World!")' };
+
+      await expectAsync(driver.executeScript(command)).toBeRejectedWithError(
+        'Please pass command as {script: "", args: []}'
+      );
+    });
+
+    it('should throw error if command has additional keys', async () => {
+      const command = {
+        script: 'console.log("Hello, World!")',
+        args: [],
+        otherKey: 'value'
+      };
+
+      await expectAsync(driver.executeScript(command)).toBeRejectedWithError(
+        'Please pass command as {script: "", args: []}'
+      );
+    });
+  });
+});

--- a/packages/webdriver-utils/test/providers/automateProvider.test.js
+++ b/packages/webdriver-utils/test/providers/automateProvider.test.js
@@ -8,56 +8,32 @@ import Cache from '../../src/util/cache.js';
 
 describe('AutomateProvider', () => {
   let superScreenshotSpy;
+  let args;
+  let percyBuildInfo = {
+    id: '123',
+    url: 'https://percy.io/abc/123'
+  };
 
   beforeEach(async () => {
     superScreenshotSpy = spyOn(GenericProvider.prototype, 'screenshot');
+    args = {
+      sessionId: '1234',
+      commandExecutorUrl: 'https://localhost/command-executor',
+      capabilities: { platform: 'win' },
+      sessionCapabilities: {},
+      clientInfo: 'client',
+      environmentInfo: 'environment',
+      options: {},
+      buildInfo: percyBuildInfo
+    };
   });
 
   afterEach(() => {
     superScreenshotSpy.calls.reset();
   });
 
-  describe('browserstackExecutor', () => {
-    let executeScriptSpy;
-    let percyBuildInfo = {
-      id: '123',
-      url: 'https://percy.io/abc/123'
-    };
-
-    beforeEach(async () => {
-      executeScriptSpy = spyOn(Driver.prototype, 'executeScript');
-      spyOn(Driver.prototype, 'getCapabilites');
-    });
-
-    it('throws Error when called without initializing driver', async () => {
-      let automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
-      await expectAsync(automateProvider.browserstackExecutor('getSessionDetails'))
-        .toBeRejectedWithError('Driver is null, please initialize driver with createDriver().');
-    });
-
-    it('calls browserstackExecutor with correct arguemnts for actions only', async () => {
-      let automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
-      await automateProvider.createDriver();
-      await automateProvider.browserstackExecutor('getSessionDetails');
-      expect(executeScriptSpy)
-        .toHaveBeenCalledWith({ script: 'browserstack_executor: {"action":"getSessionDetails"}', args: [] });
-    });
-
-    it('calls browserstackExecutor with correct arguemnts for actions + args', async () => {
-      let automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
-      await automateProvider.createDriver();
-      await automateProvider.browserstackExecutor('getSessionDetails', 'new');
-      expect(executeScriptSpy)
-        .toHaveBeenCalledWith({ script: 'browserstack_executor: {"action":"getSessionDetails","arguments":"new"}', args: [] });
-    });
-  });
-
   describe('setDebugUrl', () => {
     let percyScreenshotBeginSpy;
-    let percyBuildInfo = {
-      id: '123',
-      url: 'https://percy.io/abc/123'
-    };
 
     beforeEach(async () => {
       percyScreenshotBeginSpy = spyOn(AutomateProvider.prototype,
@@ -66,7 +42,7 @@ describe('AutomateProvider', () => {
     });
 
     it('sets automate url', async () => {
-      let automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
+      let automateProvider = new AutomateProvider(args);
       await automateProvider.createDriver();
       await automateProvider.screenshot('abc', { });
 
@@ -75,7 +51,7 @@ describe('AutomateProvider', () => {
     });
 
     it('throws error if driver is not initialized', async () => {
-      let automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
+      let automateProvider = new AutomateProvider(args);
       await expectAsync(automateProvider.setDebugUrl())
         .toBeRejectedWithError('Driver is null, please initialize driver with createDriver().');
     });
@@ -94,6 +70,7 @@ describe('AutomateProvider', () => {
   describe('screenshot', () => {
     let percyScreenshotBeginSpy;
     let percyScreenshotEndSpy;
+    let automateProvider;
     const options = {
       ignoreRegionXpaths: [],
       ignoreRegionSelectors: [],
@@ -104,11 +81,6 @@ describe('AutomateProvider', () => {
       considerRegionElements: [],
       customConsiderRegions: []
     };
-    let percyBuildInfo = {
-      id: '123',
-      url: 'https://percy.io/abc/123'
-    };
-    const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
 
     beforeEach(async () => {
       percyScreenshotBeginSpy = spyOn(AutomateProvider.prototype,
@@ -116,6 +88,7 @@ describe('AutomateProvider', () => {
       percyScreenshotEndSpy = spyOn(AutomateProvider.prototype,
         'percyScreenshotEnd').and.returnValue(true);
       spyOn(Driver.prototype, 'getCapabilites');
+      automateProvider = new AutomateProvider(args);
     });
 
     it('test call with default args', async () => {
@@ -140,24 +113,19 @@ describe('AutomateProvider', () => {
   });
 
   describe('percyScreenshotBegin', () => {
-    let percyBuildInfo = {
-      id: '123',
-      url: 'https://percy.io/abc/123'
-    };
-
     beforeEach(async () => {
       spyOn(Driver.prototype, 'getCapabilites');
     });
 
     it('throw error', async () => {
-      const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
+      const automateProvider = new AutomateProvider(args);
       await automateProvider.createDriver();
       spyOn(Driver.prototype, 'executeScript').and.returnValue(Promise.reject(new Error('Random network error')));
       await expectAsync(automateProvider.percyScreenshotBegin('abc')).toBeRejectedWithError('Random network error');
     });
 
     it('marks the percy session as success', async () => {
-      const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
+      const automateProvider = new AutomateProvider(args);
       await automateProvider.createDriver();
       spyOn(Driver.prototype, 'executeScript').and.returnValue(Promise.resolve({ success: true }));
       await automateProvider.percyScreenshotBegin('abc');
@@ -165,21 +133,21 @@ describe('AutomateProvider', () => {
     });
 
     it('throw error if statusCode:13', async () => {
-      const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, {}, 'client', 'environment', {}, percyBuildInfo);
+      const automateProvider = new AutomateProvider(args);
       await automateProvider.createDriver();
       spyOn(Driver.prototype, 'executeScript').and.returnValue(Promise.resolve({ status: 13, value: 'OS/Browser/Selenium combination is not supported' }));
       await expectAsync(automateProvider.percyScreenshotBegin('abc')).toBeRejectedWithError('OS/Browser/Selenium combination is not supported');
     });
 
     it('throw "Got invalid error resposne" if result.value does not exists', async () => {
-      const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, {}, 'client', 'environment', {}, percyBuildInfo);
+      const automateProvider = new AutomateProvider(args);
       await automateProvider.createDriver();
       spyOn(Driver.prototype, 'executeScript').and.returnValue(Promise.resolve({ status: 13 }));
       await expectAsync(automateProvider.percyScreenshotBegin('abc')).toBeRejectedWithError('Got invalid error response');
     });
 
     it('mark percy sesssion as failure', async () => {
-      const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, {}, 'client', 'environment', {}, percyBuildInfo);
+      const automateProvider = new AutomateProvider(args);
       await automateProvider.createDriver();
       // eslint-disable-next-line prefer-promise-reject-errors
       spyOn(Driver.prototype, 'executeScript').and.returnValue(Promise.reject({ response: { body: JSON.stringify({ value: { error: 'OS/Browser/Selenium combination is not supported', message: 'OS/Browser/Selenium combination is not supported' } }) } }));
@@ -187,7 +155,7 @@ describe('AutomateProvider', () => {
     });
 
     it('catch direct response error', async () => {
-      const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, {}, 'client', 'environment', {}, percyBuildInfo);
+      const automateProvider = new AutomateProvider(args);
       await automateProvider.createDriver();
       // eslint-disable-next-line prefer-promise-reject-errors
       spyOn(Driver.prototype, 'executeScript').and.returnValue(Promise.reject('Random Error'));
@@ -200,12 +168,13 @@ describe('AutomateProvider', () => {
       id: '123',
       url: 'https://percy.io/abc/123'
     };
+    let automateProvider;
 
     let errorObj = new Error('Random network error');
-    const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
 
     beforeEach(async () => {
       spyOn(Driver.prototype, 'getCapabilites');
+      automateProvider = new AutomateProvider(args);
     });
 
     it('supresses exception and does not throw', async () => {
@@ -239,7 +208,8 @@ describe('AutomateProvider', () => {
     });
 
     it('passes sync options value to', async () => {
-      const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', { sync: true }, percyBuildInfo);
+      args.options = { sync: true };
+      const automateProvider = new AutomateProvider(args);
       await automateProvider.createDriver();
       automateProvider.driver.executeScript = jasmine.createSpy().and.resolveTo('success');
       await automateProvider.percyScreenshotEnd('abc', undefined);
@@ -268,15 +238,22 @@ describe('AutomateProvider', () => {
   }
 
   describe('getTiles', () => {
-    let percyBuildInfo = {
-      id: '123',
-      url: 'https://percy.io/abc/123'
-    };
     let browserstackExecutorSpy = null;
     let executeScriptSpy;
+    let args = {
+      sessionId: '1234',
+      commandExecutorUrl: 'https://localhost/command-executor',
+      capabilities: { platform: 'win' },
+      sessionCapabilities: {},
+      clientInfo: 'client',
+      environmentInfo: 'environment',
+      options: {},
+      buildInfo: percyBuildInfo
+    };
 
     describe('fullpage', () => {
-      const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', { fullPage: true }, percyBuildInfo);
+      args.options = { fullPage: true };
+      const automateProvider = new AutomateProvider(args);
 
       beforeEach(async () => {
         Cache.reset();
@@ -349,7 +326,8 @@ describe('AutomateProvider', () => {
     });
 
     describe('singlepage', () => {
-      const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
+      args.options = {};
+      const automateProvider = new AutomateProvider(args);
       beforeEach(async () => {
         Cache.reset();
         spyOn(Driver.prototype, 'getCapabilites');
@@ -391,13 +369,9 @@ describe('AutomateProvider', () => {
     let windowSizeSpy;
     let orientationSpy;
     let resolutionSpy;
-    let percyBuildInfo = {
-      id: '123',
-      url: 'https://percy.io/abc/123'
-    };
+    let automateProvider;
 
     describe('for desktop', () => {
-      const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
       beforeEach(async () => {
         percyScreenshotBeginSpy = spyOn(AutomateProvider.prototype,
           'percyScreenshotBegin').and.returnValue({ value: '{"buildHash":"12e3","sessionHash":"abc1d","capabilities":{"browserName":"chrome","browserVersion":"113.0","os":"win11","os_version":"11","deviceOrientation":false,"resolution":["1920","1080"]},"success":true,"deviceName":"x.x.x.x"}' });
@@ -408,6 +382,7 @@ describe('AutomateProvider', () => {
           .and.returnValue('1980 x 1080');
         orientationSpy = spyOn(DesktopMetaData.prototype, 'orientation')
           .and.returnValue('landscape');
+        automateProvider = new AutomateProvider(args);
       });
 
       it('generates comparison tag for desktop', async () => {
@@ -435,7 +410,6 @@ describe('AutomateProvider', () => {
     });
 
     describe('for devices', () => {
-      const automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'android' }, {}, 'client', 'environment', {}, percyBuildInfo);
       beforeEach(async () => {
         percyScreenshotBeginSpy = spyOn(AutomateProvider.prototype,
           'percyScreenshotBegin').and.returnValue({ value: '{"buildHash":"12e3","sessionHash":"abc1d","capabilities":{"browserName":"chrome_android","browserVersion":"chrome_android","os":"android","os_version":"11","deviceOrientation":"portrait","resolution":["1920","1080"]},"success":true,"deviceName":"Samsung Galaxy S21"}' });
@@ -446,6 +420,8 @@ describe('AutomateProvider', () => {
           .and.returnValue('1980 x 1080');
         orientationSpy = spyOn(MobileMetaData.prototype, 'orientation')
           .and.returnValue(undefined);
+        args.capabilities = { platform: 'android' };
+        automateProvider = new AutomateProvider(args);
       });
 
       it('generates comparsion tag for mobile', async () => {
@@ -474,7 +450,7 @@ describe('AutomateProvider', () => {
 
     describe('driver is null', () => {
       it('throws Error when called without initializing driver', async () => {
-        let automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
+        let automateProvider = new AutomateProvider(args);
         await expectAsync(automateProvider.getTag())
           .toBeRejectedWithError('Driver is null, please initialize driver with createDriver().');
       });
@@ -482,7 +458,7 @@ describe('AutomateProvider', () => {
 
     describe('automateResults is null', () => {
       it('throws Error automateResults are not available', async () => {
-        let automateProvider = new AutomateProvider('1234', 'https://localhost/command-executor', { platform: 'win' }, {}, 'client', 'environment', {}, percyBuildInfo);
+        let automateProvider = new AutomateProvider(args);
         await automateProvider.createDriver();
         await expectAsync(automateProvider.getTag())
           .toBeRejectedWithError('Comparison tag details not available');

--- a/packages/webdriver-utils/test/providers/automateProvider.test.js
+++ b/packages/webdriver-utils/test/providers/automateProvider.test.js
@@ -455,14 +455,5 @@ describe('AutomateProvider', () => {
           .toBeRejectedWithError('Driver is null, please initialize driver with createDriver().');
       });
     });
-
-    describe('automateResults is null', () => {
-      it('throws Error automateResults are not available', async () => {
-        let automateProvider = new AutomateProvider(args);
-        await automateProvider.createDriver();
-        await expectAsync(automateProvider.getTag())
-          .toBeRejectedWithError('Comparison tag details not available');
-      });
-    });
   });
 });

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -1000,4 +1000,34 @@ describe('GenericProvider', () => {
       expect(provider.getUserAgentString(data)).toEqual('');
     });
   });
+
+  describe('browserstackExecutor', () => {
+    let executeScriptSpy;
+
+    beforeEach(async () => {
+      executeScriptSpy = spyOn(Driver.prototype, 'executeScript');
+    });
+
+    it('throws Error when called without initializing driver', async () => {
+      let provider = new GenericProvider(args);
+      await expectAsync(provider.browserstackExecutor('getSessionDetails'))
+        .toBeRejectedWithError('Driver is null, please initialize driver with createDriver().');
+    });
+
+    it('calls browserstackExecutor with correct arguemnts for actions only', async () => {
+      let provider = new GenericProvider(args);
+      await provider.createDriver();
+      await provider.browserstackExecutor('getSessionDetails');
+      expect(executeScriptSpy)
+        .toHaveBeenCalledWith({ script: 'browserstack_executor: {"action":"getSessionDetails"}', args: [] });
+    });
+
+    it('calls browserstackExecutor with correct arguemnts for actions + args', async () => {
+      let provider = new GenericProvider(args);
+      await provider.createDriver();
+      await provider.browserstackExecutor('getSessionDetails', 'new');
+      expect(executeScriptSpy)
+        .toHaveBeenCalledWith({ script: 'browserstack_executor: {"action":"getSessionDetails","arguments":"new"}', args: [] });
+    });
+  });
 });

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -7,8 +7,18 @@ import MobileMetaData from '../../src/metadata/mobileMetaData.js';
 describe('GenericProvider', () => {
   let genericProvider;
   let capabilitiesSpy;
+  let args;
 
   beforeEach(() => {
+    args = {
+      sessionId: '123',
+      commandExecutorUrl: 'http:executorUrl',
+      capabilities: { platform: 'win' },
+      sessionCapabilities: {},
+      clientInfo: 'local-poc-poa',
+      environmentInfo: 'staging-poc-poa',
+      options: {}
+    };
     capabilitiesSpy = spyOn(Driver.prototype, 'getCapabilites')
       .and.returnValue(Promise.resolve({ browserName: 'Chrome' }));
   });
@@ -19,11 +29,12 @@ describe('GenericProvider', () => {
 
     beforeEach(() => {
       metaDataResolverSpy = spyOn(MetaDataResolver, 'resolve');
+      args.capabilities = {};
       expectedDriver = new Driver('123', 'http:executorUrl', {});
     });
 
     it('creates driver', async () => {
-      genericProvider = new GenericProvider('123', 'http:executorUrl', {});
+      genericProvider = new GenericProvider(args);
       await genericProvider.createDriver();
       expect(genericProvider.driver).toEqual(expectedDriver);
       expect(capabilitiesSpy).toHaveBeenCalledTimes(1);
@@ -38,7 +49,7 @@ describe('GenericProvider', () => {
     });
 
     it('creates tiles from screenshot', async () => {
-      genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
+      genericProvider = new GenericProvider(args);
       genericProvider.createDriver();
       const tiles = await genericProvider.getTiles(false);
       expect(tiles.tiles.length).toEqual(1);
@@ -50,7 +61,7 @@ describe('GenericProvider', () => {
     });
 
     it('throws error if driver not initailized', async () => {
-      genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
+      genericProvider = new GenericProvider(args);
       await expectAsync(genericProvider.getTiles(false)).toBeRejectedWithError('Driver is null, please initialize driver with createDriver().');
     });
   });
@@ -90,7 +101,8 @@ describe('GenericProvider', () => {
     });
 
     it('returns correct tag for android', async () => {
-      genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'android', platformName: 'android' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
+      args.capabilities = { platform: 'android', platformName: 'android' };
+      genericProvider = new GenericProvider(args);
       spyOn(MobileMetaData.prototype, 'osName').and.returnValue('android');
       await genericProvider.createDriver();
       const tag = await genericProvider.getTag();
@@ -108,7 +120,7 @@ describe('GenericProvider', () => {
     });
 
     it('returns correct tag for others', async () => {
-      genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
+      genericProvider = new GenericProvider(args);
       spyOn(MobileMetaData.prototype, 'osName').and.returnValue('mockOsName');
       await genericProvider.createDriver();
       const tag = await genericProvider.getTag();
@@ -126,7 +138,7 @@ describe('GenericProvider', () => {
     });
 
     it('throws error if driver not initailized', async () => {
-      genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
+      genericProvider = new GenericProvider(args);
       await expectAsync(genericProvider.getTag()).toBeRejectedWithError('Driver is null, please initialize driver with createDriver().');
     });
   });
@@ -170,7 +182,7 @@ describe('GenericProvider', () => {
       });
 
       it('calls correct funcs', async () => {
-        genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
+        genericProvider = new GenericProvider(args);
         await genericProvider.createDriver();
         let res = await genericProvider.screenshot('mock-name', {});
         expect(getTagSpy).toHaveBeenCalledTimes(1);
@@ -228,7 +240,7 @@ describe('GenericProvider', () => {
       });
 
       it('calls correct funcs with iOS', async () => {
-        genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
+        genericProvider = new GenericProvider(args);
         await genericProvider.createDriver();
         let res = await genericProvider.screenshot('mock-name', {});
         expect(iOSGetTagSpy).toHaveBeenCalledTimes(1);
@@ -256,7 +268,7 @@ describe('GenericProvider', () => {
     });
 
     it('should call executeScript to get windowHeight', async () => {
-      genericProvider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'local-poc-poa', 'staging-poc-poa', {});
+      genericProvider = new GenericProvider(args);
       await genericProvider.createDriver();
       await genericProvider.getWindowHeight();
       expect(genericProvider.driver.executeScript).toHaveBeenCalledTimes(1);
@@ -269,7 +281,7 @@ describe('GenericProvider', () => {
     let scrollFactors;
     describe('When iOS singlepage screenshot', () => {
       beforeEach(async () => {
-        provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+        provider = new GenericProvider(args);
         await provider.createDriver();
         scrollFactors = { value: [0, 10] };
         provider.currentTag = { osName: 'iOS' };
@@ -311,8 +323,18 @@ describe('GenericProvider', () => {
     });
 
     describe('When iOS fullpage screenshot', () => {
+      let args = {
+        sessionId: '123',
+        commandExecutorUrl: 'http:executorUrl',
+        capabilities: { platform: 'win' },
+        sessionCapabilities: {},
+        clientInfo: 'local-poc-poa',
+        environmentInfo: 'staging-poc-poa',
+        options: {}
+      };
       beforeEach(async () => {
-        provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'client', 'environment', { fullPage: true });
+        args.options = { fullPage: true };
+        provider = new GenericProvider(args);
         await provider.createDriver();
         scrollFactors = { value: [0, 10] };
         provider.currentTag = { osName: 'iOS' };
@@ -332,7 +354,8 @@ describe('GenericProvider', () => {
 
     describe('When OS X singlepage', () => {
       beforeEach(async () => {
-        provider = new GenericProvider('123', 'http:executorUrl', { platform: 'OS X' }, {});
+        args.capabilities = { platform: 'OS X' };
+        provider = new GenericProvider(args);
         await provider.createDriver();
         scrollFactors = { value: [0, 10] };
         provider.currentTag = { osName: 'OS X' };
@@ -373,7 +396,9 @@ describe('GenericProvider', () => {
 
     describe('When OS X fullpage screenshot', () => {
       beforeEach(async () => {
-        provider = new GenericProvider('123', 'http:executorUrl', { platform: 'OS X' }, {}, 'client', 'environment', { fullPage: true });
+        args.capabilities = { platform: 'OS X' };
+        args.options = { fullPage: true };
+        provider = new GenericProvider(args);
         await provider.createDriver();
         scrollFactors = { value: [0, 10] };
         provider.currentTag = { osName: 'OS X' };
@@ -414,7 +439,7 @@ describe('GenericProvider', () => {
 
     describe('When Other singlepage', () => {
       beforeEach(async () => {
-        provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+        provider = new GenericProvider(args);
         await provider.createDriver();
         provider.currentTag = { osName: 'Android' };
         provider.pageYShiftFactor = 0;
@@ -435,7 +460,8 @@ describe('GenericProvider', () => {
 
     describe('When Other fullpage', () => {
       beforeEach(async () => {
-        provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'client', 'environment', { fullPage: true });
+        args.options = { fullPage: true };
+        provider = new GenericProvider(args);
         await provider.createDriver();
         provider.currentTag = { osName: 'Android' };
         provider.pageYShiftFactor = 0;
@@ -474,7 +500,7 @@ describe('GenericProvider', () => {
     describe('When singlepage screenshot', () => {
       beforeEach(async () => {
         // mock metadata
-        provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+        provider = new GenericProvider(args);
         provider.currentTag = { osName: 'Windows' };
         await provider.createDriver();
         spyOn(DesktopMetaData.prototype, 'devicePixelRatio')
@@ -502,7 +528,8 @@ describe('GenericProvider', () => {
     describe('When fullpage screenshot', () => {
       beforeEach(async () => {
         // mock metadata
-        provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'client', 'environment', { fullPage: true });
+        args.options = { fullPage: true };
+        provider = new GenericProvider(args);
         provider.currentTag = { osName: 'Windows' };
         await provider.createDriver();
         spyOn(DesktopMetaData.prototype, 'devicePixelRatio')
@@ -536,7 +563,7 @@ describe('GenericProvider', () => {
     let mockLocation = { x: 10, y: 20, width: 100, height: 200 };
     beforeEach(async () => {
       // mock metadata
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider = new GenericProvider(args);
       provider.currentTag = { osName: 'Windows' };
       await provider.createDriver();
       spyOn(DesktopMetaData.prototype, 'devicePixelRatio')
@@ -580,7 +607,8 @@ describe('GenericProvider', () => {
       let scrollY = 20;
       beforeEach(async () => {
         // mock metadata
-        provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'client', 'environment', { fullPage: true });
+        args.options = { fullPage: true };
+        provider = new GenericProvider(args);
         provider.currentTag = { osName: 'Windows' };
         await provider.createDriver();
         provider.initialScrollLocation = { value: [scrollX, scrollY] };
@@ -606,7 +634,7 @@ describe('GenericProvider', () => {
     let xpathResponse = { top: 0, bottom: 500, right: 0, left: 300 };
 
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider = new GenericProvider(args);
       await provider.createDriver();
       getRegionObjectSpy = spyOn(GenericProvider.prototype, 'getRegionObjectFromBoundingBox').and.returnValue(xpathResponse);
     });
@@ -639,7 +667,7 @@ describe('GenericProvider', () => {
     let provider;
 
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider = new GenericProvider(args);
       await provider.createDriver();
       getRegionObjectSpy = spyOn(GenericProvider.prototype, 'getRegionObjectFromBoundingBox').and.returnValue({});
     });
@@ -671,7 +699,7 @@ describe('GenericProvider', () => {
     let provider;
     let executeScriptSpy;
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider = new GenericProvider(args);
       provider.currentTag = { osName: 'Windows' };
       await provider.createDriver();
       executeScriptSpy = spyOn(Driver.prototype, 'executeScript');
@@ -686,7 +714,7 @@ describe('GenericProvider', () => {
   describe('isIOS', () => {
     let provider;
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider = new GenericProvider(args);
       provider.currentTag = { osName: 'Windows' };
     });
 
@@ -709,7 +737,7 @@ describe('GenericProvider', () => {
     const elements = ['mockElement_1', 'mockElement_2', 'mockElement_3'];
 
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider = new GenericProvider(args);
       await provider.createDriver();
       getRegionObjectSpy = spyOn(GenericProvider.prototype, 'getRegionObject').and.returnValue({});
       scrollToPositionSpy = spyOn(GenericProvider.prototype, 'scrollToPosition');
@@ -746,7 +774,7 @@ describe('GenericProvider', () => {
     let provider;
 
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider = new GenericProvider(args);
       await provider.createDriver();
       spyOn(DesktopMetaData.prototype, 'windowSize')
         .and.returnValue(Promise.resolve({ width: 1920, height: 1080 }));
@@ -796,7 +824,7 @@ describe('GenericProvider', () => {
     ];
 
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider = new GenericProvider(args);
       await provider.createDriver();
       doTransformationSpy = spyOn(GenericProvider.prototype, 'doTransformations');
       undoTransformationSpy = spyOn(GenericProvider.prototype, 'undoTransformations');
@@ -840,7 +868,7 @@ describe('GenericProvider', () => {
     let getInitialScrollLocationSpy;
 
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider = new GenericProvider(args);
       await provider.createDriver();
       executeScriptSpy = spyOn(Driver.prototype, 'executeScript');
       getInitialScrollLocationSpy = spyOn(GenericProvider.prototype, 'getInitialScrollLocation');
@@ -880,7 +908,8 @@ describe('GenericProvider', () => {
     });
 
     it('should get initial scroll position for singlepage', async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {}, 'client', 'environment', { fullPage: true });
+      args.options = { fullPage: true };
+      provider = new GenericProvider(args);
       await provider.createDriver();
       await provider.doTransformations();
       expect(getInitialScrollLocationSpy).toHaveBeenCalled();
@@ -892,7 +921,7 @@ describe('GenericProvider', () => {
     let executeScriptSpy;
 
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider = new GenericProvider(args);
       await provider.createDriver();
       executeScriptSpy = spyOn(Driver.prototype, 'executeScript');
     });
@@ -913,7 +942,7 @@ describe('GenericProvider', () => {
     let executeScriptSpy;
 
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider = new GenericProvider(args);
       await provider.createDriver();
       executeScriptSpy = spyOn(Driver.prototype, 'executeScript');
     });
@@ -929,7 +958,7 @@ describe('GenericProvider', () => {
     let getScrollDetailsSpy;
 
     beforeEach(async () => {
-      provider = new GenericProvider('123', 'http:executorUrl', { platform: 'win' }, {});
+      provider = new GenericProvider(args);
       await provider.createDriver();
       getScrollDetailsSpy = spyOn(GenericProvider.prototype, 'getScrollDetails');
       provider.initialScrollLocation = { value: [1, 1] };

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -952,4 +952,15 @@ describe('GenericProvider', () => {
         .toHaveBeenCalledWith({ script: 'browserstack_executor: {"action":"getSessionDetails","arguments":"new"}', args: [] });
     });
   });
+
+  describe('getTag', () => {
+    it('throws Error when automate results is null', async () => {
+      let provider = new GenericProvider(args);
+      provider.automateResults = null;
+      const error = new Error('Comparison tag details not available');
+      await expectAsync(
+        provider.getTag({ width: 100, height: 100, resolution: 'resolution' })
+      ).toBeRejectedWith(error);
+    });
+  });
 });

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -974,4 +974,30 @@ describe('GenericProvider', () => {
       expect(getScrollDetailsSpy).toHaveBeenCalled();
     });
   });
+
+  describe('getUserAgentString', () => {
+    let provider = new GenericProvider(args);
+    it('should return empty string if input is not a Set or string', () => {
+      expect(provider.getUserAgentString(123)).toEqual('');
+      expect(provider.getUserAgentString(null)).toEqual('');
+      expect(provider.getUserAgentString(undefined)).toEqual('');
+      expect(provider.getUserAgentString([])).toEqual('');
+      expect(provider.getUserAgentString({})).toEqual('');
+    });
+
+    it('should return stringified Set elements separated by semicolon', () => {
+      const data = new Set(['Mozilla/5.0', 'AppleWebKit/537.36', 'Chrome/64.0.3282.140']);
+      expect(provider.getUserAgentString(data)).toEqual('Mozilla/5.0; AppleWebKit/537.36; Chrome/64.0.3282.140');
+    });
+
+    it('should return the same string if input is a string', () => {
+      const data = 'Mozilla/5.0; AppleWebKit/537.36; Chrome/64.0.3282.140';
+      expect(provider.getUserAgentString(data)).toEqual(data);
+    });
+
+    it('should return empty string for empty Set', () => {
+      const data = new Set();
+      expect(provider.getUserAgentString(data)).toEqual('');
+    });
+  });
 });

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -2,7 +2,6 @@ import GenericProvider from '../../src/providers/genericProvider.js';
 import Driver from '../../src/driver.js';
 import MetaDataResolver from '../../src/metadata/metaDataResolver.js';
 import DesktopMetaData from '../../src/metadata/desktopMetaData.js';
-import MobileMetaData from '../../src/metadata/mobileMetaData.js';
 
 describe('GenericProvider', () => {
   let genericProvider;
@@ -63,83 +62,6 @@ describe('GenericProvider', () => {
     it('throws error if driver not initailized', async () => {
       genericProvider = new GenericProvider(args);
       await expectAsync(genericProvider.getTiles(false)).toBeRejectedWithError('Driver is null, please initialize driver with createDriver().');
-    });
-  });
-
-  describe('getTag', () => {
-    beforeEach(() => {
-      spyOn(DesktopMetaData.prototype, 'windowSize')
-        .and.returnValue(Promise.resolve({ width: 1000, height: 1000 }));
-      spyOn(DesktopMetaData.prototype, 'orientation')
-        .and.returnValue('landscape');
-      spyOn(DesktopMetaData.prototype, 'deviceName')
-        .and.returnValue('mockDeviceName');
-      spyOn(DesktopMetaData.prototype, 'osName')
-        .and.returnValue('mockOsName');
-      spyOn(DesktopMetaData.prototype, 'osVersion')
-        .and.returnValue('mockOsVersion');
-      spyOn(DesktopMetaData.prototype, 'browserName')
-        .and.returnValue('mockBrowserName');
-      spyOn(DesktopMetaData.prototype, 'browserVersion')
-        .and.returnValue('111');
-      spyOn(DesktopMetaData.prototype, 'screenResolution')
-        .and.returnValue('1980 x 1080');
-      spyOn(MobileMetaData.prototype, 'windowSize')
-        .and.returnValue(Promise.resolve({ width: 1000, height: 1000 }));
-      spyOn(MobileMetaData.prototype, 'orientation')
-        .and.returnValue('landscape');
-      spyOn(MobileMetaData.prototype, 'deviceName')
-        .and.returnValue('mockDeviceName');
-      spyOn(MobileMetaData.prototype, 'osVersion')
-        .and.returnValue('mockOsVersion');
-      spyOn(MobileMetaData.prototype, 'browserName')
-        .and.returnValue('mockBrowserName');
-      spyOn(MobileMetaData.prototype, 'browserVersion')
-        .and.returnValue('111');
-      spyOn(MobileMetaData.prototype, 'screenResolution')
-        .and.returnValue('1980 x 1080');
-    });
-
-    it('returns correct tag for android', async () => {
-      args.capabilities = { platform: 'android', platformName: 'android' };
-      genericProvider = new GenericProvider(args);
-      spyOn(MobileMetaData.prototype, 'osName').and.returnValue('android');
-      await genericProvider.createDriver();
-      const tag = await genericProvider.getTag();
-      expect(tag).toEqual({
-        name: 'mockDeviceName',
-        osName: 'android',
-        osVersion: 'mockOsVersion',
-        width: 1000,
-        height: 1000,
-        orientation: 'landscape',
-        browserName: 'mockBrowserName',
-        browserVersion: '111',
-        resolution: '1980 x 1080'
-      });
-    });
-
-    it('returns correct tag for others', async () => {
-      genericProvider = new GenericProvider(args);
-      spyOn(MobileMetaData.prototype, 'osName').and.returnValue('mockOsName');
-      await genericProvider.createDriver();
-      const tag = await genericProvider.getTag();
-      expect(tag).toEqual({
-        name: 'mockDeviceName',
-        osName: 'mockOsName',
-        osVersion: 'mockOsVersion',
-        width: 1000,
-        height: 1000,
-        orientation: 'landscape',
-        browserName: 'mockBrowserName',
-        browserVersion: '111',
-        resolution: '1980 x 1080'
-      });
-    });
-
-    it('throws error if driver not initailized', async () => {
-      genericProvider = new GenericProvider(args);
-      await expectAsync(genericProvider.getTag()).toBeRejectedWithError('Driver is null, please initialize driver with createDriver().');
     });
   });
 

--- a/packages/webdriver-utils/test/providers/playwrightProvider.test.js
+++ b/packages/webdriver-utils/test/providers/playwrightProvider.test.js
@@ -395,7 +395,7 @@ describe('PlaywrightProvider', () => {
         resolution: 'resolution'
       });
       expect(response).toEqual({
-        name: undefined,
+        name: 'Windows_11_Chrome_90.0',
         osName: 'Windows',
         osVersion: '11',
         width: 100,
@@ -415,8 +415,8 @@ describe('PlaywrightProvider', () => {
         'browserVersionOrDeviceNameRollup'
       ).and.returnValue('90.0');
       provider.automateResults = {
+        deviceName: 'deviceName',
         capabilities: {
-          deviceName: 'deviceName',
           os: 'os',
           os_version: '11.0',
           browserName: 'browserName',
@@ -431,7 +431,7 @@ describe('PlaywrightProvider', () => {
 
       expect(NormalizeData.prototype.browserRollUp).toHaveBeenCalledWith('browserName', true);
       expect(response).toEqual({
-        name: undefined,
+        name: 'deviceName',
         osName: 'ANDROID',
         osVersion: '11',
         width: 100,

--- a/packages/webdriver-utils/test/providers/playwrightProvider.test.js
+++ b/packages/webdriver-utils/test/providers/playwrightProvider.test.js
@@ -211,6 +211,60 @@ describe('PlaywrightProvider', () => {
       });
     });
 
+    it('should capture tiles successfully with default values for singlepage screenshot', async () => {
+      provider.browserstackExecutor = jasmine
+        .createSpy('browserstackExecutor')
+        .and.resolveTo({
+          value: JSON.stringify({
+            success: true,
+            result: JSON.stringify({
+              tiles: [
+                {
+                  sha: 'tile1'
+                }
+              ],
+              comparison_tag_data: {
+                width: 100,
+                height: 100,
+                resolution: 'resolution'
+              },
+              dom_sha: 'domSHA'
+            })
+          })
+        });
+
+      const response = await provider.getTiles(false);
+      expect(provider.browserstackExecutor).toHaveBeenCalledWith(
+        'percyScreenshot',
+        {
+          state: 'screenshot',
+          percyBuildId: 1,
+          screenshotType: 'singlepage',
+          scaleFactor: 1,
+          options: 'options',
+          frameworkData: { frameGuid: 'frameGuid', pageGuid: 'pageGuid' },
+          framework: 'playwright'
+        }
+      );
+      expect(response).toEqual({
+        tiles: [
+          new Tile({
+            statusBarHeight: 0,
+            navBarHeight: 0,
+            headerHeight: 0,
+            footerHeight: 0,
+            fullscreen: false,
+            sha: 'tile1'
+          })
+        ],
+        domInfoSha: 'domSHA',
+        tagData: { width: 100, height: 100, resolution: 'resolution' },
+        ignoreRegionsData: [],
+        considerRegionsData: [],
+        metadata: { screenshotType: 'singlepage' }
+      });
+    });
+
     it('should capture tiles successfully for fullscreen screenshot', async () => {
       provider = new PlaywrightProvider(
         'sessionId',

--- a/packages/webdriver-utils/test/providers/playwrightProvider.test.js
+++ b/packages/webdriver-utils/test/providers/playwrightProvider.test.js
@@ -1,0 +1,364 @@
+import PlaywrightProvider from '../../src/providers/playwrightProvider.js';
+import GenericProvider from '../../src/providers/genericProvider.js';
+import Tile from '../../src/util/tile.js';
+import NormalizeData from '../../src/metadata/normalizeData.js';
+
+describe('PlaywrightProvider', () => {
+  let provider;
+
+  beforeEach(async () => {
+    provider = new PlaywrightProvider(
+      'sessionId',
+      'frameGuid',
+      'pageGuid',
+      'clientInfo',
+      'environmentInfo',
+      'options',
+      { id: 1 }
+    );
+  });
+
+  describe('constructor', () => {
+    it('should initialize the PlaywrightProvider with the provided parameters', () => {
+      expect(provider.sessionId).toBe('sessionId');
+      expect(provider.frameGuid).toBe('frameGuid');
+      expect(provider.pageGuid).toBe('pageGuid');
+      expect(provider.clientInfo).toBe('clientInfo');
+      expect(provider.environmentInfo).toBe('environmentInfo');
+      expect(provider.options).toBe('options');
+      expect(provider.buildInfo).toEqual({ id: 1 });
+    });
+  });
+
+  describe('createDriver', () => {
+    it('should create a new PlaywrightDriver', async () => {
+      await provider.createDriver();
+      expect(provider.driver).toBeDefined();
+      expect(provider.driver.sessionId).toEqual('sessionId');
+    });
+  });
+
+  describe('setDebugUrl', () => {
+    it('should set the debugUrl property with the correct value', async () => {
+      provider.automateResults = {
+        buildHash: 'buildHash',
+        sessionHash: 'sessionHash'
+      };
+      await provider.setDebugUrl();
+      expect(provider.debugUrl).toBe(
+        'https://automate.browserstack.com/builds/buildHash/sessions/sessionHash'
+      );
+    });
+  });
+
+  describe('screenshot', () => {
+    // Mock the percyScreenshotBegin and percyScreenshotEnd methods
+    const percyScreenshotBeginMock = jasmine
+      .createSpy('percyScreenshotBegin')
+      .and.returnValue(
+        Promise.resolve({
+          value: JSON.stringify({
+            buildHash: 'buildHash',
+            sessionHash: 'sessionHash'
+          })
+        })
+      );
+    const percyScreenshotEndMock = jasmine
+      .createSpy('percyScreenshotEnd')
+      .and.returnValue(Promise.resolve());
+
+    beforeEach(() => {
+      // Replace the original methods with the mocks in the prototype of the parent class
+      spyOn(GenericProvider.prototype, 'percyScreenshotBegin').and.callFake(
+        percyScreenshotBeginMock
+      );
+      spyOn(GenericProvider.prototype, 'percyScreenshotEnd').and.callFake(
+        percyScreenshotEndMock
+      );
+      // Mock the response for getTiles
+      provider.getTiles = jasmine.createSpy('getTiles').and.resolveTo({
+        tiles: [],
+        domInfoSha: 'domInfoSha',
+        tagData: { width: 100, height: 100, resolution: 'resolution' },
+        ignoreRegionsData: [],
+        considerRegionsData: [],
+        metadata: null
+      });
+      // Mock the response for getTag
+      provider.getTag = jasmine.createSpy('getTag').and.returnValue({
+        name: 'deviceName',
+        osName: 'osName',
+        osVersion: 'osVersion',
+        width: 100,
+        height: 100,
+        orientation: 'orientation',
+        browserName: 'browserName',
+        browserVersion: 'browserVersion',
+        resolution: 'resolution'
+      });
+    });
+
+    afterEach(() => {
+      percyScreenshotBeginMock.calls.reset();
+      percyScreenshotEndMock.calls.reset();
+    });
+
+    it('should capture screenshots successfully', async () => {
+      const response = await provider.screenshot('name', {});
+      expect(percyScreenshotBeginMock).toHaveBeenCalledWith('name');
+      expect(provider.automateResults).toEqual({
+        buildHash: 'buildHash',
+        sessionHash: 'sessionHash'
+      });
+      expect(provider.debugUrl).toBe(
+        'https://automate.browserstack.com/builds/buildHash/sessions/sessionHash'
+      );
+      expect(provider.getTiles).toHaveBeenCalled();
+      expect(provider.getTag).toHaveBeenCalled();
+      expect(response).toEqual({
+        name: 'name',
+        tag: {
+          name: 'deviceName',
+          osName: 'osName',
+          osVersion: 'osVersion',
+          width: 100,
+          height: 100,
+          orientation: 'orientation',
+          browserName: 'browserName',
+          browserVersion: 'browserVersion',
+          resolution: 'resolution'
+        },
+        tiles: [],
+        externalDebugUrl:
+          'https://automate.browserstack.com/builds/buildHash/sessions/sessionHash',
+        ignoredElementsData: { ignoreElementsData: [] },
+        consideredElementsData: { considerElementsData: [] },
+        environmentInfo: 'environmentInfo',
+        clientInfo: 'clientInfo',
+        domInfoSha: 'domInfoSha',
+        metadata: null
+      });
+    });
+
+    it('should handle errors during screenshot capture', async () => {
+      const error = new Error('Failed to capture screenshots');
+      provider.getTiles.and.rejectWith(error);
+      await expectAsync(provider.screenshot('name', {})).toBeRejectedWith(
+        error
+      );
+      expect(percyScreenshotEndMock).toHaveBeenCalledWith('name', error);
+    });
+  });
+
+  describe('getTiles', () => {
+    it('should capture tiles successfully for singlepage screenshot', async () => {
+      provider.browserstackExecutor = jasmine
+        .createSpy('browserstackExecutor')
+        .and.resolveTo({
+          value: JSON.stringify({
+            success: true,
+            result: JSON.stringify({
+              tiles: [
+                {
+                  status_bar: 20,
+                  nav_bar: 30,
+                  header_height: 40,
+                  footer_height: 50,
+                  sha: 'tile1'
+                }
+              ],
+              comparison_tag_data: {
+                width: 100,
+                height: 100,
+                resolution: 'resolution'
+              },
+              ignore_regions_data: [{ x: 10, y: 20, width: 30, height: 40 }],
+              consider_regions_data: [{ x: 50, y: 60, width: 70, height: 80 }],
+              dom_sha: 'domSHA'
+            })
+          })
+        });
+
+      const response = await provider.getTiles(false);
+      expect(provider.browserstackExecutor).toHaveBeenCalledWith(
+        'percyScreenshot',
+        {
+          state: 'screenshot',
+          percyBuildId: 1,
+          screenshotType: 'singlepage',
+          scaleFactor: 1,
+          options: 'options',
+          frameworkData: { frameGuid: 'frameGuid', pageGuid: 'pageGuid' },
+          framework: 'playwright'
+        }
+      );
+      expect(response).toEqual({
+        tiles: [
+          new Tile({
+            statusBarHeight: 20,
+            navBarHeight: 30,
+            headerHeight: 40,
+            footerHeight: 50,
+            fullscreen: false,
+            sha: 'tile1'
+          })
+        ],
+        domInfoSha: 'domSHA',
+        tagData: { width: 100, height: 100, resolution: 'resolution' },
+        ignoreRegionsData: [{ x: 10, y: 20, width: 30, height: 40 }],
+        considerRegionsData: [{ x: 50, y: 60, width: 70, height: 80 }],
+        metadata: { screenshotType: 'singlepage' }
+      });
+    });
+
+    it('should capture tiles successfully for fullscreen screenshot', async () => {
+      provider = new PlaywrightProvider(
+        'sessionId',
+        'frameGuid',
+        'pageGuid',
+        'clientInfo',
+        'environmentInfo',
+        { fullPage: true },
+        { id: 1 }
+      );
+      provider.browserstackExecutor = jasmine
+        .createSpy('browserstackExecutor')
+        .and.resolveTo({
+          value: JSON.stringify({
+            success: true,
+            result: JSON.stringify({
+              tiles: [
+                {
+                  status_bar: 20,
+                  nav_bar: 30,
+                  header_height: 40,
+                  footer_height: 50,
+                  sha: 'tile1'
+                },
+                {
+                  status_bar: 10,
+                  nav_bar: 20,
+                  header_height: 30,
+                  footer_height: 40,
+                  sha: 'tile2'
+                }
+              ],
+              comparison_tag_data: {
+                width: 200,
+                height: 200,
+                resolution: 'resolution'
+              },
+              ignore_regions_data: [{ x: 10, y: 20, width: 30, height: 40 }],
+              consider_regions_data: [{ x: 50, y: 60, width: 70, height: 80 }],
+              dom_sha: 'domSHA'
+            })
+          })
+        });
+
+      const response = await provider.getTiles(true);
+      expect(provider.browserstackExecutor).toHaveBeenCalledWith(
+        'percyScreenshot',
+        {
+          state: 'screenshot',
+          percyBuildId: 1,
+          screenshotType: 'fullpage',
+          scaleFactor: 1,
+          options: { fullPage: true },
+          frameworkData: { frameGuid: 'frameGuid', pageGuid: 'pageGuid' },
+          framework: 'playwright'
+        }
+      );
+      expect(response).toEqual({
+        tiles: [
+          new Tile({
+            statusBarHeight: 20,
+            navBarHeight: 30,
+            headerHeight: 40,
+            footerHeight: 50,
+            fullscreen: true,
+            sha: 'tile1'
+          }),
+          new Tile({
+            statusBarHeight: 10,
+            navBarHeight: 20,
+            headerHeight: 30,
+            footerHeight: 40,
+            fullscreen: true,
+            sha: 'tile2'
+          })
+        ],
+        domInfoSha: 'domSHA',
+        tagData: { width: 200, height: 200, resolution: 'resolution' },
+        ignoreRegionsData: [{ x: 10, y: 20, width: 30, height: 40 }],
+        considerRegionsData: [{ x: 50, y: 60, width: 70, height: 80 }],
+        metadata: { screenshotType: 'fullpage' }
+      });
+    });
+
+    it('should handle errors during tile capture', async () => {
+      const error = new Error('Failed to capture tiles');
+      provider.browserstackExecutor = jasmine
+        .createSpy('browserstackExecutor')
+        .and.rejectWith(error);
+      await expectAsync(provider.getTiles()).toBeRejectedWith(error);
+    });
+
+    it('should handle errors if response is not success', async () => {
+      const error = new Error(
+        'Failed to get screenshots from Automate.' +
+          ' Check dashboard for error.'
+      );
+      provider.browserstackExecutor = jasmine
+        .createSpy('browserstackExecutor')
+        .and.resolveTo({
+          value: JSON.stringify({ success: false, result: {} })
+        });
+      await expectAsync(provider.getTiles()).toBeRejectedWith(error);
+    });
+  });
+
+  describe('getTag', () => {
+    it('should return the tag details', async () => {
+      spyOn(NormalizeData.prototype, 'osRollUp').and.returnValue('Windows');
+      spyOn(NormalizeData.prototype, 'browserRollUp').and.returnValue('Chrome');
+      spyOn(
+        NormalizeData.prototype,
+        'browserVersionOrDeviceNameRollup'
+      ).and.returnValue('90.0');
+      provider.automateResults = {
+        capabilities: {
+          deviceName: 'deviceName',
+          os: 'os',
+          os_version: '11.0',
+          browserName: 'browserName',
+          browserVersion: 'browserVersion',
+          deviceOrientation: 'orientation'
+        }
+      };
+      const response = await provider.getTag({
+        width: 100,
+        height: 100,
+        resolution: 'resolution'
+      });
+      expect(response).toEqual({
+        name: undefined,
+        osName: 'Windows',
+        osVersion: '11',
+        width: 100,
+        height: 100,
+        orientation: 'orientation',
+        browserName: 'Chrome',
+        browserVersion: '90.0',
+        resolution: 'resolution'
+      });
+    });
+
+    it('should throw an error if automateResults is not available', async () => {
+      provider.automateResults = null;
+      const error = new Error('Comparison tag details not available');
+      await expectAsync(
+        provider.getTag({ width: 100, height: 100, resolution: 'resolution' })
+      ).toBeRejectedWith(error);
+    });
+  });
+});

--- a/packages/webdriver-utils/test/providers/playwrightProvider.test.js
+++ b/packages/webdriver-utils/test/providers/playwrightProvider.test.js
@@ -420,8 +420,7 @@ describe('PlaywrightProvider', () => {
           os: 'os',
           os_version: '11.0',
           browserName: 'browserName',
-          browserVersion: 'browserVersion',
-          deviceOrientation: 'orientation'
+          browserVersion: 'browserVersion'
         }
       };
       const response = await provider.getTag({
@@ -437,7 +436,7 @@ describe('PlaywrightProvider', () => {
         osVersion: '11',
         width: 100,
         height: 100,
-        orientation: 'orientation',
+        orientation: 'landscape',
         browserName: 'Chrome',
         browserVersion: '90.0',
         resolution: 'resolution'

--- a/packages/webdriver-utils/test/providers/playwrightProvider.test.js
+++ b/packages/webdriver-utils/test/providers/playwrightProvider.test.js
@@ -353,6 +353,42 @@ describe('PlaywrightProvider', () => {
       });
     });
 
+    it('should return the correct tag details for android', async () => {
+      spyOn(NormalizeData.prototype, 'osRollUp').and.returnValue('ANDROID');
+      spyOn(NormalizeData.prototype, 'browserRollUp').and.returnValue('Chrome');
+      spyOn(
+        NormalizeData.prototype,
+        'browserVersionOrDeviceNameRollup'
+      ).and.returnValue('90.0');
+      provider.automateResults = {
+        capabilities: {
+          deviceName: 'deviceName',
+          os: 'os',
+          os_version: '11.0',
+          browserName: 'browserName',
+          browserVersion: 'browserVersion',
+          deviceOrientation: 'orientation'
+        }
+      };
+      const response = await provider.getTag({
+        width: 100,
+        height: 100,
+        resolution: 'resolution'
+      });
+
+      expect(NormalizeData.prototype.browserRollUp).toHaveBeenCalledWith('browserName', true);
+      expect(response).toEqual({
+        name: undefined,
+        osName: 'ANDROID',
+        osVersion: '11',
+        width: 100,
+        height: 100,
+        orientation: 'orientation',
+        browserName: 'Chrome',
+        browserVersion: '90.0',
+        resolution: 'resolution'
+      });
+    });
     it('should throw an error if automateResults is not available', async () => {
       provider.automateResults = null;
       const error = new Error('Comparison tag details not available');


### PR DESCRIPTION
Changes: 
1. Made a common method captureScreenshot in WebdriverUtils which based on framework will decide to use the provider class to use for further execution.
2. Shifted few common methods like percyScreenshotBegin, percyScreenshotEnd, browserstackExecutor in genericProvider as it is being used as base class.
3. Also in constructor of these classes instead of taking each argument separately taking it as hash and assigning it to instance of object so that we can directly pass from child class without need to add every arguments from every child class.
4. For Playwright Provider we needed following things to be passed for execution 
     1. Page Guid
     2. MainFrame Guid
     3. browserstack sessionId to make percy call.