### PR TITLE
added support for regions for SDKs

### DIFF
--- a/packages/cli-upload/test/upload.test.js
+++ b/packages/cli-upload/test/upload.test.js
@@ -94,6 +94,7 @@ describe('percy upload', () => {
           'scope-options': {},
           'minimum-height': 10,
           'enable-javascript': null,
+          regions: null,
           'enable-layout': false,
           'th-test-case-execution-id': null
         },

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -32,6 +32,15 @@ function validateId(type, id) {
   }
 }
 
+function ensureElementSelector(regions) {
+  if (!Array.isArray(regions)) return null;
+
+  return regions.map(region => ({
+    ...region,
+    elementSelector: region.elementSelector || { fullPage: true }
+  }));
+}
+
 // Validate project path arguments
 function validateProjectPath(path) {
   if (!path) throw new Error('Missing project path');
@@ -416,6 +425,7 @@ export class PercyClient {
     }
 
     let tagsArr = tagsList(labels);
+    let regionsArr = ensureElementSelector(regions);
 
     this.log.debug(`Validating resources: ${name}...`, meta);
     for (let resource of resources) {
@@ -436,7 +446,7 @@ export class PercyClient {
           'test-case': testCase || null,
           tags: tagsArr,
           'scope-options': scopeOptions || {},
-          regions: regions || null,
+          regions: regionsArr || null,
           'minimum-height': minHeight || null,
           'enable-javascript': enableJavaScript || null,
           'enable-layout': enableLayout || false,
@@ -505,6 +515,7 @@ export class PercyClient {
         tile.content = await fs.promises.readFile(tile.filepath);
       }
     }
+    let regionsArr = ensureElementSelector(regions);
     this.log.debug(`${tiles.length} tiles for comparision: ${tag.name}...`, meta);
 
     return this.post(`snapshots/${snapshotId}/comparisons`, {
@@ -513,7 +524,7 @@ export class PercyClient {
         attributes: {
           'external-debug-url': externalDebugUrl || null,
           'ignore-elements-data': ignoredElementsData || null,
-          regions: regions || null,
+          regions: regionsArr || null,
           'consider-elements-data': consideredElementsData || null,
           'dom-info-sha': domInfoSha || null,
           sync: !!sync,

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -37,7 +37,7 @@ function ensureElementSelector(regions) {
 
   return regions.map(region => ({
     ...region,
-    elementSelector: region.elementSelector || { fullPage: true }
+    elementSelector: region.elementSelector || { fullpage: true }
   }));
 }
 

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -436,7 +436,7 @@ export class PercyClient {
           'test-case': testCase || null,
           tags: tagsArr,
           'scope-options': scopeOptions || {},
-          'regions': regions || null,
+          regions: regions || null,
           'minimum-height': minHeight || null,
           'enable-javascript': enableJavaScript || null,
           'enable-layout': enableLayout || false,
@@ -513,7 +513,7 @@ export class PercyClient {
         attributes: {
           'external-debug-url': externalDebugUrl || null,
           'ignore-elements-data': ignoredElementsData || null,
-          'regions': regions || null,
+          regions: regions || null,
           'consider-elements-data': consideredElementsData || null,
           'dom-info-sha': domInfoSha || null,
           sync: !!sync,

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -403,6 +403,7 @@ export class PercyClient {
     testCase,
     labels,
     thTestCaseExecutionId,
+    regions,
     resources = [],
     meta
   } = {}) {
@@ -435,6 +436,7 @@ export class PercyClient {
           'test-case': testCase || null,
           tags: tagsArr,
           'scope-options': scopeOptions || {},
+          'regions': regions || null,
           'minimum-height': minHeight || null,
           'enable-javascript': enableJavaScript || null,
           'enable-layout': enableLayout || false,
@@ -488,7 +490,7 @@ export class PercyClient {
 
   async createComparison(snapshotId, {
     tag, tiles = [], externalDebugUrl, ignoredElementsData,
-    domInfoSha, consideredElementsData, metadata, sync, meta = {}
+    domInfoSha, consideredElementsData, metadata, regions, sync, meta = {}
   } = {}) {
     validateId('snapshot', snapshotId);
     // Remove post percy api deploy
@@ -511,6 +513,7 @@ export class PercyClient {
         attributes: {
           'external-debug-url': externalDebugUrl || null,
           'ignore-elements-data': ignoredElementsData || null,
+          'regions': regions || null,
           'consider-elements-data': consideredElementsData || null,
           'dom-info-sha': domInfoSha || null,
           sync: !!sync,

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -490,7 +490,7 @@ export class PercyClient {
 
   async createComparison(snapshotId, {
     tag, tiles = [], externalDebugUrl, ignoredElementsData,
-    domInfoSha, consideredElementsData, metadata, regions, sync, meta = {}
+    domInfoSha, consideredElementsData, metadata, sync, regions, meta = {}
   } = {}) {
     validateId('snapshot', snapshotId);
     // Remove post percy api deploy

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -849,7 +849,7 @@ describe('PercyClient', () => {
         scopeOptions: { scroll: true },
         minHeight: 1000,
         enableJavaScript: true,
-        regions: { elementSelector: { elementCSS: '#test' }, algorithm: 'ignore' },
+        regions: [{ elementSelector: { elementCSS: '#test' }, algorithm: 'ignore' }],
         enableLayout: true,
         clientInfo: 'sdk/info',
         environmentInfo: 'sdk/env',
@@ -882,7 +882,7 @@ describe('PercyClient', () => {
             name: 'snapfoo',
             widths: [1000],
             scope: '#main',
-            regions: { elementSelector: { elementCSS: '#test' }, algorithm: 'ignore' },
+            regions: [{ elementSelector: { elementCSS: '#test' }, algorithm: 'ignore' }],
             sync: true,
             'test-case': 'foo test case',
             tags: [{ id: null, name: 'tag 1' }, { id: null, name: 'tag 2' }],
@@ -1147,7 +1147,7 @@ describe('PercyClient', () => {
         ignoredElementsData: ignoredElementsData,
         consideredElementsData: consideredElementsData,
         domInfoSha: 'abcd=',
-        regions: { elementSelector: { elementCSS: '#test' }, algorithm: 'layout' },
+        regions: [{ algorithm: 'layout' }],
         metadata: {
           windowHeight: 1947,
           screenshotType: 'singlepage'
@@ -1162,7 +1162,7 @@ describe('PercyClient', () => {
             'ignore-elements-data': ignoredElementsData,
             'consider-elements-data': consideredElementsData,
             'dom-info-sha': 'abcd=',
-            regions: { elementSelector: { elementCSS: '#test' }, algorithm: 'layout' },
+            regions: [{ elementSelector: { fullPage: true }, algorithm: 'layout' }],
             sync: true,
             metadata: {
               windowHeight: 1947,

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -1162,7 +1162,7 @@ describe('PercyClient', () => {
             'ignore-elements-data': ignoredElementsData,
             'consider-elements-data': consideredElementsData,
             'dom-info-sha': 'abcd=',
-            regions: [{ elementSelector: { fullPage: true }, algorithm: 'layout' }],
+            regions: [{ elementSelector: { fullpage: true }, algorithm: 'layout' }],
             sync: true,
             metadata: {
               windowHeight: 1947,

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -849,6 +849,7 @@ describe('PercyClient', () => {
         scopeOptions: { scroll: true },
         minHeight: 1000,
         enableJavaScript: true,
+        regions: { elementSelector: { elementCSS: '#test' }, algorithm: 'ignore' },
         enableLayout: true,
         clientInfo: 'sdk/info',
         environmentInfo: 'sdk/env',
@@ -881,6 +882,7 @@ describe('PercyClient', () => {
             name: 'snapfoo',
             widths: [1000],
             scope: '#main',
+            regions: { elementSelector: { elementCSS: '#test' }, algorithm: 'ignore' },
             sync: true,
             'test-case': 'foo test case',
             tags: [{ id: null, name: 'tag 1' }, { id: null, name: 'tag 2' }],
@@ -936,6 +938,7 @@ describe('PercyClient', () => {
             'minimum-height': null,
             'enable-javascript': null,
             'enable-layout': false,
+            regions: null,
             'th-test-case-execution-id': null
           },
           relationships: {
@@ -1006,6 +1009,7 @@ describe('PercyClient', () => {
             'enable-javascript': null,
             'minimum-height': null,
             widths: null,
+            regions: null,
             'enable-layout': false,
             'th-test-case-execution-id': null
           },
@@ -1143,6 +1147,7 @@ describe('PercyClient', () => {
         ignoredElementsData: ignoredElementsData,
         consideredElementsData: consideredElementsData,
         domInfoSha: 'abcd=',
+        regions: { elementSelector: { elementCSS: '#test' }, algorithm: 'layout' },
         metadata: {
           windowHeight: 1947,
           screenshotType: 'singlepage'
@@ -1157,6 +1162,7 @@ describe('PercyClient', () => {
             'ignore-elements-data': ignoredElementsData,
             'consider-elements-data': consideredElementsData,
             'dom-info-sha': 'abcd=',
+            regions: { elementSelector: { elementCSS: '#test' }, algorithm: 'layout' },
             sync: true,
             metadata: {
               windowHeight: 1947,
@@ -1232,6 +1238,7 @@ describe('PercyClient', () => {
             'consider-elements-data': null,
             'dom-info-sha': null,
             sync: false,
+            regions: null,
             metadata: null
           },
           relationships: {
@@ -1529,6 +1536,7 @@ describe('PercyClient', () => {
               'minimum-height': null,
               widths: null,
               sync: false,
+              regions: null,
               'enable-layout': false,
               'th-test-case-execution-id': null
             },
@@ -1551,6 +1559,7 @@ describe('PercyClient', () => {
               'consider-elements-data': null,
               'dom-info-sha': null,
               sync: false,
+              regions: null,
               metadata: null
             },
             relationships: {

--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -255,6 +255,16 @@ export function validate(data, key = '/config') {
           });
           delete data.regions[index];
         }
+      } else {
+        if (region.algorithm === 'ignore') {
+          const pathStr = `regions[${index}].elementSelector`;
+          errors.set(pathStr, {
+            path: pathStr,
+            message: "'elementSelector' is required when algorithm is 'ignore'."
+          });
+
+          delete data.regions[index];
+        }
       }
 
       const algorithmType = region.algorithm;

--- a/packages/config/src/validate.js
+++ b/packages/config/src/validate.js
@@ -183,8 +183,9 @@ function shouldHideError(key, path, error) {
 
 // Validates data according to the associated schema and returns a list of errors, if any.
 export function validate(data, key = '/config') {
+  let errors = new Map();
+
   if (!ajv.validate(key, data)) {
-    let errors = new Map();
 
     for (let error of ajv.errors) {
       let { instancePath, parentSchema, keyword, message, params } = error;
@@ -236,13 +237,55 @@ export function validate(data, key = '/config') {
       // map one error per path
       errors.set(path, { path, message });
     }
-
-    // filter empty values as a result of scrubbing
-    filterEmpty(data);
-
-    // return an array of errors
-    return Array.from(errors.values());
   }
+
+  if (data.regions && Array.isArray(data.regions)) {
+    data.regions.forEach((region, index) => {
+      if (region.elementSelector) {
+        const selectorKeys = ['elementCSS', 'elementXpath', 'boundingBox'];
+        const providedKeys = selectorKeys.filter(key => region.elementSelector[key] !== undefined);
+        
+        if (providedKeys.length !== 1) {
+          const pathStr = `regions[${index}].elementSelector`;
+          errors.set(pathStr, {
+            path: pathStr,
+            message: "Exactly one of 'elementCSS', 'elementXpath', or 'boundingBox' must be provided."
+          });
+          delete data.regions[index];
+        }
+      }
+
+      const algorithmType = region.algorithm;
+      const hasConfiguration = region.configuration !== undefined;
+      
+      if (algorithmType === 'layout' || algorithmType === 'ignore') {
+        if (hasConfiguration) {
+          const pathStr = `regions[${index}].configuration`;
+          errors.set(pathStr, {
+            path: pathStr,
+            message: `Configuration is not applicable for '${algorithmType}' algorithm`
+          });
+          
+          delete data.regions[index];
+        }
+      }
+      
+      if ((algorithmType === 'standard' || algorithmType === 'intelliignore') && !hasConfiguration) {
+        const pathStr = `regions[${index}]`;
+        errors.set(pathStr, {
+          path: pathStr,
+          message: `Configuration is recommended for '${algorithmType}' algorithm`
+        });
+      }
+
+    });
+  }
+
+  // filter empty values as a result of scrubbing
+  filterEmpty(data);
+
+  // return an array of errors
+  return Array.from(errors.values());
 }
 
 export default validate;

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -667,10 +667,10 @@ describe('PercyConfig', () => {
                   type: 'object',
                   additionalProperties: false,
                   properties: {
-                    top: { type: 'string', pattern: '^\\d+px$' },
-                    bottom: { type: 'string', pattern: '^\\d+px$' },
-                    left: { type: 'string', pattern: '^\\d+px$' },
-                    right: { type: 'string', pattern: '^\\d+px$' }
+                    top: { type: 'integer' },
+                    bottom: { type: 'integer' },
+                    left: { type: 'integer' },
+                    right: { type: 'integer' }
                   }
                 },
                 algorithm: {

--- a/packages/config/test/index.test.js
+++ b/packages/config/test/index.test.js
@@ -696,7 +696,7 @@ describe('PercyConfig', () => {
                   }
                 }
               },
-              required: ['algorithm', 'elementSelector']
+              required: ['algorithm']
             }
           }
         });
@@ -720,11 +720,17 @@ describe('PercyConfig', () => {
 
       it('validates missing elementSelector', () => {
         expect(PercyConfig.validate({
-          regions: [{ algorithm: 'standard' }]
+          regions: [{ algorithm: 'standard', configuration: { diffSensitivity: 2 } }]
+        })).toEqual(undefined);
+      });
+
+      it('validates algorithm missing elementSelector', () => {
+        expect(PercyConfig.validate({
+          regions: [{ algorithm: 'ignore' }]
         })).toEqual([
           {
             path: 'regions[0].elementSelector',
-            message: 'missing required property'
+            message: "'elementSelector' is required when algorithm is 'ignore'."
           }
         ]);
       });

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -220,7 +220,7 @@ export const configSchema = {
               }
             }
           },
-          required: ['algorithm', 'elementSelector']
+          required: ['algorithm']
         }
       }
     }

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -191,10 +191,10 @@ export const configSchema = {
               type: 'object',
               additionalProperties: false,
               properties: {
-                top: { type: 'string', pattern: '^\\d+px$' },
-                bottom: { type: 'string', pattern: '^\\d+px$' },
-                left: { type: 'string', pattern: '^\\d+px$' },
-                right: { type: 'string', pattern: '^\\d+px$' }
+                top: { type: 'integer' },
+                bottom: { type: 'integer' },
+                left: { type: 'integer' },
+                right: { type: 'integer' }
               }
             },
             algorithm: {

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -163,9 +163,68 @@ export const configSchema = {
             }
           }
         }
+      },
+        regions: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              elementSelector: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  boundingBox: {
+                    type: 'object',
+                    additionalProperties: false,
+                    properties: {
+                      x: { type: 'integer' },
+                      y: { type: 'integer' },
+                      width: { type: 'integer' },
+                      height: { type: 'integer' }
+                    }
+                  },
+                  elementXpath: { type: 'string' },
+                  elementCSS: { type: 'string' }
+                }
+              },
+              padding: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  top: { type: 'string', pattern: '^\\d+px$' },
+                  bottom: { type: 'string', pattern: '^\\d+px$' },
+                  left: { type: 'string', pattern: '^\\d+px$' },
+                  right: { type: 'string', pattern: '^\\d+px$' }
+                }
+              },
+              algorithm: {
+                type: 'string',
+                enum: ['standard', 'layout', 'ignore', 'intelliignore']
+              },
+              configuration: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  diffSensitivity: { type: "integer", minimum: 0 }, 
+                  imageIgnoreThreshold: { type: "number", minimum: 0, maximum: 1 },
+                  carouselsEnabled: { type: "boolean" },
+                  bannersEnabled: { type: "boolean" },
+                  adsEnabled: { type: "boolean" }
+                }
+              },
+              assertion: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  diffIgnoreThreshold: { type: 'number', minimum: 0, maximum: 1 }
+                }
+              }
+            },
+            required: ['algorithm', 'elementSelector']
+          }
+        }
       }
-    }
-  },
+    },
   discovery: {
     type: 'object',
     additionalProperties: false,
@@ -308,6 +367,7 @@ export const snapshotSchema = {
         labels: { $ref: '/config/snapshot#/properties/labels' },
         thTestCaseExecutionId: { $ref: '/config/snapshot#/properties/thTestCaseExecutionId' },
         reshuffleInvalidTags: { $ref: '/config/snapshot#/properties/reshuffleInvalidTags' },
+        regions: { $ref: '/config/snapshot#/properties/regions' },
         scopeOptions: { $ref: '/config/snapshot#/properties/scopeOptions' },
         discovery: {
           type: 'object',
@@ -692,6 +752,7 @@ export const comparisonSchema = {
         ignoreElementsData: regionsSchema
       }
     },
+    regions: { $ref: '/config/snapshot#/properties/regions' },
     consideredElementsData: {
       type: 'object',
       additionalProperties: false,

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -164,67 +164,67 @@ export const configSchema = {
           }
         }
       },
-        regions: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              elementSelector: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  boundingBox: {
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                      x: { type: 'integer' },
-                      y: { type: 'integer' },
-                      width: { type: 'integer' },
-                      height: { type: 'integer' }
-                    }
-                  },
-                  elementXpath: { type: 'string' },
-                  elementCSS: { type: 'string' }
-                }
-              },
-              padding: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  top: { type: 'string', pattern: '^\\d+px$' },
-                  bottom: { type: 'string', pattern: '^\\d+px$' },
-                  left: { type: 'string', pattern: '^\\d+px$' },
-                  right: { type: 'string', pattern: '^\\d+px$' }
-                }
-              },
-              algorithm: {
-                type: 'string',
-                enum: ['standard', 'layout', 'ignore', 'intelliignore']
-              },
-              configuration: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  diffSensitivity: { type: "integer", minimum: 0 }, 
-                  imageIgnoreThreshold: { type: "number", minimum: 0, maximum: 1 },
-                  carouselsEnabled: { type: "boolean" },
-                  bannersEnabled: { type: "boolean" },
-                  adsEnabled: { type: "boolean" }
-                }
-              },
-              assertion: {
-                type: 'object',
-                additionalProperties: false,
-                properties: {
-                  diffIgnoreThreshold: { type: 'number', minimum: 0, maximum: 1 }
-                }
+      regions: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            elementSelector: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                boundingBox: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: {
+                    x: { type: 'integer' },
+                    y: { type: 'integer' },
+                    width: { type: 'integer' },
+                    height: { type: 'integer' }
+                  }
+                },
+                elementXpath: { type: 'string' },
+                elementCSS: { type: 'string' }
               }
             },
-            required: ['algorithm', 'elementSelector']
-          }
+            padding: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                top: { type: 'string', pattern: '^\\d+px$' },
+                bottom: { type: 'string', pattern: '^\\d+px$' },
+                left: { type: 'string', pattern: '^\\d+px$' },
+                right: { type: 'string', pattern: '^\\d+px$' }
+              }
+            },
+            algorithm: {
+              type: 'string',
+              enum: ['standard', 'layout', 'ignore', 'intelliignore']
+            },
+            configuration: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                diffSensitivity: { type: 'integer', minimum: 0 },
+                imageIgnoreThreshold: { type: 'number', minimum: 0, maximum: 1 },
+                carouselsEnabled: { type: 'boolean' },
+                bannersEnabled: { type: 'boolean' },
+                adsEnabled: { type: 'boolean' }
+              }
+            },
+            assertion: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                diffIgnoreThreshold: { type: 'number', minimum: 0, maximum: 1 }
+              }
+            }
+          },
+          required: ['algorithm', 'elementSelector']
         }
       }
-    },
+    }
+  },
   discovery: {
     type: 'object',
     additionalProperties: false,

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -56,6 +56,7 @@ export function percyAutomateRequestHandler(req, percy) {
     ignoreRegionXpaths: percy.config.snapshot.ignoreRegions?.ignoreRegionXpaths,
     considerRegionSelectors: percy.config.snapshot.considerRegions?.considerRegionSelectors,
     considerRegionXpaths: percy.config.snapshot.considerRegions?.considerRegionXpaths,
+    regions: percy.config.snapshot.regions,
     sync: percy.config.snapshot.sync,
     version: 'v2'
   },

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -187,6 +187,7 @@ export default class GenericProvider {
       consideredElementsData: {
         considerElementsData: considerRegions
       },
+      regions: options.regions,
       environmentInfo: this.getUserAgentString(this.environmentInfoDetails),
       clientInfo: this.getUserAgentString(this.clientInfoDetails),
       domInfoSha: tiles.domInfoSha,

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -187,7 +187,7 @@ export default class GenericProvider {
       consideredElementsData: {
         considerElementsData: considerRegions
       },
-      regions: options.regions,
+      regions: this.options.regions || null,
       environmentInfo: this.getUserAgentString(this.environmentInfoDetails),
       clientInfo: this.getUserAgentString(this.clientInfoDetails),
       domInfoSha: tiles.domInfoSha,

--- a/packages/webdriver-utils/src/providers/playwrightProvider.js
+++ b/packages/webdriver-utils/src/providers/playwrightProvider.js
@@ -66,6 +66,7 @@ export default class PlaywrightProvider extends GenericProvider {
         consideredElementsData: {
           considerElementsData: tiles.considerRegionsData
         },
+        regions: options.regions,
         environmentInfo: this.environmentInfo,
         clientInfo: this.clientInfo,
         domInfoSha: tiles.domInfoSha,

--- a/packages/webdriver-utils/src/providers/playwrightProvider.js
+++ b/packages/webdriver-utils/src/providers/playwrightProvider.js
@@ -66,7 +66,7 @@ export default class PlaywrightProvider extends GenericProvider {
         consideredElementsData: {
           considerElementsData: tiles.considerRegionsData
         },
-        regions: options.regions,
+        regions: options.regions || null,
         environmentInfo: this.environmentInfo,
         clientInfo: this.clientInfo,
         domInfoSha: tiles.domInfoSha,

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -120,6 +120,7 @@ describe('GenericProvider', () => {
           consideredElementsData: { considerElementsData: [] },
           clientInfo: 'local-poc-poa',
           domInfoSha: 'mock-dom-sha',
+          regions: null,
           metadata: null
         });
       });
@@ -178,6 +179,7 @@ describe('GenericProvider', () => {
           consideredElementsData: { considerElementsData: [] },
           clientInfo: 'local-poc-poa',
           domInfoSha: 'mock-dom-sha',
+          regions: null,
           metadata: null
         });
       });

--- a/packages/webdriver-utils/test/providers/playwrightProvider.test.js
+++ b/packages/webdriver-utils/test/providers/playwrightProvider.test.js
@@ -136,6 +136,7 @@ describe('PlaywrightProvider', () => {
         environmentInfo: 'environmentInfo',
         clientInfo: 'clientInfo',
         domInfoSha: 'domInfoSha',
+        regions: null,
         metadata: null
       });
     });


### PR DESCRIPTION
added support for regions

```const obj1 = {
  elementSelector: {
    boundingBox: { x: 100, y: 150, width: 300, height: 200 },
    elementXpath: "/html/body/div[1]/div[1]/header/div[2]/nav/ul/li[1]/a",
    elementCSS: ".ad-banner"     -> only one of them and mandatory
  }
  padding: {
    top: 10,
    left: 20,
    right: 15,
    bottom: 10
  }
  algorithm: "intelliignore",  -> mandatory, it can be standard, layout, ignore, intelliignore
  configuration: {  for layout, ignore nothing is required
    diffSensitivity: 2,  // these all are applicable for standard and intellignore
    imageIgnoreThreshold: 0.2,
    carouselsEnabled: true
    bannersEnabled: true 
    adsEnabled: true
  },
   assertion: {
    diffIgnoreThreshold: 0.4,
    }
};

percy.snapshot("Homepage", regions:[obj1, obj2, ..]);
```
also added validations 