### PR TITLE
Recreating custom element and not cloning them directly as it causes attributeCallback function to get triggered

### DIFF
--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -15,7 +15,12 @@ import { handleErrors } from './utils';
 
 const ignoreTags = ['NOSCRIPT'];
 
-function cloneCustomElementWithoutAttributeChanged(element) {
+/**
+ * if a custom element has attribute callback then cloneNode calls a callback that can
+ * increase CPU load or some other change.
+ * So we want to make sure that it is not called when doing serialization.
+*/
+function cloneElementWithoutLifecycle(element) {
   if (!(element.attributeChangedCallback) || !element.tagName.includes('-')) {
     return element.cloneNode(); // Standard clone for non-custom elements
   }
@@ -52,7 +57,7 @@ export function cloneNodeAndShadow(ctx) {
       // mark the node before cloning
       markElement(node, disableShadowDOM);
 
-      let clone = cloneCustomElementWithoutAttributeChanged(node);
+      let clone = cloneElementWithoutLifecycle(node);
       // let clone = node.cloneNode();
 
       // Handle <style> tag specifically for media queries

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -52,9 +52,6 @@ export function cloneNodeAndShadow(ctx) {
       // mark the node before cloning
       markElement(node, disableShadowDOM);
 
-      if (node.attributeChangedCallback) {
-        console.log('there are attributeChangedCallback here');
-      }
       let clone = cloneCustomElementWithoutAttributeChanged(node);
       // let clone = node.cloneNode();
 

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -58,7 +58,6 @@ export function cloneNodeAndShadow(ctx) {
       markElement(node, disableShadowDOM);
 
       let clone = cloneElementWithoutLifecycle(node);
-      // let clone = node.cloneNode();
 
       // Handle <style> tag specifically for media queries
       if (node.nodeName === 'STYLE' && !enableJavaScript) {

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -89,7 +89,8 @@ export function cloneNodeAndShadow(ctx) {
 
       // shallow clone should not contain children
       if (clone.children) {
-        Array.from(clone.children).forEach(child => clone.removeChild(child));
+        /* istanbul ignore next */
+        Array.from(clone.children).forEach((child) => clone.removeChild(child));
       }
 
       // clone shadow DOM

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -25,6 +25,7 @@ function doctype(dom) {
 function serializeHTML(ctx) {
   let html = getOuterHTML(ctx.clone.documentElement, { shadowRootElements: ctx.shadowRootElements });
   // replace serialized data attributes with real attributes
+  html = html.replace(/(<\/?)data-percy-custom-element-/g, '$1');
   html = html.replace(/ data-percy-serialized-attribute-(\w+?)=/ig, ' $1=');
   // include the doctype with the html string
   return doctype(ctx.dom) + html;

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -24,8 +24,9 @@ function doctype(dom) {
 // Serializes and returns the cloned DOM as an HTML string
 function serializeHTML(ctx) {
   let html = getOuterHTML(ctx.clone.documentElement, { shadowRootElements: ctx.shadowRootElements });
-  // replace serialized data attributes with real attributes
+  // this is replacing serialized data tag with real tag
   html = html.replace(/(<\/?)data-percy-custom-element-/g, '$1');
+  // replace serialized data attributes with real attributes
   html = html.replace(/ data-percy-serialized-attribute-(\w+?)=/ig, ' $1=');
   // include the doctype with the html string
   return doctype(ctx.dom) + html;

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -297,6 +297,42 @@ describe('serializeDOM', () => {
     });
   });
 
+  it('renders custom image elements with src attribute properly', () => {
+    if (getTestBrowser() !== chromeBrowser) {
+      return;
+    }
+
+    class CustomImage extends window.HTMLElement {
+      static get observedAttributes() {
+        return ['src'];
+      }
+
+      constructor() {
+        super();
+        this.img = document.createElement('img');
+        this.appendChild(this.img);
+      }
+
+      attributeChangedCallback(name, oldValue, newValue) {
+        if (name === 'src') {
+          this.img.src = newValue || '';
+        }
+      }
+    }
+
+    window.customElements.define('custom-image', CustomImage);
+
+    withExample(`
+      <custom-image src="https://example.com/test.jpg"></custom-image>
+    `, { withShadow: false });
+
+    const html = serializeDOM().html;
+
+    expect(html).toMatch(
+      /<custom-image[^>]*><img src="https:\/\/example\.com\/test\.jpg"><\/custom-image>/
+    );
+  });
+
   describe('with `domTransformation`', () => {
     beforeEach(() => {
       withExample('<span class="delete-me">Delete me</span>', { withShadow: false });


### PR DESCRIPTION
Recreating custom element and not cloning them directly as it causes attributeCallback function to get triggered

Issue ->
- When were were doing cloneNode on a custom element. If attributeCallback is defined on that custom element then it was getting triggered, which caused spike in cpu usage.
- We are now recreating the node and not cloning them.