### PR TITLE
PVS-158 Logging discovery and snapshot queue sizes

### DIFF
--- a/packages/core/src/queue.js
+++ b/packages/core/src/queue.js
@@ -99,8 +99,17 @@ export class Queue {
     return task.deferred;
   }
 
+  logQueueSize() {
+    this.log.debug(`${this.name} queueInfo: ${JSON.stringify({
+      queued: this.#queued.size,
+      pending: this.#pending.size,
+      total: this.#pending.size + this.#queued.size,
+    })}`);
+  }
+
   // Maybe processes the next queued item task.
   #dequeue() {
+    this.logQueueSize();
     if (!this.#queued.size || this.readyState < 2) return;
     if (this.#pending.size >= this.concurrency) return;
     let [task] = this.#queued;


### PR DESCRIPTION
Logging discovery and snapshot queue sizes.
Logging - queue, pending and Total queue sizes for both discovery and snapshot.
-> It will be logged when #dequeue is called.
-> That way queue sizes will be logged when push is called as well as run is called on the Queue.