### PR TITLE
Auto capture and insert cookie in asset discovery browser

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -157,9 +157,9 @@ async function* captureSnapshotResources(page, snapshot, options) {
   const log = logger('core:discovery');
   let { discovery, additionalSnapshots = [], ...baseSnapshot } = snapshot;
   let { capture, captureWidths, deviceScaleFactor, mobile, captureForDevices } = options;
-  let cookies = snapshot?.domSnapshot?.cookies;
-  if (process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES === 'true') {
-    cookies = null;
+  let cookies;
+  if (process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES !== 'true') {
+    cookies = snapshot?.domSnapshot?.cookies;
   }
   if (typeof cookies === 'string') {
     cookies = cookies.split('; ').map(c => c.split('='));
@@ -185,7 +185,7 @@ async function* captureSnapshotResources(page, snapshot, options) {
 
   // navigate to the url
   yield resizePage(snapshot.widths[0]);
-  yield page.goto(snapshot.url, cookies);
+  yield page.goto(snapshot.url, { cookies });
 
   if (snapshot.execute) {
     // when any execute options are provided, inject snapshot options

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -158,7 +158,7 @@ async function* captureSnapshotResources(page, snapshot, options) {
   let { discovery, additionalSnapshots = [], ...baseSnapshot } = snapshot;
   let { capture, captureWidths, deviceScaleFactor, mobile, captureForDevices } = options;
   let cookies = snapshot?.domSnapshot?.cookies;
-  if (!process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES || process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES !== 'true') {
+  if (process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES || process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES === 'true') {
     cookies = null;
   }
   if (typeof cookies === 'string') {

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -161,7 +161,7 @@ async function* captureSnapshotResources(page, snapshot, options) {
   if (process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES !== 'true') {
     cookies = snapshot?.domSnapshot?.cookies;
   }
-  if (typeof cookies === 'string') {
+  if (typeof cookies === 'string' && cookies !== '') {
     cookies = cookies.split('; ').map(c => c.split('='));
     cookies = cookies.map(([key, value]) => { return { name: key, value: value }; });
   }

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -157,6 +157,14 @@ async function* captureSnapshotResources(page, snapshot, options) {
   const log = logger('core:discovery');
   let { discovery, additionalSnapshots = [], ...baseSnapshot } = snapshot;
   let { capture, captureWidths, deviceScaleFactor, mobile, captureForDevices } = options;
+  let cookies = snapshot?.domSnapshot?.cookies;
+  if (!process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES || process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES !== 'true') {
+    cookies = null;
+  }
+  if (typeof cookies === 'string') {
+    cookies = cookies.split('; ').map(c => c.split('='));
+    cookies = cookies.map(([key, value]) => { return { name: key, value: value }; });
+  }
 
   // used to take snapshots and remove any discovered root resource
   let takeSnapshot = async (options, width) => {
@@ -177,7 +185,7 @@ async function* captureSnapshotResources(page, snapshot, options) {
 
   // navigate to the url
   yield resizePage(snapshot.widths[0]);
-  yield page.goto(snapshot.url);
+  yield page.goto(snapshot.url, cookies);
 
   if (snapshot.execute) {
     // when any execute options are provided, inject snapshot options

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -158,7 +158,7 @@ async function* captureSnapshotResources(page, snapshot, options) {
   let { discovery, additionalSnapshots = [], ...baseSnapshot } = snapshot;
   let { capture, captureWidths, deviceScaleFactor, mobile, captureForDevices } = options;
   let cookies = snapshot?.domSnapshot?.cookies;
-  if (process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES || process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES === 'true') {
+  if (process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES === 'true') {
     cookies = null;
   }
   if (typeof cookies === 'string') {

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -52,6 +52,7 @@ export class Page {
     if (!autoCapturedCookie) return userPassedCookie;
     if (userPassedCookie.length === 0) return autoCapturedCookie;
 
+    // User passed cookie will be prioritized over auto captured cookie
     const mergedCookies = [...userPassedCookie, ...autoCapturedCookie];
     const uniqueCookies = [];
     const names = new Set();

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -48,36 +48,34 @@ export class Page {
     });
   }
 
+  mergeCookies(userPassedCookie, autoCapturedCookie) {
+    if (!autoCapturedCookie) return userPassedCookie;
+    if (userPassedCookie.length === 0) return autoCapturedCookie;
+
+    const mergedCookies = [...userPassedCookie, ...autoCapturedCookie];
+    const uniqueCookies = [];
+    const names = new Set();
+
+    for (const cookie of mergedCookies) {
+      if (!names.has(cookie.name)) {
+        uniqueCookies.push(cookie);
+        names.add(cookie.name);
+      }
+    }
+
+    return uniqueCookies;
+  }
+
   // Go to a URL and wait for navigation to occur
   async goto(url, { waitUntil = 'load', cookies } = {}) {
     this.log.debug(`Navigate to: ${url}`, this.meta);
 
     let navigate = async () => {
-      const mergeCookies = (userPassedCookie, autoCapturedCookie) => {
-        const mergedCookies = [...userPassedCookie, ...autoCapturedCookie];
-        const uniqueCookies = [];
-        const names = new Set();
-
-        for (const cookie of mergedCookies) {
-          if (!names.has(cookie.name)) {
-            uniqueCookies.push(cookie);
-            names.add(cookie.name);
-          }
-        }
-
-        return uniqueCookies;
-      };
-
       const userPassedCookie = this.session.browser.cookies;
       // set cookies before navigation so we can default the domain to this hostname
       if (userPassedCookie.length || cookies) {
         let defaultDomain = hostname(url);
-
-        if (userPassedCookie.length > 0 && cookies) {
-          cookies = mergeCookies(userPassedCookie, cookies);
-        } else if (userPassedCookie.length) {
-          cookies = userPassedCookie;
-        }
+        cookies = this.mergeCookies(userPassedCookie, cookies);
 
         await this.session.send('Network.setCookies', {
           // spread is used to make a shallow copy of the cookie

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -49,17 +49,18 @@ export class Page {
   }
 
   // Go to a URL and wait for navigation to occur
-  async goto(url, { waitUntil = 'load' } = {}) {
+  async goto(url, cookies, { waitUntil = 'load' } = {}) {
     this.log.debug(`Navigate to: ${url}`, this.meta);
 
     let navigate = async () => {
       // set cookies before navigation so we can default the domain to this hostname
-      if (this.session.browser.cookies.length) {
+      if (this.session.browser.cookies.length || cookies) {
         let defaultDomain = hostname(url);
 
+        cookies = this.session.browser.cookies.length > 0 ? this.session.browser.cookies : cookies;
         await this.session.send('Network.setCookies', {
           // spread is used to make a shallow copy of the cookie
-          cookies: this.session.browser.cookies.map(({ ...cookie }) => {
+          cookies: cookies.map(({ ...cookie }) => {
             if (!cookie.url) cookie.domain ||= defaultDomain;
             return cookie;
           })

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -1266,16 +1266,14 @@ describe('Discovery', () => {
       expect(cookie).toEqual('chocolate=654321');
     });
 
-    it('should priotize cookie passed by user', async () => {
+    it('should merge cookie passed by user', async () => {
       // test cookie array
       await startWithCookies([{
-        name: 'chocolate',
+        name: 'test-cookie',
         value: '654321'
       }, {
         name: 'shortbread',
-        value: '987654',
-        // not the snapshot url
-        url: 'http://example.com/'
+        value: '987654'
       }]);
 
       await percy.snapshot({
@@ -1283,7 +1281,7 @@ describe('Discovery', () => {
         url: 'http://localhost:8000',
         domSnapshot: {
           html: testDOM,
-          cookies: 'test-cookie=value'
+          cookies: 'test-cookie=value; cookie-name=cookie-value'
         }
       });
 
@@ -1291,7 +1289,7 @@ describe('Discovery', () => {
         '[percy] Snapshot taken: mmm cookies'
       ]));
 
-      expect(cookie).toEqual('chocolate=654321');
+      expect(cookie).toEqual('test-cookie=654321; shortbread=987654; cookie-name=cookie-value');
     });
 
     it('can send default collected cookies from serialization', async () => {

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -1317,6 +1317,31 @@ describe('Discovery', () => {
       expect(cookie).toEqual('test-cookie=value');
     });
 
+    it('does not use cookie if empty cookies is passed (in case of httponly)', async () => {
+      await percy.stop();
+
+      percy = await Percy.start({
+        token: 'PERCY_TOKEN',
+        snapshot: { widths: [1000] },
+        discovery: { concurrency: 1 }
+      });
+
+      await percy.snapshot({
+        name: 'mmm cookies',
+        url: 'http://localhost:8000',
+        domSnapshot: {
+          html: testDOM,
+          cookies: ''
+        }
+      });
+
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Snapshot taken: mmm cookies'
+      ]));
+
+      expect(cookie).toEqual(undefined);
+    });
+
     it('should not use captured cookie when PERCY_DO_NOT_USE_CAPTURED_COOKIES is set', async () => {
       process.env.PERCY_DO_NOT_USE_CAPTURED_COOKIES = true;
       await percy.stop();

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -104,8 +104,17 @@ export function serializeDOM(options) {
     ctx.hints.add('DOM elements found outside </body>');
   }
 
+  let cookies = null;
+  try {
+    cookies = dom.cookie;
+  } catch (err) {
+    let errorMessage = `Could not capture cookie: ${err.message}`;
+    ctx.warnings.add(errorMessage);
+    console.error(errorMessage);
+  }
   let result = {
     html: serializeHTML(ctx),
+    cookies: cookies,
     warnings: Array.from(ctx.warnings),
     resources: Array.from(ctx.resources),
     hints: Array.from(ctx.hints)

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -104,17 +104,9 @@ export function serializeDOM(options) {
     ctx.hints.add('DOM elements found outside </body>');
   }
 
-  let cookies = null;
-  try {
-    cookies = dom.cookie;
-  } catch (err) {
-    let errorMessage = `Could not capture cookie: ${err.message}`;
-    ctx.warnings.add(errorMessage);
-    console.error(errorMessage);
-  }
   let result = {
     html: serializeHTML(ctx),
-    cookies: cookies,
+    cookies: dom.cookie,
     warnings: Array.from(ctx.warnings),
     resources: Array.from(ctx.resources),
     hints: Array.from(ctx.hints)

--- a/packages/dom/test/helpers.js
+++ b/packages/dom/test/helpers.js
@@ -47,6 +47,7 @@ export function withExample(html, options = { withShadow: true, withRestrictedSh
     p.innerText = 'P tag outside body';
     document.documentElement.append(p);
   }
+  document.cookie = 'test-cokkie=test-value';
   return document;
 }
 

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -5,6 +5,7 @@ describe('serializeDOM', () => {
   it('returns serialied html, warnings, and resources', () => {
     expect(serializeDOM()).toEqual({
       html: jasmine.any(String),
+      cookies: jasmine.any(String),
       warnings: jasmine.any(Array),
       resources: jasmine.any(Array),
       hints: jasmine.any(Array)
@@ -28,7 +29,7 @@ describe('serializeDOM', () => {
 
   it('optionally returns a stringified response', () => {
     expect(serializeDOM({ stringifyResponse: true }))
-      .toMatch('{"html":".*","warnings":\\[\\],"resources":\\[\\],"hints":\\[\\]}');
+      .toMatch('{"html":".*","cookies":".*","warnings":\\[\\],"resources":\\[\\],"hints":\\[\\]}');
   });
 
   it('always has a doctype', () => {
@@ -74,6 +75,11 @@ describe('serializeDOM', () => {
 
     const result = serializeDOM();
     expect(result.html).not.toContain('loading="lazy"');
+  });
+
+  it('collects cookies', () => {
+    const result = serializeDOM();
+    expect(result.cookies).toContain('test-cokkie=test-value');
   });
 
   it('clone node is always shallow', () => {


### PR DESCRIPTION
- Capture cookies using `document.cookie` in serialize-dom so can be used in asset discovery.
- Use this cookie and insert in asset discovery browser.
- Disable this behaviour using PERCY_DO_NOT_USE_CAPTURED_COOKIES env variable
- Prioritise cookie passed via percy.yml over auto captured cookie.

Note: httponly cookie can't be captured so that needs to be passed using percy.yml