### PR TITLE
Cache base64 resources

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -380,8 +380,9 @@ export class PercyClient {
           sha: resource.sha,
           ...meta
         };
-        yield this.uploadResource(buildId, resource, resourceMeta).then(() => {
+        yield this.uploadResource(buildId, resource, resourceMeta).then((result) => {
           this.log.debug(`Uploaded resource ${resource.url}`, resourceMeta);
+          return result;
         });
       }
     }, this, uploadConcurrency);

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -380,8 +380,9 @@ export class PercyClient {
           sha: resource.sha,
           ...meta
         };
-        yield this.uploadResource(buildId, resource, resourceMeta);
-        this.log.debug(`Uploaded resource ${resource.url}`, resourceMeta);
+        yield this.uploadResource(buildId, resource, resourceMeta).then(() => {
+          this.log.debug(`Uploaded resource ${resource.url}`, resourceMeta);
+        });
       }
     }, this, uploadConcurrency);
   }

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -16,7 +16,7 @@ import { handleErrors } from './utils';
 const ignoreTags = ['NOSCRIPT'];
 
 export function cloneNodeAndShadow(ctx) {
-  let { dom, disableShadowDOM, resources } = ctx;
+  let { dom, disableShadowDOM, resources, cache } = ctx;
   // clones shadow DOM and light DOM for a given node
   let cloneNode = (node, parent) => {
     try {
@@ -37,7 +37,7 @@ export function cloneNodeAndShadow(ctx) {
       // We apply any element transformations here to avoid another treeWalk
       applyElementTransformations(clone);
 
-      serializeBase64(clone, resources);
+      serializeBase64(clone, resources, cache);
 
       parent.appendChild(clone);
 

--- a/packages/dom/test/serialize-base64.test.js
+++ b/packages/dom/test/serialize-base64.test.js
@@ -8,6 +8,8 @@ describe('serializeBase64', () => {
     it(`${platform}: serializes base64 elements`, async () => {
       withExample(`
       <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEU" id="img">
+      <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEU" id="img2">
+      <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhE2" id="diff_img">
       `);
 
       serialized = serializeDOM();
@@ -15,11 +17,28 @@ describe('serializeBase64', () => {
 
       expect($('#img')[0].getAttribute('src'))
         .toMatch('/__serialized__/\\w+\\.png');
+      expect($('#img2')[0].getAttribute('src'))
+        .toMatch('/__serialized__/\\w+\\.png');
+      expect($('#diff_img')[0].getAttribute('src'))
+        .toMatch('/__serialized__/\\w+\\.png');
+      // both img and img2 refer to same resource as its same content
+      expect($('#img')[0].getAttribute('src'))
+        .toMatch($('#img2')[0].getAttribute('src'));
+
       expect(serialized.resources).toContain(jasmine.objectContaining({
         url: $('#img')[0].getAttribute('src'),
         content: 'iVBORw0KGgoAAAANSUhEU',
         mimetype: 'image/png'
       }));
+
+      expect(serialized.resources).toContain(jasmine.objectContaining({
+        url: $('#diff_img')[0].getAttribute('src'),
+        content: 'iVBORw0KGgoAAAANSUhE2',
+        mimetype: 'image/png'
+      }));
+
+      // even though we have 3 images - we have 2 unique base64 sha's
+      expect(serialized.resources.length).toEqual(2);
     });
 
     it(`${platform}: serializes SVGAnimatedString having base64`, async () => {


### PR DESCRIPTION
Changes:
- Now we cache data src resources - is helpful in some cases where we were getting hundreds of repeated resources as those were on different dom nodes
- We now set src on cloned node using `data-percy-serialized-attribute-src` - which is later replaced with src. This allows us to avoid network call that browser makes when we set src on any cloned node.