### PR TITLE
Adding check for null body in serializeDOM

### DIFF
--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -122,7 +122,7 @@ export function serializeDOM(options) {
       let sibling = clonedBody.nextSibling;
       clonedBody.append(sibling);
     }
-  } else if (ctx.clone.body.nextSibling) {
+  } else if (ctx.clone.body?.nextSibling) {
     ctx.hints.add('DOM elements found outside </body>');
   }
 

--- a/packages/dom/test/helpers.js
+++ b/packages/dom/test/helpers.js
@@ -3,18 +3,23 @@ export const chromeBrowser = 'CHROME';
 export const firefoxBrowser = 'FIREFOX';
 
 // create and cleanup testing DOM
-export function withExample(html, options = { withShadow: true, withRestrictedShadow: false, invalidTagsOutsideBody: false }) {
+export function withExample(html, options = { withShadow: true, withRestrictedShadow: false, invalidTagsOutsideBody: false, withoutBody: false }) {
   let $test = document.getElementById('test');
   if ($test) $test.remove();
 
   let $testShadow = document.getElementById('test-shadow');
   if ($testShadow) $testShadow.remove();
 
-  $test = document.createElement('div');
-  $test.id = 'test';
-  $test.innerHTML = `<h1>Hello DOM testing</h1>${html}`;
-
-  document.body.appendChild($test);
+  if (options.withoutBody) {
+    // Create a DOM structure without a <body> tag
+    const $html = document.documentElement;
+    $html.innerHTML = `<title>Test</title>${html}`;
+  } else {
+    $test = document.createElement('div');
+    $test.id = 'test';
+    $test.innerHTML = `<h1>Hello DOM testing</h1>${html}`;
+    document.body.appendChild($test);
+  }
 
   if (options.withShadow) {
     $testShadow = document.createElement('div');

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -406,6 +406,19 @@ describe('serializeDOM', () => {
     });
   });
 
+  describe('when `ctx.clone.body` is null for about:blank pages', () => {
+    beforeEach(() => {
+      withExample('', { withoutBody: true });
+    });
+
+    it('does not add hints and does not throw an error', () => {
+      expect(() => {
+        const result = serializeDOM();
+        expect(result.hints).toEqual([]);
+      }).not.toThrow();
+    });
+  });
+
   describe('waitForResize', () => {
     it('updates window.resizeCount', async () => {
       waitForResize();


### PR DESCRIPTION
Added a check to prevent errors when ctx.clone.body is null, such as in about:blank pages. This ensures that accessing ctx.clone.body?.nextSibling doesn't throw, maintaining stability in edge cases where no <body> exists.
