### PR TITLE
adding secure flag for cookies that starts with __Secure

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -88,7 +88,14 @@ function parseCookies(cookiesStr) {
 
   return cookiesStr.split('; ').map(c => {
     const eqIdx = c.indexOf('=');
-    return { name: c.substring(0, eqIdx), value: c.substring(eqIdx + 1) };
+    const name = c.substring(0, eqIdx);
+    const value = c.substring(eqIdx + 1);
+    const cookieObj = { name, value };
+
+    if (name.startsWith('__Secure')) {
+      cookieObj.secure = true;
+    }
+    return cookieObj;
   });
 }
 

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -1367,7 +1367,7 @@ describe('Discovery', () => {
         url: 'http://localhost:8000',
         domSnapshot: {
           html: testDOM,
-          cookies: 'test-cookie=value'
+          cookies: '__Secure-test-cookie=value'
         }
       });
 
@@ -1375,7 +1375,7 @@ describe('Discovery', () => {
         '[percy] Snapshot taken: mmm cookies'
       ]));
 
-      expect(cookie).toEqual('test-cookie=value');
+      expect(cookie).toEqual('__Secure-test-cookie=value');
     });
 
     it('does not use cookie if empty cookies is passed (in case of httponly)', async () => {


### PR DESCRIPTION
adding secure flag for cookies that starts with __Secure because any cookie that starts with __Secure. The browser search for secure flag.

Docs -> https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
