### PR TITLE
updating path-to-regexp to 6.3.0 where the vulnerabilities are fixed

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "micromatch": "^4.0.6",
     "mime-types": "^2.1.34",
     "pako": "^2.1.0",
-    "path-to-regexp": "^6.2.0",
+    "path-to-regexp": "^6.3.0",
     "rimraf": "^3.0.2",
     "ws": "^8.17.1",
     "yaml": "^2.4.1"

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -365,6 +365,7 @@ async function sendResponseResource(network, request, session) {
         errorReason: 'Aborted'
       });
     } else if (resource && (resource.root || resource.provided || !disableCache)) {
+      // Don't rename the below log line as it is used in getting network logs in api
       log.debug(resource.root ? '- Serving root resource' : '- Resource cache hit', meta);
 
       await send('Fetch.fulfillRequest', {
@@ -441,10 +442,12 @@ async function saveResponseResource(network, request) {
 
   if (!resource || (!resource.root && !resource.provided && disableCache)) {
     try {
+      // Don't rename the below log line as it is used in getting network logs in api
       log.debug(`Processing resource: ${url}`, meta);
       let shouldCapture = response && hostnameMatches(allowedHostnames, url);
       let body = shouldCapture && await response.buffer();
 
+      // Don't rename the below log line as it is used in getting network logs in api
       /* istanbul ignore if: first check is a sanity check */
       if (!response) {
         return log.debug('- Skipping no response', meta);
@@ -490,6 +493,7 @@ async function saveResponseResource(network, request) {
       log.debug(`- sha: ${resource.sha}`, meta);
       log.debug(`- mimetype: ${resource.mimetype}`, meta);
     } catch (error) {
+      // Don't rename the below log line as it is used in getting network logs in api
       log.debug(`Encountered an error processing resource: ${url}`, meta);
       log.debug(error, meta);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7017,10 +7017,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@^6.2.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
-  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
+path-to-regexp@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
 
 path-type@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
updating path-to-regexp to 6.3.0 where the vulnerabilities are fixed