### PR TITLE
Fixed behaviour of PERCY_POSTINSTALL_BROWSER

### DIFF
--- a/packages/core/post-install.js
+++ b/packages/core/post-install.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
 try {
-  if (process.env.PERCY_POSTINSTALL_BROWSER) {
+  if (!['false', '0', undefined].includes(process.env.PERCY_POSTINSTALL_BROWSER)) {
     // Automatically download and install Chromium if PERCY_POSTINSTALL_BROWSER is set
     await import('./dist/install.js').then(install => install.chromium());
   } else if (!process.send && fs.existsSync('./src')) {


### PR DESCRIPTION
Context:
As per https://github.com/percy/cli/issues/1687 we are only looking at if `PERCY_POSTINSTALL_BROWSER` env var is set and not its value. Causing us to install browser even if `PERCY_POSTINSTALL_BROWSER=false` i.e. its set to false. 

Updating check to confirm that the flag is set and value is not in 0 or false.

This still means something like `PERCY_POSTINSTALL_BROWSER=no` or `PERCY_POSTINSTALL_BROWSER=abcdf` or `PERCY_POSTINSTALL_BROWSER=null` would still trigger browser download but we are not trying to handle every possible condition and we want to be as backwards compatible as possible. 

This PR does break backwards compatibility but in obviously correct cases [ which is more like a bug in older versions ]