### PR TITLE
Adding waitForTimeout/waitForSelector for assets discovery browser when JS is enabled 

### DIFF
--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -196,6 +196,14 @@ export const configSchema = {
         maximum: 750,
         minimum: 1
       },
+      waitForSelector: {
+        type: 'string'
+      },
+      waitForTimeout: {
+        type: 'integer',
+        minimum: 1,
+        maximum: 30000
+      },
       disableCache: {
         type: 'boolean'
       },
@@ -295,6 +303,8 @@ export const snapshotSchema = {
             allowedHostnames: { $ref: '/config/discovery#/properties/allowedHostnames' },
             disallowedHostnames: { $ref: '/config/discovery#/properties/disallowedHostnames' },
             requestHeaders: { $ref: '/config/discovery#/properties/requestHeaders' },
+            waitForSelector: { $ref: '/config/discovery#/properties/waitForSelector' },
+            waitForTimeout: { $ref: '/config/discovery#/properties/waitForTimeout' },
             authorization: { $ref: '/config/discovery#/properties/authorization' },
             disableCache: { $ref: '/config/discovery#/properties/disableCache' },
             captureMockedServiceWorker: { $ref: '/config/discovery#/properties/captureMockedServiceWorker' },

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -130,6 +130,8 @@ function getSnapshotOptions(options, { config, meta }) {
       allowedHostnames: config.discovery.allowedHostnames,
       disallowedHostnames: config.discovery.disallowedHostnames,
       networkIdleTimeout: config.discovery.networkIdleTimeout,
+      waitForTimeout: config.discovery.waitForTimeout,
+      waitForSelector: config.discovery.waitForSelector,
       devicePixelRatio: config.discovery.devicePixelRatio,
       requestHeaders: config.discovery.requestHeaders,
       authorization: config.discovery.authorization,

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -257,6 +257,15 @@ async function waitForSelector(selector, timeout) {
   }
 }
 
+// wait for a query selector to exist within an optional timeout inside browser
+export async function waitForSelectorInsideBrowser(page, selector, timeout) {
+  try {
+    return page.eval(`await waitForSelector(${JSON.stringify(selector)}, ${timeout})`);
+  } catch {
+    throw new Error(`Unable to find: ${selector}`);
+  }
+}
+
 // Browser-specific util to wait for an xpath selector to exist within an optional timeout.
 /* istanbul ignore next: tested, but coverage is stripped */
 async function waitForXPath(selector, timeout) {

--- a/packages/core/test/utils.test.js
+++ b/packages/core/test/utils.test.js
@@ -1,6 +1,7 @@
-import { decodeAndEncodeURLWithLogging } from '../src/utils.js';
-import { logger } from './helpers/index.js';
+import { decodeAndEncodeURLWithLogging, waitForSelectorInsideBrowser } from '../src/utils.js';
+import { logger, setupTest } from './helpers/index.js';
 import percyLogger from '@percy/logger';
+import Percy from '@percy/core';
 
 describe('utils', () => {
   let log;
@@ -43,6 +44,33 @@ describe('utils', () => {
           warningMessage: 'some Warning Message'
         });
       expect(logger.stderr).toEqual(['[percy] some Warning Message']);
+    });
+  });
+  describe('waitForSelectorInsideBrowser', () => {
+    it('waitForSelectorInsideBrowser should work when called with correct parameters', async () => {
+      await setupTest();
+      let percy = await Percy.start({
+        token: 'PERCY_TOKEN',
+        snapshot: { widths: [1000] },
+        discovery: { concurrency: 1 }
+      });
+      const page = await percy.browser.page();
+      spyOn(page, 'eval').and.callThrough();
+      waitForSelectorInsideBrowser(page, 'body', 30000);
+
+      expect(page.eval).toHaveBeenCalledWith('await waitForSelector("body", 30000)');
+    });
+    it('should handle errors when waitForSelectorInsideBrowser fails', async () => {
+      let error = null;
+      const expectedError = new Error('Unable to find: body');
+
+      try {
+        await waitForSelectorInsideBrowser(null, 'body', 30000);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toEqual(expectedError);
     });
   });
 });


### PR DESCRIPTION
- added waitForTimeout and waitForSelector at the time of discovery when JS is enabled 

**so now waitForTimeout and waitForSelector are at 2 places:**
- snapshot level (snapshot.waitForTimeout)
- discovery level (snapshot.discovery.waitForTimeout)

**usage of both:**

 **when it is passed at snapshot level** => 
these options are used before a DOM snapshot is taken. The primary goal is to ensure that the page has fully loaded and any necessary DOM elements are present before capturing the state of the page. This mode is currently only supported when used with percy snapshot cli command.

 **when it is passed at discovery level and JS is enabled** => in this phase, these options are used to wait for specific assets or network requests to be discovered and captured. The asset-discovery process often occurs during or after initial page load, and some resources may not be immediately available. 

**how client should use:**

snapshot level => You should use these options at the snapshot level when you want to ensure the readiness of a page before it is captured. This ensures that no partial or incomplete content is included in the snapshot.

discovery level =>  You should use these options in the discovery level when you are facing issues with missing assets or incomplete network requests. By waiting for the selector or a set timeout, you give enough time for assets to load

- used both at the time of discovery
- added test cases for the same

