### PR TITLE
Added default headers for chromium in direct requests

### DIFF
--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -417,7 +417,18 @@ async function makeDirectRequest(network, request, session) {
   const { cookies } = await session.send('Network.getCookies', { urls: [request.url] });
 
   let headers = {
+    // add default browser
+    accept: '*/*',
+    'sec-fetch-site': 'same-origin',
+    'sec-fetch-mode': 'cors',
+    'sec-fetch-dest': 'font',
+    'sec-ch-ua': '"Chromium";v="123", "Google Chrome";v="123", "Not?A_Brand";v="99"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': '"macOS"',
+    'sec-fetch-user': '?1',
+    // add request fetched headers
     ...request.headers,
+    // add applicable cookies
     cookie: cookies.map(cookie => `${cookie.name}=${cookie.value}`).join('; ')
   };
 


### PR DESCRIPTION
Context:
- It seems like some security softwares / or cdns have started requiring these headers - else they return 403s 
- I am assuming that addition of extra headers would not affect where its already working


