### PR TITLE
Fix 'receiving' typos

### DIFF
--- a/packages/cli-build/src/wait.js
+++ b/packages/cli-build/src/wait.js
@@ -87,7 +87,7 @@ function logProgress({
     case undefined:
       return log.progress('Waiting for build...');
     case 'pending':
-      return log.progress('Recieving snapshots...');
+      return log.progress('Receiving snapshots...');
     case 'processing':
       return log.progress(`Processing ${count} snapshots - ` + (
         finished === total ? 'finishing up...' : (

--- a/packages/cli-build/test/wait.test.js
+++ b/packages/cli-build/test/wait.test.js
@@ -60,7 +60,7 @@ describe('percy build:wait', () => {
     ]));
   });
 
-  it('logs while recieving snapshots', async () => {
+  it('logs while receiving snapshots', async () => {
     api
       .reply('/builds/123', () => [200, build({
         state: 'pending'
@@ -74,7 +74,7 @@ describe('percy build:wait', () => {
 
     expect(logger.stderr).toEqual(['[percy] Ignoring interval since it cannot be less than 1000ms.']);
     expect(logger.stdout).toEqual(jasmine.arrayContaining([
-      '[percy] Recieving snapshots...'
+      '[percy] Receiving snapshots...'
     ]));
   });
 

--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -154,7 +154,7 @@ export function createPercyServer(percy, port) {
 
       res.json(200, { success: true, data: data });
     })
-  // Recieves events from sdk's.
+  // Receives events from sdk's.
     .route('post', '/percy/events', async (req, res) => {
       const body = percyBuildEventHandler(req, pkg.version);
       await percy.client.sendBuildEvents(percy.build?.id, body);

--- a/scripts/loader.js
+++ b/scripts/loader.js
@@ -11,7 +11,7 @@ const MOCK_REG = /^mock:\/\/|\?.+$/g;
 // global mocks can be added from tests
 export const MOCK_IMPORTS = global.__MOCK_IMPORTS__ = global.__MOCK_IMPORTS__ ||
   new Proxy(Object.assign(new Map(), { __uid__: 0 }), {
-    get(target, prop, reciever) {
+    get(target, prop, receiver) {
       if (typeof target[prop] !== 'function') return target[prop];
 
       return prop === 'set' ? (key, value) => {


### PR DESCRIPTION
This small PR fixes several typos to the word "receiving", which was visible on the Percy dashboard and in console logs.

![Screenshot 2024-11-26 at 13 49 58](https://github.com/user-attachments/assets/857c38a7-d9fc-4850-a9ba-1cb36050c6d2)
