### PR TITLE
Adding prodBuild param for scanner alt env

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -173,7 +173,7 @@ export class PercyClient {
           tags: tagsArr,
           'cli-start-time': cliStartTime,
           source: source,
-          'prod-build': this.config.percy?.prodBuild
+          'skip-base-build': this.config.percy?.skipBaseBuild
         },
         relationships: {
           resources: {

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -172,7 +172,8 @@ export class PercyClient {
           partial: this.env.partial,
           tags: tagsArr,
           'cli-start-time': cliStartTime,
-          source: source
+          source: source,
+          'prod-build': this.config.percy?.prodBuild
         },
         relationships: {
           resources: {

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -150,6 +150,10 @@ describe('PercyClient', () => {
 
   describe('#createBuild()', () => {
     let cliStartTime = new Date().toISOString();
+    beforeEach(() => {
+      delete process.env.PERCY_AUTO_ENABLED_GROUP_BUILD;
+    });
+
     it('creates a new build', async () => {
       await expectAsync(client.createBuild()).toBeResolvedTo({
         data: {
@@ -381,6 +385,47 @@ describe('PercyClient', () => {
             source: 'auto_enabled_group',
             partial: client.env.partial,
             tags: [{ id: null, name: 'tag1' }, { id: null, name: 'tag2' }]
+          }
+        }));
+    });
+
+    it('creates a new build with prodBuild config', async () => {
+      client = new PercyClient({
+        token: 'PERCY_TOKEN',
+        config: { percy: { prodBuild: true } }
+      });
+      await expectAsync(client.createBuild({ projectType: 'web' })).toBeResolvedTo({
+        data: {
+          id: '123',
+          attributes: {
+            'build-number': 1,
+            'web-url': 'https://percy.io/test/test/123'
+          }
+        }
+      });
+
+      expect(api.requests['/builds'][0].body.data)
+        .toEqual(jasmine.objectContaining({
+          attributes: {
+            branch: client.env.git.branch,
+            type: 'web',
+            'target-branch': client.env.target.branch,
+            'target-commit-sha': client.env.target.commit,
+            'commit-sha': client.env.git.sha,
+            'commit-committed-at': client.env.git.committedAt,
+            'commit-author-name': client.env.git.authorName,
+            'commit-author-email': client.env.git.authorEmail,
+            'commit-committer-name': client.env.git.committerName,
+            'commit-committer-email': client.env.git.committerEmail,
+            'commit-message': client.env.git.message,
+            'pull-request-number': client.env.pullRequest,
+            'parallel-nonce': client.env.parallel.nonce,
+            'parallel-total-shards': client.env.parallel.total,
+            'cli-start-time': null,
+            source: 'user_created',
+            partial: client.env.partial,
+            'prod-build': true,
+            tags: []
           }
         }));
     });

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -389,10 +389,10 @@ describe('PercyClient', () => {
         }));
     });
 
-    it('creates a new build with prodBuild config', async () => {
+    it('creates a new build with skipBaseBuild config', async () => {
       client = new PercyClient({
         token: 'PERCY_TOKEN',
-        config: { percy: { prodBuild: true } }
+        config: { percy: { skipBaseBuild: true } }
       });
       await expectAsync(client.createBuild({ projectType: 'web' })).toBeResolvedTo({
         data: {
@@ -424,7 +424,7 @@ describe('PercyClient', () => {
             'cli-start-time': null,
             source: 'user_created',
             partial: client.env.partial,
-            'prod-build': true,
+            'skip-base-build': true,
             tags: []
           }
         }));

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -17,7 +17,7 @@ export const configSchema = {
       labels: {
         type: 'string'
       },
-      prodBuild: {
+      skipBaseBuild: {
         type: 'boolean',
         default: false
       }

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -16,6 +16,10 @@ export const configSchema = {
       },
       labels: {
         type: 'string'
+      },
+      prodBuild: {
+        type: 'boolean',
+        default: false
       }
     }
   },


### PR DESCRIPTION
Adding prod build config for scanner projects to make base build as null so that they don't get compared to any other builds for alternate env support.