### PR TITLE
Increase retry count for verify comparison

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -535,7 +535,7 @@ export class PercyClient {
 
   // Convenience method for verifying if tile is present
   async verify(comparisonId, sha) {
-    let retries = 10;
+    let retries = 20;
     let success = null;
     do {
       await waitForTimeout(500);

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -1249,6 +1249,16 @@ describe('PercyClient', () => {
   });
 
   describe('#uploadComparisonTiles()', () => {
+    let originalTimeout;
+    beforeEach(() => {
+      originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
+    });
+
+    afterEach(() => {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+    });
+
     it('throws when missing a build id', async () => {
       await expectAsync(client.uploadComparisonTiles())
         .toBeRejectedWithError('Missing comparison ID');


### PR DESCRIPTION
- Increase retry count for verify comparison.
- ✨  Improvement: This is to avoid timeout failures when tiles are taking time to upload.