### PR TITLE
✨  Adding env variable support so that if set to true we exit with status code 0 when any percy related error occurs.

### DIFF
--- a/packages/cli-command/src/command.js
+++ b/packages/cli-command/src/command.js
@@ -7,8 +7,6 @@ import * as builtInFlags from './flags.js';
 import formatHelp from './help.js';
 import parse from './parse.js';
 
-const percyExitWithZeroOnError = process.env.PERCY_EXIT_WITH_ZERO_ON_ERROR === 'true';
-
 // Copies a command definition and adds built-in flags and config options.
 function withBuiltIns(definition) {
   let def = { ...definition };
@@ -56,6 +54,7 @@ function withBuiltIns(definition) {
 
 // Helper to throw an error with an exit code and optional reason message
 function exit(exitCode, reason = '', shouldOverrideExitCode = true) {
+  let percyExitWithZeroOnError = process.env.PERCY_EXIT_WITH_ZERO_ON_ERROR === 'true';
   exitCode = percyExitWithZeroOnError && shouldOverrideExitCode ? 0 : exitCode;
   let err = reason instanceof Error ? reason : new Error(reason);
   // Adding additional object so that it can be used in runner function below.
@@ -161,6 +160,7 @@ export function command(name, definition, callback) {
 
         if (definition.exitOnError) {
           let shouldOverrideExitCode = err.shouldOverrideExitCode !== false;
+          let percyExitWithZeroOnError = process.env.PERCY_EXIT_WITH_ZERO_ON_ERROR === 'true';
           let exitCode = percyExitWithZeroOnError && shouldOverrideExitCode ? 0 : err.exitCode;
           process.exit(exitCode);
         }

--- a/packages/cli-command/test/command.test.js
+++ b/packages/cli-command/test/command.test.js
@@ -290,13 +290,6 @@ describe('Command', () => {
 
     logger.reset();
     delete process.env.PERCY_EXIT_WITH_ZERO_ON_ERROR;
-
-    // await test(['0', 'Warning']);
-
-    // expect(test).not.toHaveProperty('never');
-    // expect(logger.stderr).toEqual([
-    //   '[percy] Warning'
-    // ]);
   });
 
   it('handles interrupting generator actions', async () => {

--- a/packages/cli-command/test/command.test.js
+++ b/packages/cli-command/test/command.test.js
@@ -160,7 +160,22 @@ describe('Command', () => {
     });
 
     await expectAsync(test()).toBeRejected();
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(1);
+  });
+
+  it('handles maybe exiting on unhandled errors and exits with status 0 when PERCY_EXIT_WITH_ZERO_ON_ERROR is set to true', async () => {
+    process.env.PERCY_EXIT_WITH_ZERO_ON_ERROR = 'true';
+    let spy = spyOn(process, 'exit');
+
+    let test = command('test', {
+      exitOnError: true
+    }, () => {
+      throw new Error();
+    });
+
+    await expectAsync(test()).toBeRejected();
+    expect(spy).toHaveBeenCalledWith(0);
+    delete process.env.PERCY_EXIT_WITH_ZERO_ON_ERROR;
   });
 
   it('handles graceful exit errors', async () => {
@@ -180,8 +195,13 @@ describe('Command', () => {
         message = new Error(message);
       }
 
-      exit(code, message);
-      test.never = true;
+      if (code > 400) {
+        exit(code, message, false);
+        test.never = true;
+      } else {
+        exit(code, message);
+        test.never = true;
+      }
     });
 
     await test(['123']).catch(e => {
@@ -197,6 +217,7 @@ describe('Command', () => {
     await test(['456', 'Reason']).catch(e => {
       expect(e).toHaveProperty('message', 'Reason');
       expect(e).toHaveProperty('exitCode', 456);
+      expect(e).toHaveProperty('shouldOverrideExitCode', false);
     });
 
     expect(test).not.toHaveProperty('never');
@@ -212,6 +233,70 @@ describe('Command', () => {
     expect(logger.stderr).toEqual([
       '[percy] Warning'
     ]);
+  });
+
+  it('exits with status 0 when PERCY_EXIT_WITH_ZERO_ON_ERROR is set to true', async () => {
+    process.env.PERCY_EXIT_WITH_ZERO_ON_ERROR = 'true';
+    let test = command('test', {
+      args: [{
+        name: 'code',
+        parse: Number,
+        required: true
+      }, {
+        name: 'message'
+      }, {
+        shouldOverrideExitCode: 'shouldOverrideExitCode'
+      }]
+    }, ({ args, exit }) => {
+      let { code, message } = args;
+
+      // exercise coverage
+      if (message && code >= 1) {
+        message = new Error(message);
+      }
+
+      if (code > 400) {
+        exit(code, message, false);
+        test.never = true;
+      } else {
+        exit(code, message);
+        test.never = true;
+      }
+    });
+
+    await test(['123']).catch(e => {
+      expect(e).toHaveProperty('exitCode', 0);
+      expect(e).toHaveProperty('shouldOverrideExitCode', true);
+    });
+
+    expect(test).not.toHaveProperty('never');
+    expect(logger.stderr).toEqual([]);
+
+    logger.reset();
+
+    await test(['123', 'Reason']).catch(e => {
+      expect(e).toHaveProperty('message', 'Reason');
+      expect(e).toHaveProperty('exitCode', 0);
+      expect(e).toHaveProperty('shouldOverrideExitCode', true);
+    });
+
+    await test(['401', 'some reason']).catch(e => {
+      expect(e).toHaveProperty('message', 'some reason');
+      expect(e).toHaveProperty('exitCode', 401);
+      expect(e).toHaveProperty('shouldOverrideExitCode', false);
+    });
+
+    expect(test).not.toHaveProperty('never');
+
+    logger.reset();
+    delete process.env.PERCY_EXIT_WITH_ZERO_ON_ERROR;
+
+    // await test(['0', 'Warning']);
+
+    // expect(test).not.toHaveProperty('never');
+    // expect(logger.stderr).toEqual([
+    //   '[percy] Warning'
+    // ]);
   });
 
   it('handles interrupting generator actions', async () => {

--- a/packages/cli-exec/src/exec.js
+++ b/packages/cli-exec/src/exec.js
@@ -46,14 +46,14 @@ export const exec = command('exec', {
     log.error("You must supply a command to run after '--'");
     log.info('Example:');
     log.info('  $ percy exec -- npm test');
-    exit(1);
+    exit(1, '', false);
   }
 
   // verify the provided command exists
   let { default: which } = await import('which');
 
   if (!which.sync(command, { nothrow: true })) {
-    exit(127, `Command not found "${command}"`);
+    exit(127, `Command not found "${command}"`, false);
   }
 
   // attempt to start percy if enabled
@@ -91,7 +91,7 @@ export const exec = command('exec', {
   await percy?.stop(!!error);
 
   // forward any returned status code
-  if (status) exit(status, error);
+  if (status) exit(status, error, false);
 
   // force exit post timeout
   await waitForTimeout(10000);

--- a/packages/cli-exec/src/exec.js
+++ b/packages/cli-exec/src/exec.js
@@ -90,6 +90,7 @@ export const exec = command('exec', {
   // stop percy if running (force stop if there is an error);
   await percy?.stop(!!error);
 
+  log.info(`Command "${[command, ...args].join(' ')}" exited with status: ${status}`);
   // forward any returned status code
   if (status) exit(status, error, false);
 

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -88,7 +88,8 @@ describe('percy exec', () => {
       '[percy] Percy has started!',
       '[percy] Running "node --eval "',
       '[percy] Finalized build #1: https://percy.io/test/test/123',
-      "[percy] Build's CLI logs sent successfully. Please share this log ID with Percy team in case of any issues - random_sha"
+      "[percy] Build's CLI logs sent successfully. Please share this log ID with Percy team in case of any issues - random_sha",
+      '[percy] Command "node --eval " exited with status: 0'
     ]);
   });
 
@@ -112,7 +113,8 @@ describe('percy exec', () => {
       '[percy] Percy is disabled'
     ]);
     expect(logger.stdout).toEqual([
-      '[percy] Running "node --eval "'
+      '[percy] Running "node --eval "',
+      '[percy] Command "node --eval " exited with status: 0'
     ]);
   });
 

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -108,7 +108,7 @@ async function main({
 
     jasmine.loadConfig({
       spec_dir: 'test',
-      spec_files: ['**/*.test.js'],
+      spec_files: ['**/exec.test.js'],
       requires: [path.resolve(filename, '../babel-register.cjs')],
       helpers: [path.resolve(filename, '../test-helpers.js')],
       random: false

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -108,7 +108,7 @@ async function main({
 
     jasmine.loadConfig({
       spec_dir: 'test',
-      spec_files: ['**/exec.test.js'],
+      spec_files: ['**/*.test.js'],
       requires: [path.resolve(filename, '../babel-register.cjs')],
       helpers: [path.resolve(filename, '../test-helpers.js')],
       random: false


### PR DESCRIPTION
 Adding env variable support so that if set to true we exit with status code 0 when any percy related error occurs.
`PERCY_EXIT_WITH_ZERO_ON_ERROR` is the env variable.
It won't override when customer command throws any error.

This will solve https://github.com/percy/cli/issues/1590 issue.
Ticket -> https://browserstack.atlassian.net/browse/PER-3235