### PR TITLE
adding reponse status to processing resources

### DIFF
--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -441,6 +441,7 @@ async function saveResponseResource(network, request) {
 
   if (!resource || (!resource.root && !resource.provided && disableCache)) {
     try {
+      log.debug(`Processing resource: ${url}`, meta);
       let shouldCapture = response && hostnameMatches(allowedHostnames, url);
       let body = shouldCapture && await response.buffer();
 
@@ -458,8 +459,6 @@ async function saveResponseResource(network, request) {
       } else if (!enableJavaScript && !ALLOWED_RESOURCES.includes(request.type)) {
         return log.debug(`- Skipping disallowed resource type [${request.type}]`, meta);
       }
-
-      log.debug(`Processing resource: ${url}`, meta);
 
       // mime package does not handle query params
       let urlObj = new URL(url);

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -432,12 +432,15 @@ async function saveResponseResource(network, request) {
   let log = network.log;
   let url = originURL(request);
   let response = request.response;
-  let meta = { ...network.meta, url };
+  let meta = {
+    ...network.meta,
+    url,
+    responseStatus: response?.status
+  };
   let resource = network.intercept.getResource(url);
 
   if (!resource || (!resource.root && !resource.provided && disableCache)) {
     try {
-      log.debug(`Processing resource: ${url}`, meta);
       let shouldCapture = response && hostnameMatches(allowedHostnames, url);
       let body = shouldCapture && await response.buffer();
 
@@ -455,6 +458,8 @@ async function saveResponseResource(network, request) {
       } else if (!enableJavaScript && !ALLOWED_RESOURCES.includes(request.type)) {
         return log.debug(`- Skipping disallowed resource type [${request.type}]`, meta);
       }
+
+      log.debug(`Processing resource: ${url}`, meta);
 
       // mime package does not handle query params
       let urlObj = new URL(url);


### PR DESCRIPTION
adding reponse status to processing resources
https://browserstack.atlassian.net/browse/PER-3796
```
{
  "debug": "core:discovery",
  "level": "debug",
  "message": "Processing resource: https://percy.io/static/assets/vendor-74426c8e7d74b11701ff2c8b2ab300d5.css",
  "meta": {
      "snapshot": {
          "name": "percy"
      },
      "snapshotURL": "https://www.percy.io/customers",
      "url": "https://percy.io/static/assets/vendor-74426c8e7d74b11701ff2c8b2ab300d5.css",
      "responseStatus": 200
  },
  "timestamp": 1725535454307,
  "error": false
},
```

You can get the logs from `36229285` build.