### PR TITLE
Adding support for IGNORE_TIMEOUT_ERROR env

### DIFF
--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -154,7 +154,7 @@ export class Network {
       msg += this.logNetworkRequests(filter);
     }
 
-    if (process.env.IGNORE_TIMEOUT_ERROR === 'true') {
+    if (process.env.PERCY_IGNORE_TIMEOUT_ERROR === 'true') {
       let warnMsg = 'Ignoring network timeout failures.';
       warnMsg += this.logNetworkRequests(filter);
       this.log.warn(warnMsg);

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -141,11 +141,24 @@ export class Network {
     return this.#aborted.has(requestId);
   }
 
+  logNetworkRequests(filter) {
+    let msg = '';
+    let reqs = Array.from(this.#requests.values()).filter(filter).map(r => r.url);
+    msg += `\n\n  ${['Active requests:', ...reqs].join('\n  - ')}\n`;
+    return msg;
+  }
+
   // Throw a better network timeout error
   _throwTimeoutError(msg, filter = () => true) {
     if (this.log.shouldLog('debug')) {
-      let reqs = Array.from(this.#requests.values()).filter(filter).map(r => r.url);
-      msg += `\n\n  ${['Active requests:', ...reqs].join('\n  - ')}\n`;
+      msg += this.logNetworkRequests(filter);
+    }
+
+    if (process.env.IGNORE_TIMEOUT_ERROR === 'true') {
+      let warnMsg = 'Ignoring network timeout failures.';
+      warnMsg += this.logNetworkRequests(filter);
+      this.log.warn(warnMsg);
+      return;
     }
 
     throw new Error(msg);

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -973,6 +973,7 @@ describe('Discovery', () => {
     afterEach(() => {
       Network.TIMEOUT = undefined;
       process.env.PERCY_NETWORK_IDLE_WAIT_TIMEOUT = undefined;
+      process.env.IGNORE_TIMEOUT_ERROR = undefined;
     });
 
     it('throws an error when requests fail to idle in time', async () => {
@@ -1065,6 +1066,22 @@ describe('Discovery', () => {
       ));
       expect(logger.stderr).toContain(jasmine.stringMatching(
         '^\\[percy:core:discovery] Setting PERCY_NETWORK_IDLE_WAIT_TIMEOUT over 60000ms is not'
+      ));
+    });
+
+    it('should not throw error when requests fail to idle in time when IGNORE_TIMEOUT_ERROR is true', async () => {
+      process.env.IGNORE_TIMEOUT_ERROR = 'true';
+      await percy.snapshot({
+        name: 'test idle',
+        url: 'http://localhost:8000'
+      });
+
+      expect(logger.stderr).toContain(jasmine.stringMatching(
+        '^\\[percy] Ignoring network timeout failures.'
+      ));
+
+      expect(logger.stderr).toContain(jasmine.stringMatching(
+        '  Active requests:\n' + '  - http://localhost:8000/img.gif\n'
       ));
     });
 

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -973,7 +973,7 @@ describe('Discovery', () => {
     afterEach(() => {
       Network.TIMEOUT = undefined;
       process.env.PERCY_NETWORK_IDLE_WAIT_TIMEOUT = undefined;
-      process.env.IGNORE_TIMEOUT_ERROR = undefined;
+      process.env.PERCY_IGNORE_TIMEOUT_ERROR = undefined;
     });
 
     it('throws an error when requests fail to idle in time', async () => {
@@ -1069,8 +1069,8 @@ describe('Discovery', () => {
       ));
     });
 
-    it('should not throw error when requests fail to idle in time when IGNORE_TIMEOUT_ERROR is true', async () => {
-      process.env.IGNORE_TIMEOUT_ERROR = 'true';
+    it('should not throw error when requests fail to idle in time when PERCY_IGNORE_TIMEOUT_ERROR is true', async () => {
+      process.env.PERCY_IGNORE_TIMEOUT_ERROR = 'true';
       await percy.snapshot({
         name: 'test idle',
         url: 'http://localhost:8000'

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -29,7 +29,7 @@ describe('Percy', () => {
     await server.close();
     delete process.env.PERCY_TOKEN;
     delete process.env.PERCY_CLIENT_ERROR_LOGS;
-    delete process.env.IGNORE_TIMEOUT_ERROR;
+    delete process.env.PERCY_IGNORE_TIMEOUT_ERROR;
   });
 
   const sharedExpectBlockForSuggestion = (expectedBody) => {

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -29,6 +29,7 @@ describe('Percy', () => {
     await server.close();
     delete process.env.PERCY_TOKEN;
     delete process.env.PERCY_CLIENT_ERROR_LOGS;
+    delete process.env.IGNORE_TIMEOUT_ERROR;
   });
 
   const sharedExpectBlockForSuggestion = (expectedBody) => {


### PR DESCRIPTION
- Adding support for PERCY_IGNORE_TIMEOUT_ERROR env
- This will ensure that if above env is set to true, we would regardless upload snapshots instead of failing them.