### PR TITLE
Serialize scroll location

### DIFF
--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -80,7 +80,7 @@ export function cloneNodeAndShadow(ctx) {
       }
 
       // We apply any element transformations here to avoid another treeWalk
-      applyElementTransformations(clone, node);
+      applyElementTransformations(node, clone);
 
       serializeBase64(clone, resources, cache);
 

--- a/packages/dom/src/transform-dom.js
+++ b/packages/dom/src/transform-dom.js
@@ -5,7 +5,7 @@ export function dropLoadingAttribute(domElement) {
   domElement.removeAttribute('loading');
 }
 
-export function serializeScrollState(clone, original) {
+export function serializeScrollState(original, clone) {
   if (!original || !clone) return;
 
   // Check and set scrollTop if it exists and has a value
@@ -20,9 +20,9 @@ export function serializeScrollState(clone, original) {
 }
 
 // All transformations that we need to apply for a successful discovery and stable render
-function applyElementTransformations(domElement, originalElement) {
+function applyElementTransformations(originalElement, domElement) {
   dropLoadingAttribute(domElement);
-  serializeScrollState(domElement, originalElement);
+  serializeScrollState(originalElement, domElement);
 }
 
 export default applyElementTransformations;

--- a/packages/dom/test/transform-dom.test.js
+++ b/packages/dom/test/transform-dom.test.js
@@ -22,21 +22,21 @@ describe('transformDOM', () => {
     });
 
     it('does not set attributes if scrollTop and scrollLeft are 0 or undefined', () => {
-      serializeScrollState(clone, original);
+      serializeScrollState(original, clone);
       expect(clone.hasAttribute('data-percy-scrolltop')).toBe(false);
       expect(clone.hasAttribute('data-percy-scrollleft')).toBe(false);
     });
 
     it('sets data-percy-scrolltop if scrollTop is non-zero', () => {
       original.scrollTop = 42;
-      serializeScrollState(clone, original);
+      serializeScrollState(original, clone);
       expect(clone.getAttribute('data-percy-scrolltop')).toBe('42');
       expect(clone.hasAttribute('data-percy-scrollleft')).toBe(false);
     });
 
     it('sets data-percy-scrollleft if scrollLeft is non-zero', () => {
       original.scrollLeft = 17;
-      serializeScrollState(clone, original);
+      serializeScrollState(original, clone);
       expect(clone.getAttribute('data-percy-scrollleft')).toBe('17');
       expect(clone.hasAttribute('data-percy-scrolltop')).toBe(false);
     });
@@ -44,14 +44,14 @@ describe('transformDOM', () => {
     it('sets both attributes if both scrollTop and scrollLeft are non-zero', () => {
       original.scrollTop = 5;
       original.scrollLeft = 10;
-      serializeScrollState(clone, original);
+      serializeScrollState(original, clone);
       expect(clone.getAttribute('data-percy-scrolltop')).toBe('5');
       expect(clone.getAttribute('data-percy-scrollleft')).toBe('10');
     });
 
     it('does nothing if original or clone is missing', () => {
-      expect(() => serializeScrollState(null, original)).not.toThrow();
-      expect(() => serializeScrollState(clone, null)).not.toThrow();
+      expect(() => serializeScrollState(original, null)).not.toThrow();
+      expect(() => serializeScrollState(null, clone)).not.toThrow();
     });
   });
 


### PR DESCRIPTION
# Preserve scroll location during DOM serialization

## Problem
We currently don't preserve scroll positions when serializing DOM elements. This can lead to visual differences when capturing screenshots, as elements that were scrolled in the original page appear at their default scroll position (top/left) in the serialized version.

## Solution
This PR introduces scroll state serialization functionality through the `serializeScrollState` function in `transform-dom.js`. The function:

- Captures `scrollTop` and `scrollLeft` values from original DOM elements
- Stores them as `data-percy-scrolltop` and `data-percy-scrollleft` attributes on cloned elements
- Only sets attributes when scroll values are non-zero, keeping the DOM clean
- Handles edge cases gracefully (null/undefined elements)

<img width="628" height="153" alt="image" src="https://github.com/user-attachments/assets/376ecd14-ca13-4989-a8e5-37bf507ec3eb" />

