### PR TITLE
Shadowroot support using getHTML

### DIFF
--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -88,12 +88,7 @@ export function getOuterHTML(docElement) {
   // firefox doesn't serialize shadow DOM, we're awaiting API's by firefox to become ready and are not polyfilling it.
   if (!docElement.getHTML) { return docElement.outerHTML; }
   // chromium gives us declarative shadow DOM serialization API
-  let innerHTML = '';
-  if (docElement.getInnerHTML) {
-    innerHTML = docElement.getInnerHTML({ includeShadowRoots: true });
-  } else if (docElement.getHTML) {
-    innerHTML = docElement.getHTML({ serializableShadowRoots: true });
-  }
+  let innerHTML = docElement.getHTML({ serializableShadowRoots: true });
   docElement.textContent = '';
   // Note: Here we are specifically passing replacer function to avoid any replacements due to
   // special characters in client's dom like $&

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -54,7 +54,8 @@ export function cloneNodeAndShadow(ctx) {
           clone.shadowRoot.innerHTML = '';
         } else {
           clone.attachShadow({
-            mode: 'open'
+            mode: 'open',
+            serializable: true
           });
         }
         // clone dom elements
@@ -85,9 +86,14 @@ export function cloneNodeAndShadow(ctx) {
  */
 export function getOuterHTML(docElement) {
   // firefox doesn't serialize shadow DOM, we're awaiting API's by firefox to become ready and are not polyfilling it.
-  if (!docElement.getInnerHTML) { return docElement.outerHTML; }
+  if (!docElement.getHTML) { return docElement.outerHTML; }
   // chromium gives us declarative shadow DOM serialization API
-  let innerHTML = docElement.getInnerHTML({ includeShadowRoots: true });
+  let innerHTML = '';
+  if (docElement.getInnerHTML) {
+    innerHTML = docElement.getInnerHTML({ includeShadowRoots: true });
+  } else if (docElement.getHTML) {
+    innerHTML = docElement.getHTML({ serializableShadowRoots: true });
+  }
   docElement.textContent = '';
   // Note: Here we are specifically passing replacer function to avoid any replacements due to
   // special characters in client's dom like $&

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -87,10 +87,13 @@ export function cloneNodeAndShadow(ctx) {
 export function getOuterHTML(docElement) {
   // All major browsers in latest versions supports getHTML API to get serialized DOM
   // https://developer.mozilla.org/en-US/docs/Web/API/Element/getHTML
-  // firefox doesn't serialize shadow DOM, we're awaiting API's by firefox to become ready and are not polyfilling it.
+  // old firefox doesn't serialize shadow DOM, we're awaiting API's by firefox to become ready and are not polyfilling it.
+  // new firefox from 128 onwards serializes it using getHTML
+  /* istanbul ignore if: Only triggered in firefox <= 128 and tests runs on latest */
   if (!docElement.getHTML) { return docElement.outerHTML; }
   // chromium gives us declarative shadow DOM serialization API
   let innerHTML = '';
+  /* istanbul ignore else if: Only triggered in chrome <= 128 and tests runs on latest */
   if (docElement.getHTML) {
     innerHTML = docElement.getHTML({ serializableShadowRoots: true });
   } else if (docElement.getInnerHTML) {

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -81,10 +81,21 @@ export function cloneNodeAndShadow(ctx) {
   return fragment;
 };
 
+/**
+ * Use `getInnerHTML()` to serialize shadow dom as <template> tags. `innerHTML` and `outerHTML` don't do this. Buzzword: "declarative shadow dom"
+ */
 export function getOuterHTML(docElement) {
-  // getHTML is standard way of getting serialized DOM and is supported across all major browsers
+  // All major browsers in latest versions supports getHTML API to get serialized DOM
   // https://developer.mozilla.org/en-US/docs/Web/API/Element/getHTML
-  let innerHTML = docElement.getHTML({ serializableShadowRoots: true });
+  // firefox doesn't serialize shadow DOM, we're awaiting API's by firefox to become ready and are not polyfilling it.
+  if (!docElement.getHTML) { return docElement.outerHTML; }
+  // chromium gives us declarative shadow DOM serialization API
+  let innerHTML = '';
+  if (docElement.getHTML) {
+    innerHTML = docElement.getHTML({ serializableShadowRoots: true });
+  } else if (docElement.getInnerHTML) {
+    innerHTML = docElement.getInnerHTML({ includeShadowRoots: true });
+  }
   docElement.textContent = '';
   // Note: Here we are specifically passing replacer function to avoid any replacements due to
   // special characters in client's dom like $&

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -81,13 +81,9 @@ export function cloneNodeAndShadow(ctx) {
   return fragment;
 };
 
-/**
- * Use `getInnerHTML()` to serialize shadow dom as <template> tags. `innerHTML` and `outerHTML` don't do this. Buzzword: "declarative shadow dom"
- */
 export function getOuterHTML(docElement) {
-  // firefox doesn't serialize shadow DOM, we're awaiting API's by firefox to become ready and are not polyfilling it.
-  if (!docElement.getHTML) { return docElement.outerHTML; }
-  // chromium gives us declarative shadow DOM serialization API
+  // getHTML is standard way of getting serialized DOM and is supported across all major browsers
+  // https://developer.mozilla.org/en-US/docs/Web/API/Element/getHTML
   let innerHTML = docElement.getHTML({ serializableShadowRoots: true });
   docElement.textContent = '';
   // Note: Here we are specifically passing replacer function to avoid any replacements due to

--- a/packages/dom/test/serialize-css.test.js
+++ b/packages/dom/test/serialize-css.test.js
@@ -118,7 +118,7 @@ describe('serializeCSSOM', () => {
         }]));
 
         expect(resultShadowEl.innerHTML).toEqual([
-          '<template shadowrootmode="open">',
+          '<template shadowrootmode="open" shadowrootserializable="">',
           `<link rel="stylesheet" data-percy-adopted-stylesheets-serialized="true" href="${capture.resources[0].url}">`,
           '<p>Percy-0</p>',
           '</template>'
@@ -157,14 +157,14 @@ describe('serializeCSSOM', () => {
         const resultShadowElChild = $('#Percy-1')[0];
 
         expect(resultShadowEl.innerHTML).toMatch([
-          '<template shadowrootmode="open">',
+          '<template shadowrootmode="open" shadowrootserializable="">',
           `<link rel="stylesheet" data-percy-adopted-stylesheets-serialized="true" href="${capture.resources[0].url}">`,
           '<p>Percy-0</p>',
           '</template>'
         ].join(''));
 
         expect(resultShadowElChild.innerHTML).toMatch([
-          '<template shadowrootmode="open">',
+          '<template shadowrootmode="open" shadowrootserializable="">',
           `<link rel="stylesheet" data-percy-adopted-stylesheets-serialized="true" href="${capture.resources[1].url}">`,
           `<link rel="stylesheet" data-percy-adopted-stylesheets-serialized="true" href="${capture.resources[0].url}">`,
           '<p>Percy-1</p>',

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -125,7 +125,7 @@ describe('serializeDOM', () => {
       shadow.appendChild(paragraphEl);
 
       const html = serializeDOM().html;
-      expect(html).toMatch('<template shadowrootmode="open">');
+      expect(html).toMatch('<template shadowrootmode="open" shadowrootserializable="">');
       expect(html).toMatch('Hey Percy!');
     });
 
@@ -162,10 +162,10 @@ describe('serializeDOM', () => {
       const html = serializeDOM().html;
 
       expect(html).toMatch(new RegExp([
-        '<template shadowrootmode="open">',
+        '<template shadowrootmode="open" shadowrootserializable="">',
         '<p>Percy-1</p>',
         '<div id="Percy-2" .*>',
-        '<template shadowrootmode="open">',
+        '<template shadowrootmode="open" shadowrootserializable="">',
         '<p>Percy-2</p>',
         '</template>'
       ].join('')));
@@ -193,7 +193,7 @@ describe('serializeDOM', () => {
         el = newEl;
         matchRegex += [
           `<div id="Percy-${j}" .*>`,
-          '<template shadowrootmode="open">',
+          '<template shadowrootmode="open" shadowrootserializable="">',
           `<p>Percy-${j}</p>`
         ].join('');
       }
@@ -218,7 +218,7 @@ describe('serializeDOM', () => {
         baseContent.appendChild(newEl);
         matchRegex += [
           `<div id="Percy-${j}" .*>`,
-          '<template shadowrootmode="open">',
+          '<template shadowrootmode="open" shadowrootserializable="">',
           `<p>Percy-${j}</p>`,
           '</template>',
           '</div>'
@@ -251,7 +251,7 @@ describe('serializeDOM', () => {
         constructor() {
           super();
           // Create a shadow root
-          const shadow = this.shadowRoot || this.attachShadow({ mode: 'open' });
+          const shadow = this.shadowRoot || this.attachShadow({ mode: 'open', serializable: true });
           const wrapper = document.createElement('h2');
           wrapper.innerText = 'Test';
           shadow.appendChild(wrapper);


### PR DESCRIPTION
- Shadowroot support using getHTML
- Since `getInnerHTML` is deprecated from chrome 129 onwards and `getHTML` was introduced, serialization of shadowroot nodes needs to be updated to ensure proper working and capturing of shadowroot elements.

Release Notes:
- https://developer.chrome.com/release-notes/129#remove_non-standard_declarative_shadow_dom_serialization

MDN
- https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/getHTML

Related Chromium Tickets
- https://issues.chromium.org/issues/41490936
- https://chromestatus.com/feature/5081733588582400