### PR TITLE
Add log for verfying if capture responsive assets is on

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -160,8 +160,6 @@ async function* captureSnapshotResources(page, snapshot, options) {
 
   // iterate over device to trigger reqeusts and capture other dpr width
   async function* captureResponsiveAssets() {
-    if (!captureForDevices) return;
-
     for (const device of captureForDevices) {
       // We are not adding these widths and pixels ratios in loop below because we want to explicitly reload the page after resize which we dont do below
       yield* captureSnapshotResources(page, { ...snapshot, widths: [device.width] }, {

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -100,9 +100,9 @@ export class Network {
       idle: timeout
     }).catch(error => {
       if (error.message.startsWith('Timeout')) {
-        this._throwTimeoutError((
-          `Timed out waiting for network requests to idle.\nCapturing responsive asset: ${captureResponsiveAssetsEnabled}`
-        ), filter);
+        let message = 'Timed out waiting for network requests to idle.';
+        if (captureResponsiveAssetsEnabled) message += '\nWhile capturing responsive assets try setting PERCY_DO_NOT_CAPTURE_RESPONSIVE_ASSETS to true.';
+        this._throwTimeoutError(message, filter);
       } else {
         throw error;
       }

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -76,7 +76,7 @@ export class Network {
   }
 
   // Resolves after the timeout when there are no more in-flight requests.
-  async idle(filter = () => true, timeout = this.timeout) {
+  async idle(filter = () => true, timeout = this.timeout, captureResponsiveAssetsEnabled = false) {
     let requests = [];
 
     this.log.debug(`Wait for ${timeout}ms idle`, this.meta);
@@ -101,7 +101,7 @@ export class Network {
     }).catch(error => {
       if (error.message.startsWith('Timeout')) {
         this._throwTimeoutError((
-          'Timed out waiting for network requests to idle.'
+          `Timed out waiting for network requests to idle.\nCapturing responsive asset: ${captureResponsiveAssetsEnabled}`
         ), filter);
       } else {
         throw error;

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -150,7 +150,6 @@ export class Page {
     waitForTimeout,
     waitForSelector,
     execute,
-    captureResponsiveAssetsEnabled,
     ...snapshot
   }) {
     let { name, width, enableJavaScript, disableShadowDOM, domTransformation, reshuffleInvalidTags } = snapshot;
@@ -175,7 +174,7 @@ export class Page {
     }
 
     // wait for any final network activity before capturing the dom snapshot
-    await this.network.idle(undefined, undefined, captureResponsiveAssetsEnabled);
+    await this.network.idle();
 
     await this.insertPercyDom();
 

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -150,6 +150,7 @@ export class Page {
     waitForTimeout,
     waitForSelector,
     execute,
+    captureResponsiveAssetsEnabled,
     ...snapshot
   }) {
     let { name, width, enableJavaScript, disableShadowDOM, domTransformation, reshuffleInvalidTags } = snapshot;
@@ -174,7 +175,7 @@ export class Page {
     }
 
     // wait for any final network activity before capturing the dom snapshot
-    await this.network.idle();
+    await this.network.idle(undefined, undefined, captureResponsiveAssetsEnabled);
 
     await this.insertPercyDom();
 

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -927,7 +927,7 @@ describe('Discovery', () => {
       });
 
       expect(logger.stderr).toContain(
-        '[percy] Error: Timed out waiting for network requests to idle.'
+        '[percy] Error: Timed out waiting for network requests to idle.\nCapturing responsive asset: false'
       );
 
       let expectedRequestBody = {
@@ -938,7 +938,7 @@ describe('Discovery', () => {
               meta: { build: { id: '123', url: 'https://percy.io/test/test/123', number: 1 }, snapshot: { name: 'test idle' } }
             },
             {
-              message: 'Timed out waiting for network requests to idle.',
+              message: 'Timed out waiting for network requests to idle.\nCapturing responsive asset: false',
               meta: { build: { id: '123', url: 'https://percy.io/test/test/123', number: 1 }, snapshot: { name: 'test idle' } }
             }
           ]
@@ -948,6 +948,14 @@ describe('Discovery', () => {
     });
 
     it('shows debug info when requests fail to idle in time', async () => {
+      api.reply('/discovery/device-details?build_id=123', () => [200, { data: [{ width: 375, deviceScaleFactor: 2 }, { width: 390, deviceScaleFactor: 3 }] }]);
+      await percy.stop();
+      percy = await Percy.start({
+        projectType: 'web',
+        token: 'PERCY_TOKEN',
+        snapshot: { widths: [1000] },
+        discovery: { concurrency: 1 }
+      });
       percy.loglevel('debug');
 
       await percy.snapshot({
@@ -956,7 +964,7 @@ describe('Discovery', () => {
       });
 
       expect(logger.stderr).toContain(jasmine.stringMatching([
-        '^\\[percy:core] Error: Timed out waiting for network requests to idle.',
+        '^\\[percy:core] Error: Timed out waiting for network requests to idle.\nCapturing responsive asset: true',
         '',
         '  Active requests:',
         '  - http://localhost:8000/img.gif',
@@ -972,7 +980,7 @@ describe('Discovery', () => {
               meta: { build: { id: '123', url: 'https://percy.io/test/test/123', number: 1 }, snapshot: { name: 'test idle' } }
             },
             {
-              message: 'Timed out waiting for network requests to idle.\n\n  Active requests:\n  - http://localhost:8000/img.gif\n',
+              message: 'Timed out waiting for network requests to idle.\nCapturing responsive asset: true\n\n  Active requests:\n  - http://localhost:8000/img.gif\n',
               meta: { build: { id: '123', url: 'https://percy.io/test/test/123', number: 1 }, snapshot: { name: 'test idle' } }
             }
           ]


### PR DESCRIPTION
- Added log when capture responsive assets are on
- Move capture responsive assets logic after capturing dom snapshot (serialize-dom) earlier it is capturing dom in mobile widths when mobile browsers are enabled