### PR TITLE
Fixed cookies parsing bug in auto captured cookies

### DIFF
--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -474,7 +474,7 @@ async function saveResponseResource(network, request) {
       // font anyway as font responses from the browser may not be properly encoded,
       // so request them directly.
       if (mimeType?.includes('font') || (detectedMime && detectedMime.includes('font'))) {
-        log.debug('- Requesting asset directly');
+        log.debug('- Requesting asset directly', meta);
         body = await makeDirectRequest(network, request);
       }
 
@@ -491,7 +491,7 @@ async function saveResponseResource(network, request) {
       log.debug(`- mimetype: ${resource.mimetype}`, meta);
     } catch (error) {
       log.debug(`Encountered an error processing resource: ${url}`, meta);
-      log.debug(error);
+      log.debug(error, meta);
     }
   }
 


### PR DESCRIPTION
Context:
- Cookie parsing logic failed when cookies were encoded as base64 and had `=` at the end. 
- When servers used strict base64 cookie check this ended up with error response causing `ERR_HTTP2_PROTOCOL_ERROR` in discovery chromium. 

This PR fixes the logic and refactors the function. 
Also few unrelated logging improvements.

Secure cookie ->
- Sometime we are getting `Protocol error (Network.setCookies): Invalid cookie fields` because the percy captured cookie did not capture the secure flag
- Adding support for secure flag that can be set by setting this env variable `PERCY_SECURE_COOKIES` to true.