### PR TITLE
added check for resources greater than 100mb

### DIFF
--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -491,8 +491,6 @@ async function saveResponseResource(network, request, session) {
         return log.debug('- Skipping remote resource', meta);
       } else if (!body.length) {
         return log.debug('- Skipping empty response', meta);
-      } else if (body.length > MAX_RESOURCE_SIZE) {
-        return log.debug('- Skipping resource larger than 25MB', meta);
       } else if (!ALLOWED_STATUSES.includes(response.status)) {
         return log.debug(`- Skipping disallowed status [${response.status}]`, meta);
       } else if (!enableJavaScript && !ALLOWED_RESOURCES.includes(request.type)) {

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -467,6 +467,13 @@ async function saveResponseResource(network, request, session) {
     url,
     responseStatus: response?.status
   };
+  // Checing for content length more than 100MB, to prevent websocket error which is governed by
+  // maxPayload option of websocket defaulted to 100MB.
+  // If content-length is more than our allowed 25MB, no need to process that resouce we can return log.
+  let contentLength = parseInt(response.headers['Content-Length']);
+  if (contentLength > MAX_RESOURCE_SIZE) {
+    return log.debug('- Skipping resource larger than 25MB', meta);
+  }
   let resource = network.intercept.getResource(url);
 
   if (!resource || (!resource.root && !resource.provided && disableCache)) {


### PR DESCRIPTION
Description: 

1. Snapshot upload is failing for resources with size more than 100mb. 
2. Fix: Checking content-length for the response
3. If content-length > MAX_RESOURCE_SIZE (25MB) we are skipping the resource before processing it. 


JIRA: https://browserstack.atlassian.net/browse/PER-4439