### PR TITLE
Added normalization function to make options case-insensitive

### DIFF
--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -165,7 +165,7 @@ function getSnapshotOptions(options, { config, meta }) {
     }
   });
 }
-const optionMappings = {
+const OPTION_MAPPINGS = {
   name: 'name',
   widths: 'widths',
   scope: 'scope',
@@ -189,7 +189,7 @@ function normalizeOptions(options) {
 
   for (const key in options) {
     const lowerCaseKey = key.toLowerCase().replace(/[-_]/g, '');
-    const normalizedKey = optionMappings[lowerCaseKey] ? optionMappings[lowerCaseKey] : key;
+    const normalizedKey = OPTION_MAPPINGS[lowerCaseKey] ? OPTION_MAPPINGS[lowerCaseKey] : key;
     normalizedOptions[normalizedKey] = options[key];
   }
 

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -166,22 +166,22 @@ function getSnapshotOptions(options, { config, meta }) {
   });
 }
 const optionMappings = {
-    'name': 'name',
-    'widths': 'widths',
-    'scope': 'scope',
-    'scopeoptions': 'scopeOptions',
-    'minheight': 'minHeight',
-    'enablejavascript': 'enableJavaScript',
-    'enablelayout': 'enableLayout',
-    'clientinfo': 'clientInfo',
-    'environmentinfo': 'environmentInfo',
-    'sync': 'sync',
-    'testcase': 'testCase',
-    'labels': 'labels',
-    'thtestcaseexecutionid': 'thTestCaseExecutionId',
-    'resources': 'resources',
-    'meta': 'meta',
-    'snapshot': 'snapshot',
+  name: 'name',
+  widths: 'widths',
+  scope: 'scope',
+  scopeoptions: 'scopeOptions',
+  minheight: 'minHeight',
+  enablejavascript: 'enableJavaScript',
+  enablelayout: 'enableLayout',
+  clientinfo: 'clientInfo',
+  environmentinfo: 'environmentInfo',
+  sync: 'sync',
+  testcase: 'testCase',
+  labels: 'labels',
+  thtestcaseexecutionid: 'thTestCaseExecutionId',
+  resources: 'resources',
+  meta: 'meta',
+  snapshot: 'snapshot'
 };
 
 function normalizeOptions(options) {

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -165,13 +165,41 @@ function getSnapshotOptions(options, { config, meta }) {
     }
   });
 }
+const optionMappings = {
+    'name': 'name',
+    'widths': 'widths',
+    'scope': 'scope',
+    'scopeoptions': 'scopeOptions',
+    'minheight': 'minHeight',
+    'enablejavascript': 'enableJavaScript',
+    'enablelayout': 'enableLayout',
+    'clientinfo': 'clientInfo',
+    'environmentinfo': 'environmentInfo',
+    'sync': 'sync',
+    'testcase': 'testCase',
+    'labels': 'labels',
+    'thtestcaseexecutionid': 'thTestCaseExecutionId',
+    'resources': 'resources',
+    'meta': 'meta',
+    'snapshot': 'snapshot',
+};
 
+function normalizeOptions(options) {
+  const normalizedOptions = {};
+
+  for (const key in options) {
+    const lowerCaseKey = key.toLowerCase().replace(/[-_]/g, '');
+    const normalizedKey = optionMappings[lowerCaseKey] ? optionMappings[lowerCaseKey] : key;
+    normalizedOptions[normalizedKey] = options[key];
+  }
+
+  return normalizedOptions;
+}
 // Validates and migrates snapshot options against the correct schema based on provided
 // properties. Eagerly throws an error when missing a URL for any snapshot, and warns about all
 // other invalid options which are also scrubbed from the returned migrated options.
 export function validateSnapshotOptions(options) {
   let log = logger('core:snapshot');
-
   // decide which schema to validate against
   let schema = (
     (['domSnapshot', 'dom-snapshot', 'dom_snapshot']
@@ -181,6 +209,8 @@ export function validateSnapshotOptions(options) {
     ('serve' in options && '/snapshot/server') ||
     ('snapshots' in options && '/snapshot/list') ||
     ('/snapshot'));
+
+  options = normalizeOptions(options);
 
   let {
     // normalize, migrate, and remove certain properties from validating
@@ -213,10 +243,8 @@ export function validateSnapshotOptions(options) {
     log.warn('Encountered snapshot serialization warnings:');
     for (let w of domWarnings) log.warn(`- ${w}`);
   }
-
   // warn on validation errors
   let errors = PercyConfig.validate(migrated, schema);
-
   if (errors?.length > 0) {
     log.warn('Invalid snapshot options:');
     for (let e of errors) log.warn(`- ${e.path}: ${e.message}`);

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -9,7 +9,8 @@ import {
   yieldTo,
   snapshotLogName,
   decodeAndEncodeURLWithLogging,
-  compareObjectTypes
+  compareObjectTypes,
+  normalizeOptions
 } from './utils.js';
 import { JobData } from './wait-for-job.js';
 
@@ -165,36 +166,7 @@ function getSnapshotOptions(options, { config, meta }) {
     }
   });
 }
-const OPTION_MAPPINGS = {
-  name: 'name',
-  widths: 'widths',
-  scope: 'scope',
-  scopeoptions: 'scopeOptions',
-  minheight: 'minHeight',
-  enablejavascript: 'enableJavaScript',
-  enablelayout: 'enableLayout',
-  clientinfo: 'clientInfo',
-  environmentinfo: 'environmentInfo',
-  sync: 'sync',
-  testcase: 'testCase',
-  labels: 'labels',
-  thtestcaseexecutionid: 'thTestCaseExecutionId',
-  resources: 'resources',
-  meta: 'meta',
-  snapshot: 'snapshot'
-};
 
-function normalizeOptions(options) {
-  const normalizedOptions = {};
-
-  for (const key in options) {
-    const lowerCaseKey = key.toLowerCase().replace(/[-_]/g, '');
-    const normalizedKey = OPTION_MAPPINGS[lowerCaseKey] ? OPTION_MAPPINGS[lowerCaseKey] : key;
-    normalizedOptions[normalizedKey] = options[key];
-  }
-
-  return normalizedOptions;
-}
 // Validates and migrates snapshot options against the correct schema based on provided
 // properties. Eagerly throws an error when missing a URL for any snapshot, and warns about all
 // other invalid options which are also scrubbed from the returned migrated options.

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -543,3 +543,34 @@ export function compareObjectTypes(obj1, obj2) {
 
   return true;
 }
+
+const OPTION_MAPPINGS = {
+  name: 'name',
+  widths: 'widths',
+  scope: 'scope',
+  scopeoptions: 'scopeOptions',
+  minheight: 'minHeight',
+  enablejavascript: 'enableJavaScript',
+  enablelayout: 'enableLayout',
+  clientinfo: 'clientInfo',
+  environmentinfo: 'environmentInfo',
+  sync: 'sync',
+  testcase: 'testCase',
+  labels: 'labels',
+  thtestcaseexecutionid: 'thTestCaseExecutionId',
+  resources: 'resources',
+  meta: 'meta',
+  snapshot: 'snapshot'
+};
+
+export function normalizeOptions(options) {
+  const normalizedOptions = {};
+
+  for (const key in options) {
+    const lowerCaseKey = key.toLowerCase().replace(/[-_]/g, '');
+    const normalizedKey = OPTION_MAPPINGS[lowerCaseKey] ? OPTION_MAPPINGS[lowerCaseKey] : key;
+    normalizedOptions[normalizedKey] = options[key];
+  }
+
+  return normalizedOptions;
+}

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -1725,7 +1725,7 @@ describe('Percy', () => {
         'client-info': 'client-info',
         'environment-info': 'env-info',
         'test-case': 'testCase',
-        'th-test-case-execution-id': '12345',
+        'th-test-case-execution-id': '12345'
       };
 
       const result = validateSnapshotOptions(options);
@@ -1738,7 +1738,7 @@ describe('Percy', () => {
         minHeight: 1024,
         enableJavaScript: true,
         testCase: 'testCase',
-        thTestCaseExecutionId: '12345',
+        thTestCaseExecutionId: '12345'
       });
     });
 
@@ -1757,7 +1757,7 @@ describe('Percy', () => {
         Sync: true,
         TestCase: 'testCase',
         Labels: 'label1',
-        ThTestCaseExecutionId: '12345',
+        ThTestCaseExecutionId: '12345'
       };
 
       const result = validateSnapshotOptions(options);
@@ -1775,7 +1775,7 @@ describe('Percy', () => {
         sync: true,
         testCase: 'testCase',
         labels: 'label1',
-        thTestCaseExecutionId: '12345',
+        thTestCaseExecutionId: '12345'
       });
     });
 
@@ -1794,7 +1794,7 @@ describe('Percy', () => {
         sYnC: true,
         tEsTcAsE: 'testCase',
         lAbElS: 'label1',
-        tHtEsTcAsEeXeCuTiOnId: '12345',
+        tHtEsTcAsEeXeCuTiOnId: '12345'
       };
 
       const result = validateSnapshotOptions(options);
@@ -1812,7 +1812,7 @@ describe('Percy', () => {
         sync: true,
         testCase: 'testCase',
         labels: 'label1',
-        thTestCaseExecutionId: '12345',
+        thTestCaseExecutionId: '12345'
       });
     });
   });


### PR DESCRIPTION
Have added a normalization function in validateSnaphotOptions to convert any type of casing of options to camecase making them case-insensitive.

Example: 

If a user provides options as:
```
  options = {
          nAmE: 'Snapshot 1',
          url: 'http://localhost:8000',
          WiDtHs: [375, 1280],
          sCoPe: '#app',
          sCoPeOpTiOnS: { scroll: true },
          mInHeIgHt: 1024,
          eNaBlEJaVaScRiPt: true,
          eNaBlELaYoUt: false,
          cLiEnTInFo: 'client-info',
          eNvIrOnMeNtInFo: 'env-info',
          sYnC: true,
          tEsTcAsE: 'testCase',
          lAbElS: 'label1',
          tHtEsTcAsEeXeCuTiOnId: '12345'
        }
```

These will be converted to:
```
 options = {
        clientInfo: 'client-info',
        environmentInfo: 'env-info',
        name: 'Snapshot 1',
        url: 'http://localhost:8000',
        widths: [375, 1280],
        scope: '#app',
        scopeOptions: { scroll: true },
        minHeight: 1024,
        enableJavaScript: true,
        enableLayout: false,
        sync: true,
        testCase: 'testCase',
        labels: 'label1',
        thTestCaseExecutionId: '12345'
      }
```