### PR TITLE
✨ Enhance performance logging in snapshot and serialization processes

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -29,6 +29,15 @@ function debugSnapshotOptions(snapshot) {
   log.debug('---------', snapshot.meta);
   log.debug(`Received snapshot: ${snapshot.name}`, snapshot.meta);
 
+  // Check if domSnapshot contains serialization timing and log it
+  if (snapshot.domSnapshot) {
+    let domData = Array.isArray(snapshot.domSnapshot) ? snapshot.domSnapshot[0] : snapshot.domSnapshot;
+    if (domData && typeof domData === 'object' && domData.perfInfo) {
+      const perfInfo = domData.perfInfo;
+      log.debug(`- Snapshot performance info: ${JSON.stringify(perfInfo)}`, snapshot.meta);
+    }
+  }
+
   // will log debug info for an object property if its value is defined
   let debugProp = (obj, prop, format = String) => {
     let val = prop.split('.').reduce((o, k) => o?.[k], obj);

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -58,6 +58,7 @@ export function cloneNodeAndShadow(ctx) {
       markElement(node, disableShadowDOM);
 
       let clone = cloneElementWithoutLifecycle(node);
+      ctx.clonedNodeCount++;
 
       // Handle <style> tag specifically for media queries
       if (node.nodeName === 'STYLE' && !enableJavaScript) {

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -9,7 +9,8 @@ describe('serializeDOM', () => {
       userAgent: jasmine.any(String),
       warnings: jasmine.any(Array),
       resources: jasmine.any(Array),
-      hints: jasmine.any(Array)
+      hints: jasmine.any(Array),
+      perfInfo: jasmine.any(Object)
     });
   });
 
@@ -30,7 +31,7 @@ describe('serializeDOM', () => {
 
   it('optionally returns a stringified response', () => {
     expect(serializeDOM({ stringifyResponse: true }))
-      .toMatch('{"html":".*","cookies":".*","userAgent":".*","warnings":\\[\\],"resources":\\[\\],"hints":\\[\\]}');
+      .toMatch('{"html":".*","cookies":".*","userAgent":".*","warnings":\\[\\],"resources":\\[\\],"hints":\\[\\], "perfInfo":{.*}}');
   });
 
   it('always has a doctype', () => {


### PR DESCRIPTION
This pull request focuses on enhancing performance tracking and debugging capabilities in the DOM serialization process. Key changes include adding performance metrics to the serialized output, tracking the number of cloned nodes, and improving logging for snapshots. These updates aim to provide better insights into the performance and behavior of the DOM serialization process.

### Enhancements to performance tracking:

* [`packages/dom/src/serialize-dom.js`](diffhunk://#diff-9824ccc3183bab9098281b8ae310bcea8c81433684fc02806e735ed97c66fe3cR144-R164): Added performance timing to measure the duration of the DOM serialization process (`serializationTime`) and included it in the `perfInfo` object of the serialized output. The `perfInfo` object also tracks the number of cloned nodes (`clonedNodeCount`), the length of the final HTML (`finalHtmlLength`), and the number of resources (`resourceCount`). [[1]](diffhunk://#diff-9824ccc3183bab9098281b8ae310bcea8c81433684fc02806e735ed97c66fe3cR144-R164) [[2]](diffhunk://#diff-9824ccc3183bab9098281b8ae310bcea8c81433684fc02806e735ed97c66fe3cL99-R104) [[3]](diffhunk://#diff-9824ccc3183bab9098281b8ae310bcea8c81433684fc02806e735ed97c66fe3cR82-R84)

### Improvements to debugging:

* [`packages/core/src/discovery.js`](diffhunk://#diff-88351388dc614d2fe3f73c528d6807bb731d4bfba641f5a99d34e918d9b728b5R32-R40): Enhanced the `debugSnapshotOptions` function to log performance information (`perfInfo`) from the `domSnapshot` object, if available.

### Code updates for node cloning:

* [`packages/dom/src/clone-dom.js`](diffhunk://#diff-02067f8a8ffa312638a2a6525baaabf925e44fc81392b24fc9de58604100be75R61): Incremented a new `clonedNodeCount` property in the `ctx` object to track the number of cloned nodes during the DOM serialization process.

### Miscellaneous:

* [`packages/dom/src/serialize-dom.js`](diffhunk://#diff-9824ccc3183bab9098281b8ae310bcea8c81433684fc02806e735ed97c66fe3cR1): Added a global reference to the `performance` object to enable performance timing.