### PR TITLE
Fix import in ternary statement

### DIFF
--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -135,7 +135,7 @@ export async function request(url, options = {}, callback) {
   let { protocol, hostname, port, pathname, search, hash } = new URL(url);
 
   // reference the default export so tests can mock it
-  let { default: http } = await import(protocol === 'https:' ? 'https' : 'http');
+  let { default: http } = protocol === 'https:' ? await import('https') : await import('http');
   let { proxyAgentFor } = await import('./proxy.js');
 
   // automatically stringify body content

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -135,6 +135,8 @@ export async function request(url, options = {}, callback) {
   let { protocol, hostname, port, pathname, search, hash } = new URL(url);
 
   // reference the default export so tests can mock it
+  // bundling cli insdie electron (LCNC) fails if we import it like 
+  // this: await import(protocol === 'https:' ? 'https' : 'http');
   let { default: http } = protocol === 'https:' ? await import('https') : await import('http');
   let { proxyAgentFor } = await import('./proxy.js');
 

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -135,7 +135,7 @@ export async function request(url, options = {}, callback) {
   let { protocol, hostname, port, pathname, search, hash } = new URL(url);
 
   // reference the default export so tests can mock it
-  // bundling cli insdie electron (LCNC) fails if we import it like 
+  // bundling cli inside electron (LCNC) fails if we import it like 
   // this: await import(protocol === 'https:' ? 'https' : 'http');
   let { default: http } = protocol === 'https:' ? await import('https') : await import('http');
   let { proxyAgentFor } = await import('./proxy.js');

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -135,7 +135,7 @@ export async function request(url, options = {}, callback) {
   let { protocol, hostname, port, pathname, search, hash } = new URL(url);
 
   // reference the default export so tests can mock it
-  // bundling cli inside electron (LCNC) fails if we import it like 
+  // bundling cli inside electron (LCNC) fails if we import it like
   // this: await import(protocol === 'https:' ? 'https' : 'http');
   let { default: http } = protocol === 'https:' ? await import('https') : await import('http');
   let { proxyAgentFor } = await import('./proxy.js');


### PR DESCRIPTION
It will fix the bundling issue of Percy CLI lib when trying to bundle Percy inside LCNC Electron app