### PR TITLE
Snakecase import fix

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,6 +33,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
+    "@percy/config": "1.31.1",
     "@percy/env": "1.31.1",
     "@percy/logger": "1.31.1",
     "pac-proxy-agent": "^7.0.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,7 +33,6 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.31.1",
     "@percy/env": "1.31.1",
     "@percy/logger": "1.31.1",
     "pac-proxy-agent": "^7.0.2",


### PR DESCRIPTION
Seeing import { snakecase } from '@Percy/config/utils'; error while running CLI, facing the same issue while trying to run support CLI.
added import dependency