### PR TITLE
added flag forceShadowAsLightDOM

### DIFF
--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -71,6 +71,10 @@ export const configSchema = {
         type: 'boolean',
         default: false
       },
+      forceShadowDomAsLightDom: {
+        type: 'boolean',
+        default: false
+      },
       enableLayout: {
         type: 'boolean'
       },
@@ -384,6 +388,7 @@ export const snapshotSchema = {
         enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },
         cliEnableJavaScript: { $ref: '/config/snapshot#/properties/cliEnableJavaScript' },
         disableShadowDOM: { $ref: '/config/snapshot#/properties/disableShadowDOM' },
+        forceShadowDomAsLightDom: { $ref: '/config/snapshot#/properties/forceShadowDomAsLightDom' },
         domTransformation: { $ref: '/config/snapshot#/properties/domTransformation' },
         enableLayout: { $ref: '/config/snapshot#/properties/enableLayout' },
         sync: { $ref: '/config/snapshot#/properties/sync' },

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -71,7 +71,7 @@ export const configSchema = {
         type: 'boolean',
         default: false
       },
-      forceShadowDomAsLightDom: {
+      forceShadowAsLightDOM: {
         type: 'boolean',
         default: false
       },
@@ -388,7 +388,7 @@ export const snapshotSchema = {
         enableJavaScript: { $ref: '/config/snapshot#/properties/enableJavaScript' },
         cliEnableJavaScript: { $ref: '/config/snapshot#/properties/cliEnableJavaScript' },
         disableShadowDOM: { $ref: '/config/snapshot#/properties/disableShadowDOM' },
-        forceShadowDomAsLightDom: { $ref: '/config/snapshot#/properties/forceShadowDomAsLightDom' },
+        forceShadowAsLightDOM: { $ref: '/config/snapshot#/properties/forceShadowAsLightDOM' },
         domTransformation: { $ref: '/config/snapshot#/properties/domTransformation' },
         enableLayout: { $ref: '/config/snapshot#/properties/enableLayout' },
         sync: { $ref: '/config/snapshot#/properties/sync' },

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -47,7 +47,7 @@ function debugSnapshotOptions(snapshot) {
   debugProp(snapshot, 'enableJavaScript');
   debugProp(snapshot, 'cliEnableJavaScript');
   debugProp(snapshot, 'disableShadowDOM');
-  debugProp(snapshot, 'forceShadowDomAsLightDom');
+  debugProp(snapshot, 'forceShadowAsLightDOM');
   debugProp(snapshot, 'enableLayout');
   debugProp(snapshot, 'domTransformation');
   debugProp(snapshot, 'reshuffleInvalidTags');

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -47,6 +47,7 @@ function debugSnapshotOptions(snapshot) {
   debugProp(snapshot, 'enableJavaScript');
   debugProp(snapshot, 'cliEnableJavaScript');
   debugProp(snapshot, 'disableShadowDOM');
+  debugProp(snapshot, 'forceShadowDomAsLightDom');
   debugProp(snapshot, 'enableLayout');
   debugProp(snapshot, 'domTransformation');
   debugProp(snapshot, 'reshuffleInvalidTags');

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -178,7 +178,7 @@ export class Page {
     execute,
     ...snapshot
   }) {
-    let { name, width, enableJavaScript, disableShadowDOM, forceShadowDomAsLightDom, domTransformation, reshuffleInvalidTags, ignoreCanvasSerializationErrors } = snapshot;
+    let { name, width, enableJavaScript, disableShadowDOM, forceShadowAsLightDOM, domTransformation, reshuffleInvalidTags, ignoreCanvasSerializationErrors } = snapshot;
     this.log.debug(`Taking snapshot: ${name}${width ? ` @${width}px` : ''}`, this.meta);
 
     // wait for any specified timeout
@@ -212,7 +212,7 @@ export class Page {
       /* eslint-disable-next-line no-undef */
       domSnapshot: PercyDOM.serialize(options),
       url: document.URL
-    }), { enableJavaScript, disableShadowDOM, forceShadowDomAsLightDom, domTransformation, reshuffleInvalidTags, ignoreCanvasSerializationErrors });
+    }), { enableJavaScript, disableShadowDOM, forceShadowAsLightDOM, domTransformation, reshuffleInvalidTags, ignoreCanvasSerializationErrors });
 
     return { ...snapshot, ...capture };
   }

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -178,7 +178,7 @@ export class Page {
     execute,
     ...snapshot
   }) {
-    let { name, width, enableJavaScript, disableShadowDOM, domTransformation, reshuffleInvalidTags, ignoreCanvasSerializationErrors } = snapshot;
+    let { name, width, enableJavaScript, disableShadowDOM,forceShadowDomAsLightDom, domTransformation, reshuffleInvalidTags, ignoreCanvasSerializationErrors } = snapshot;
     this.log.debug(`Taking snapshot: ${name}${width ? ` @${width}px` : ''}`, this.meta);
 
     // wait for any specified timeout
@@ -212,7 +212,7 @@ export class Page {
       /* eslint-disable-next-line no-undef */
       domSnapshot: PercyDOM.serialize(options),
       url: document.URL
-    }), { enableJavaScript, disableShadowDOM, domTransformation, reshuffleInvalidTags, ignoreCanvasSerializationErrors });
+    }), { enableJavaScript, disableShadowDOM, forceShadowDomAsLightDom, domTransformation, reshuffleInvalidTags, ignoreCanvasSerializationErrors });
 
     return { ...snapshot, ...capture };
   }

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -178,7 +178,7 @@ export class Page {
     execute,
     ...snapshot
   }) {
-    let { name, width, enableJavaScript, disableShadowDOM,forceShadowDomAsLightDom, domTransformation, reshuffleInvalidTags, ignoreCanvasSerializationErrors } = snapshot;
+    let { name, width, enableJavaScript, disableShadowDOM, forceShadowDomAsLightDom, domTransformation, reshuffleInvalidTags, ignoreCanvasSerializationErrors } = snapshot;
     this.log.debug(`Taking snapshot: ${name}${width ? ` @${width}px` : ''}`, this.meta);
 
     // wait for any specified timeout

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -85,7 +85,7 @@ describe('Percy', () => {
     });
   });
 
-  fit('allows access to create browser pages for other SDKs', async () => {
+  it('allows access to create browser pages for other SDKs', async () => {
     // add a request that fails for coverage when requests aren't intercepted
     let img = '<img src="http://localhost:9000/404.png">';
     server.reply('/', () => [200, 'text/html', `<p>Hello Percy!</p>${img}`]);

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -80,7 +80,8 @@ describe('Percy', () => {
       disableShadowDOM: false,
       cliEnableJavaScript: true,
       responsiveSnapshotCapture: false,
-      ignoreCanvasSerializationErrors: false
+      ignoreCanvasSerializationErrors: false,
+      forceShadowDomAsLightDom: false,
     });
   });
 
@@ -107,7 +108,7 @@ describe('Percy', () => {
     });
 
     // expect required arguments are passed to PercyDOM.serialize
-    expect(evalSpy.calls.allArgs()[3]).toEqual(jasmine.arrayContaining([jasmine.anything(), { enableJavaScript: undefined, disableShadowDOM: true, domTransformation: undefined, reshuffleInvalidTags: undefined, ignoreCanvasSerializationErrors: undefined }]));
+    expect(evalSpy.calls.allArgs()[3]).toEqual(jasmine.arrayContaining([jasmine.anything(), { enableJavaScript: undefined, disableShadowDOM: true, domTransformation: undefined, reshuffleInvalidTags: undefined, ignoreCanvasSerializationErrors: undefined, forceShadowDomAsLightDom: false }]));
 
     expect(snapshot.url).toEqual('http://localhost:8000/');
     expect(snapshot.domSnapshot).toEqual(jasmine.objectContaining({

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -81,7 +81,7 @@ describe('Percy', () => {
       cliEnableJavaScript: true,
       responsiveSnapshotCapture: false,
       ignoreCanvasSerializationErrors: false,
-      forceShadowDomAsLightDom: false,
+      forceShadowDomAsLightDom: false
     });
   });
 

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -81,7 +81,7 @@ describe('Percy', () => {
       cliEnableJavaScript: true,
       responsiveSnapshotCapture: false,
       ignoreCanvasSerializationErrors: false,
-      forceShadowDomAsLightDom: false
+      forceShadowAsLightDOM: false
     });
   });
 
@@ -108,7 +108,7 @@ describe('Percy', () => {
     });
 
     // expect required arguments are passed to PercyDOM.serialize
-    expect(evalSpy.calls.allArgs()[3]).toEqual(jasmine.arrayContaining([jasmine.anything(), { enableJavaScript: undefined, disableShadowDOM: true, domTransformation: undefined, reshuffleInvalidTags: undefined, ignoreCanvasSerializationErrors: undefined, forceShadowDomAsLightDom: undefined }]));
+    expect(evalSpy.calls.allArgs()[3]).toEqual(jasmine.arrayContaining([jasmine.anything(), { enableJavaScript: undefined, disableShadowDOM: true, domTransformation: undefined, reshuffleInvalidTags: undefined, ignoreCanvasSerializationErrors: undefined, forceShadowAsLightDOM: undefined }]));
 
     expect(snapshot.url).toEqual('http://localhost:8000/');
     expect(snapshot.domSnapshot).toEqual(jasmine.objectContaining({

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -85,7 +85,7 @@ describe('Percy', () => {
     });
   });
 
-  it('allows access to create browser pages for other SDKs', async () => {
+  fit('allows access to create browser pages for other SDKs', async () => {
     // add a request that fails for coverage when requests aren't intercepted
     let img = '<img src="http://localhost:9000/404.png">';
     server.reply('/', () => [200, 'text/html', `<p>Hello Percy!</p>${img}`]);
@@ -108,7 +108,7 @@ describe('Percy', () => {
     });
 
     // expect required arguments are passed to PercyDOM.serialize
-    expect(evalSpy.calls.allArgs()[3]).toEqual(jasmine.arrayContaining([jasmine.anything(), { enableJavaScript: undefined, disableShadowDOM: true, domTransformation: undefined, reshuffleInvalidTags: undefined, ignoreCanvasSerializationErrors: undefined, forceShadowDomAsLightDom: false }]));
+    expect(evalSpy.calls.allArgs()[3]).toEqual(jasmine.arrayContaining([jasmine.anything(), { enableJavaScript: undefined, disableShadowDOM: true, domTransformation: undefined, reshuffleInvalidTags: undefined, ignoreCanvasSerializationErrors: undefined, forceShadowDomAsLightDom: undefined }]));
 
     expect(snapshot.url).toEqual('http://localhost:8000/');
     expect(snapshot.domSnapshot).toEqual(jasmine.objectContaining({

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -41,7 +41,7 @@ function cloneElementWithoutLifecycle(element) {
 }
 
 export function cloneNodeAndShadow(ctx) {
-  let { dom, disableShadowDOM, forceShadowDomAsLightDom, resources, cache, enableJavaScript } = ctx;
+  let { dom, disableShadowDOM, forceShadowAsLightDOM, resources, cache, enableJavaScript } = ctx;
   // clones shadow DOM and light DOM for a given node
   let cloneNode = (node, parent) => {
     try {
@@ -55,7 +55,7 @@ export function cloneNodeAndShadow(ctx) {
       };
 
       // mark the node before cloning
-      markElement(node, disableShadowDOM, forceShadowDomAsLightDom);
+      markElement(node, disableShadowDOM, forceShadowAsLightDOM);
 
       let clone = cloneElementWithoutLifecycle(node);
 
@@ -94,8 +94,8 @@ export function cloneNodeAndShadow(ctx) {
 
       // clone shadow DOM
       if (node.shadowRoot && !disableShadowDOM) {
-        if (forceShadowDomAsLightDom) {
-          // When forceShadowDomAsLightDom is true, treat shadow content as normal DOM
+        if (forceShadowAsLightDOM) {
+          // When forceShadowAsLightDOM is true, treat shadow content as normal DOM
           walkTree(node.shadowRoot.firstChild, clone);
         } else {
           // create shadowRoot
@@ -135,11 +135,11 @@ export function cloneNodeAndShadow(ctx) {
 /**
  * Use `getInnerHTML()` to serialize shadow dom as <template> tags. `innerHTML` and `outerHTML` don't do this. Buzzword: "declarative shadow dom"
  */
-export function getOuterHTML(docElement, { shadowRootElements, forceShadowDomAsLightDom }) {
+export function getOuterHTML(docElement, { shadowRootElements, forceShadowAsLightDOM }) {
   // chromium gives us declarative shadow DOM serialization API
   let innerHTML = '';
-  // When forceShadowDomAsLightDom is true, treat shadow DOM as normal HTML
-  if (forceShadowDomAsLightDom) {
+  // When forceShadowAsLightDOM is true, treat shadow DOM as normal HTML
+  if (forceShadowAsLightDOM) {
     return docElement.outerHTML;
   }
   /* istanbul ignore else if: Only triggered in chrome <= 128 and tests runs on latest */

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -41,7 +41,7 @@ function cloneElementWithoutLifecycle(element) {
 }
 
 export function cloneNodeAndShadow(ctx) {
-  let { dom, disableShadowDOM, resources, cache, enableJavaScript } = ctx;
+  let { dom, disableShadowDOM, forceShadowDomAsLightDom, resources, cache, enableJavaScript } = ctx;
   // clones shadow DOM and light DOM for a given node
   let cloneNode = (node, parent) => {
     try {
@@ -55,7 +55,7 @@ export function cloneNodeAndShadow(ctx) {
       };
 
       // mark the node before cloning
-      markElement(node, disableShadowDOM);
+      markElement(node, disableShadowDOM, forceShadowDomAsLightDom);
 
       let clone = cloneElementWithoutLifecycle(node);
 
@@ -94,18 +94,23 @@ export function cloneNodeAndShadow(ctx) {
 
       // clone shadow DOM
       if (node.shadowRoot && !disableShadowDOM) {
-        // create shadowRoot
-        if (clone.shadowRoot) {
-          // it may be set up in a custom element's constructor
-          clone.shadowRoot.innerHTML = '';
+        if (forceShadowDomAsLightDom) {
+          // When forceShadowDomAsLightDom is true, treat shadow content as normal DOM
+          walkTree(node.shadowRoot.firstChild, clone);
         } else {
-          clone.attachShadow({
-            mode: 'open',
-            serializable: true
-          });
+          // create shadowRoot
+          if (clone.shadowRoot) {
+            // it may be set up in a custom element's constructor
+            clone.shadowRoot.innerHTML = '';
+          } else {
+            clone.attachShadow({
+              mode: 'open',
+              serializable: true
+            });
+          }
+          // clone dom elements
+          walkTree(node.shadowRoot.firstChild, clone.shadowRoot);
         }
-        // clone dom elements
-        walkTree(node.shadowRoot.firstChild, clone.shadowRoot);
       }
 
       // clone light DOM
@@ -130,9 +135,13 @@ export function cloneNodeAndShadow(ctx) {
 /**
  * Use `getInnerHTML()` to serialize shadow dom as <template> tags. `innerHTML` and `outerHTML` don't do this. Buzzword: "declarative shadow dom"
  */
-export function getOuterHTML(docElement, { shadowRootElements }) {
+export function getOuterHTML(docElement, { shadowRootElements, forceShadowDomAsLightDom }) {
   // chromium gives us declarative shadow DOM serialization API
   let innerHTML = '';
+  // When forceShadowDomAsLightDom is true, treat shadow DOM as normal HTML
+  if (forceShadowDomAsLightDom) {
+    return docElement.outerHTML;
+  }
   /* istanbul ignore else if: Only triggered in chrome <= 128 and tests runs on latest */
   if (docElement.getHTML) {
     // All major browsers in latest versions supports getHTML API to get serialized DOM

--- a/packages/dom/src/prepare-dom.js
+++ b/packages/dom/src/prepare-dom.js
@@ -3,7 +3,7 @@ export function uid() {
   return `_${Math.random().toString(36).substr(2, 9)}`;
 }
 
-export function markElement(domElement, disableShadowDOM, forceShadowDomAsLightDom) {
+export function markElement(domElement, disableShadowDOM, forceShadowAsLightDOM) {
   // Mark elements that are to be serialized later with a data attribute.
   if (['input', 'textarea', 'select', 'iframe', 'canvas', 'video', 'style'].includes(domElement.tagName?.toLowerCase())) {
     if (!domElement.getAttribute('data-percy-element-id')) {
@@ -13,8 +13,8 @@ export function markElement(domElement, disableShadowDOM, forceShadowDomAsLightD
 
   // add special marker for shadow host
   if (!disableShadowDOM && domElement.shadowRoot) {
-    // When forceShadowDomAsLightDom is true, don't mark as shadow host
-    if (!forceShadowDomAsLightDom) {
+    // When forceShadowAsLightDOM is true, don't mark as shadow host
+    if (!forceShadowAsLightDOM) {
       domElement.setAttribute('data-percy-shadow-host', '');
     }
 

--- a/packages/dom/src/prepare-dom.js
+++ b/packages/dom/src/prepare-dom.js
@@ -3,7 +3,7 @@ export function uid() {
   return `_${Math.random().toString(36).substr(2, 9)}`;
 }
 
-export function markElement(domElement, disableShadowDOM) {
+export function markElement(domElement, disableShadowDOM, forceShadowDomAsLightDom) {
   // Mark elements that are to be serialized later with a data attribute.
   if (['input', 'textarea', 'select', 'iframe', 'canvas', 'video', 'style'].includes(domElement.tagName?.toLowerCase())) {
     if (!domElement.getAttribute('data-percy-element-id')) {
@@ -13,7 +13,10 @@ export function markElement(domElement, disableShadowDOM) {
 
   // add special marker for shadow host
   if (!disableShadowDOM && domElement.shadowRoot) {
-    domElement.setAttribute('data-percy-shadow-host', '');
+    // When forceShadowDomAsLightDom is true, don't mark as shadow host
+    if (!forceShadowDomAsLightDom) {
+      domElement.setAttribute('data-percy-shadow-host', '');
+    }
 
     if (!domElement.getAttribute('data-percy-element-id')) {
       domElement.setAttribute('data-percy-element-id', uid());

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -23,7 +23,7 @@ function doctype(dom) {
 
 // Serializes and returns the cloned DOM as an HTML string
 function serializeHTML(ctx) {
-  let html = getOuterHTML(ctx.clone.documentElement, { shadowRootElements: ctx.shadowRootElements, forceShadowDomAsLightDom: ctx.forceShadowDomAsLightDom });
+  let html = getOuterHTML(ctx.clone.documentElement, { shadowRootElements: ctx.shadowRootElements, forceShadowAsLightDOM: ctx.forceShadowAsLightDOM });
   // this is replacing serialized data tag with real tag
   html = html.replace(/(<\/?)data-percy-custom-element-/g, '$1');
   // replace serialized data attributes with real attributes
@@ -41,8 +41,8 @@ function serializeElements(ctx) {
     serializeCSSOM(ctx);
     serializeCanvas(ctx);
   }
-  // Only process shadow hosts if forceShadowDomAsLightDom is not enabled
-  if (!ctx.forceShadowDomAsLightDom) {
+  // Only process shadow hosts if forceShadowAsLightDOM is not enabled
+  if (!ctx.forceShadowAsLightDOM) {
     for (const shadowHost of ctx.dom.querySelectorAll('[data-percy-shadow-host]')) {
       let percyElementId = shadowHost.getAttribute('data-percy-element-id');
       let cloneShadowHost = ctx.clone.querySelector(`[data-percy-element-id="${percyElementId}"]`);
@@ -89,7 +89,7 @@ export function serializeDOM(options) {
     disableShadowDOM = options?.disable_shadow_dom,
     reshuffleInvalidTags = options?.reshuffle_invalid_tags,
     ignoreCanvasSerializationErrors = options?.ignore_canvas_serialization_errors,
-    forceShadowDomAsLightDom = options?.force_shadow_dom_as_light_dom
+    forceShadowAsLightDOM = options?.force_shadow_dom_as_light_dom
   } = options || {};
 
   // keep certain records throughout serialization
@@ -102,7 +102,7 @@ export function serializeDOM(options) {
     enableJavaScript,
     disableShadowDOM,
     ignoreCanvasSerializationErrors,
-    forceShadowDomAsLightDom
+    forceShadowAsLightDOM
   };
 
   ctx.dom = dom;

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -296,7 +296,7 @@ describe('serializeDOM', () => {
       expect(html).toMatch(new RegExp(stylePattern));
     });
 
-    it('respects forceShadowDomAsLightDom for single element', () => {
+    it('respects forceShadowAsLightDOM for single element', () => {
       if (!navigator.userAgent.toLowerCase().includes('chrome')) {
         return;
       }
@@ -305,14 +305,14 @@ describe('serializeDOM', () => {
       const el = createShadowEl(9);
       baseContent.appendChild(el);
 
-      const html = serializeDOM({ forceShadowDomAsLightDom: true }).html;
+      const html = serializeDOM({ forceShadowAsLightDOM: true }).html;
       expect(html).toMatch('<p>Percy-9</p>');
       expect(html).not.toMatch('<template shadowrootmode="open"');
       expect(html).not.toMatch('shadowrootserializable');
       expect(html).not.toMatch('data-percy-shadow-host');
     });
 
-    it('respects forceShadowDomAsLightDom for nested shadow elements', () => {
+    it('respects forceShadowAsLightDOM for nested shadow elements', () => {
       if (!navigator.userAgent.toLowerCase().includes('chrome')) {
         return;
       }
@@ -324,7 +324,7 @@ describe('serializeDOM', () => {
       el1.shadowRoot.appendChild(el2);
       baseContent.append(el1);
 
-      const html = serializeDOM({ forceShadowDomAsLightDom: true }).html;
+      const html = serializeDOM({ forceShadowAsLightDOM: true }).html;
       expect(html).toMatch('<p>Percy-10</p>');
       expect(html).toMatch('<p>Percy-11</p>');
       expect(html).not.toMatch('<template shadowrootmode="open"');
@@ -332,7 +332,7 @@ describe('serializeDOM', () => {
       expect(html).not.toMatch('data-percy-shadow-host');
     });
 
-    it('respects forceShadowDomAsLightDom for custom elements', () => {
+    it('respects forceShadowAsLightDOM for custom elements', () => {
       if (getTestBrowser() !== chromeBrowser) {
         return;
       }
@@ -355,14 +355,14 @@ describe('serializeDOM', () => {
       }
 
       withExample('<force-shadow-test></force-shadow-test>', { withShadow: false });
-      const html = serializeDOM({ forceShadowDomAsLightDom: true }).html;
+      const html = serializeDOM({ forceShadowAsLightDOM: true }).html;
 
       expect(html).toMatch('<h3>Force Shadow Test<span>Nested Content</span></h3>');
       expect(html).not.toMatch('<template shadowrootmode="open"');
       expect(html).not.toMatch('shadowrootserializable');
     });
 
-    it('respects forceShadowDomAsLightDom with many flat elements', () => {
+    it('respects forceShadowAsLightDOM with many flat elements', () => {
       if (!navigator.userAgent.toLowerCase().includes('chrome')) {
         return;
       }
@@ -378,7 +378,7 @@ describe('serializeDOM', () => {
         baseContent.appendChild(newEl);
       }
 
-      const html = serializeDOM({ forceShadowDomAsLightDom: true }).html;
+      const html = serializeDOM({ forceShadowAsLightDOM: true }).html;
 
       // Verify all content is present as light DOM
       for (let i = 0; i < levels; i++) {
@@ -389,7 +389,7 @@ describe('serializeDOM', () => {
       expect(html).not.toMatch('data-percy-shadow-host');
     });
 
-    it('respects forceShadowDomAsLightDom with slot content', () => {
+    it('respects forceShadowAsLightDOM with slot content', () => {
       if (!navigator.userAgent.toLowerCase().includes('chrome')) {
         return;
       }
@@ -411,9 +411,9 @@ describe('serializeDOM', () => {
 
       baseContent.appendChild(hostEl);
 
-      const html = serializeDOM({ forceShadowDomAsLightDom: true }).html;
+      const html = serializeDOM({ forceShadowAsLightDOM: true }).html;
 
-      // When forceShadowDomAsLightDom is true, shadow content becomes light DOM
+      // When forceShadowAsLightDOM is true, shadow content becomes light DOM
       // The slot element from shadow DOM will be present, and slotted content remains in light DOM
       expect(html).toMatch('Slotted content as light DOM');
       expect(html).toMatch('<slot name="title"></slot>');
@@ -421,7 +421,7 @@ describe('serializeDOM', () => {
       expect(html).not.toMatch('shadowrootserializable');
     });
 
-    it('disableShadowDOM takes precedence over forceShadowDomAsLightDom', () => {
+    it('disableShadowDOM takes precedence over forceShadowAsLightDOM', () => {
       if (!navigator.userAgent.toLowerCase().includes('chrome')) {
         return;
       }
@@ -434,7 +434,7 @@ describe('serializeDOM', () => {
       // This is because disableShadowDOM prevents shadow DOM cloning entirely in clone-dom.js
       const html = serializeDOM({
         disableShadowDOM: true,
-        forceShadowDomAsLightDom: true
+        forceShadowAsLightDOM: true
       }).html;
 
       expect(html).not.toMatch('<p>Percy-12</p>');
@@ -442,7 +442,7 @@ describe('serializeDOM', () => {
       expect(html).not.toMatch('data-percy-shadow-host');
     });
 
-    it('forceShadowDomAsLightDom works independently when disableShadowDOM is false', () => {
+    it('forceShadowAsLightDOM works independently when disableShadowDOM is false', () => {
       if (!navigator.userAgent.toLowerCase().includes('chrome')) {
         return;
       }
@@ -451,10 +451,10 @@ describe('serializeDOM', () => {
       const el = createShadowEl(14);
       baseContent.appendChild(el);
 
-      // When only forceShadowDomAsLightDom is true, shadow content should be rendered as light DOM
+      // When only forceShadowAsLightDOM is true, shadow content should be rendered as light DOM
       const html = serializeDOM({
         disableShadowDOM: false,
-        forceShadowDomAsLightDom: true
+        forceShadowAsLightDOM: true
       }).html;
 
       expect(html).toMatch('<p>Percy-14</p>');

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -240,7 +240,7 @@ describe('serializeDOM', () => {
 
       const html = serializeDOM({ disableShadowDOM: true }).html;
       expect(html).not.toMatch('<p>Percy-8</p>');
-      expect(html).not.toMatch('data-percy-shadow-host');
+      expect(html).not.toMatch('data-percy-shadow-hos=');
     });
 
     it('renders custom elements properly', () => {

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -240,7 +240,7 @@ describe('serializeDOM', () => {
 
       const html = serializeDOM({ disableShadowDOM: true }).html;
       expect(html).not.toMatch('<p>Percy-8</p>');
-      expect(html).not.toMatch('data-percy-shadow-hos=');
+      expect(html).not.toMatch('data-percy-shadow-host=');
     });
 
     it('renders custom elements properly', () => {

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -240,7 +240,7 @@ describe('serializeDOM', () => {
 
       const html = serializeDOM({ disableShadowDOM: true }).html;
       expect(html).not.toMatch('<p>Percy-8</p>');
-      expect(html).not.toMatch('data-percy-shadow-host=');
+      expect(html).not.toMatch('data-percy-shadow-host');
     });
 
     it('renders custom elements properly', () => {
@@ -295,191 +295,357 @@ describe('serializeDOM', () => {
       ].join('\\s*');
       expect(html).toMatch(new RegExp(stylePattern));
     });
+
+    it('respects forceShadowDomAsLightDom for single element', () => {
+      if (!navigator.userAgent.toLowerCase().includes('chrome')) {
+        return;
+      }
+      withExample('<div id="content"></div>', { withShadow: false });
+      const baseContent = document.querySelector('#content');
+      const el = createShadowEl(9);
+      baseContent.appendChild(el);
+
+      const html = serializeDOM({ forceShadowDomAsLightDom: true }).html;
+      expect(html).toMatch('<p>Percy-9</p>');
+      expect(html).not.toMatch('<template shadowrootmode="open"');
+      expect(html).not.toMatch('shadowrootserializable');
+      expect(html).not.toMatch('data-percy-shadow-host');
+    });
+
+    it('respects forceShadowDomAsLightDom for nested shadow elements', () => {
+      if (!navigator.userAgent.toLowerCase().includes('chrome')) {
+        return;
+      }
+      withExample('<div id="content"></div>', { withShadow: false });
+      const baseContent = document.querySelector('#content');
+
+      const el1 = createShadowEl(10);
+      const el2 = createShadowEl(11);
+      el1.shadowRoot.appendChild(el2);
+      baseContent.append(el1);
+
+      const html = serializeDOM({ forceShadowDomAsLightDom: true }).html;
+      expect(html).toMatch('<p>Percy-10</p>');
+      expect(html).toMatch('<p>Percy-11</p>');
+      expect(html).not.toMatch('<template shadowrootmode="open"');
+      expect(html).not.toMatch('shadowrootserializable');
+      expect(html).not.toMatch('data-percy-shadow-host');
+    });
+
+    it('respects forceShadowDomAsLightDom for custom elements', () => {
+      if (getTestBrowser() !== chromeBrowser) {
+        return;
+      }
+      
+      class ForceShadowTestElement extends window.HTMLElement {
+        constructor() {
+          super();
+          const shadow = this.attachShadow({ mode: 'open', serializable: true });
+          const wrapper = document.createElement('h3');
+          wrapper.innerText = 'Force Shadow Test';
+          const nested = document.createElement('span');
+          nested.innerText = 'Nested Content';
+          wrapper.appendChild(nested);
+          shadow.appendChild(wrapper);
+        }
+      }
+
+      if (!window.customElements.get('force-shadow-test')) {
+        window.customElements.define('force-shadow-test', ForceShadowTestElement);
+      }
+
+      withExample('<force-shadow-test></force-shadow-test>', { withShadow: false });
+      const html = serializeDOM({ forceShadowDomAsLightDom: true }).html;
+      
+      expect(html).toMatch('<h3>Force Shadow Test<span>Nested Content</span></h3>');
+      expect(html).not.toMatch('<template shadowrootmode="open"');
+      expect(html).not.toMatch('shadowrootserializable');
+    });
+
+    it('respects forceShadowDomAsLightDom with many flat elements', () => {
+      if (!navigator.userAgent.toLowerCase().includes('chrome')) {
+        return;
+      }
+      withExample('<div id="content"></div>', { withShadow: false });
+      const baseContent = document.querySelector('#content');
+
+      const levels = 50; // Reduced for performance in tests
+
+      let j = levels;
+
+      while (j--) {
+        let newEl = createShadowEl(j);
+        baseContent.appendChild(newEl);
+      }
+
+      const html = serializeDOM({ forceShadowDomAsLightDom: true }).html;
+      
+      // Verify all content is present as light DOM
+      for (let i = 0; i < levels; i++) {
+        expect(html).toMatch(`<p>Percy-${i}</p>`);
+      }
+      expect(html).not.toMatch('<template shadowrootmode="open"');
+      expect(html).not.toMatch('shadowrootserializable');
+      expect(html).not.toMatch('data-percy-shadow-host');
+    });
+
+    it('respects forceShadowDomAsLightDom with slot content', () => {
+      if (!navigator.userAgent.toLowerCase().includes('chrome')) {
+        return;
+      }
+      withExample('<div id="content"></div>', { withShadow: false });
+      const baseContent = document.querySelector('#content');
+      
+      // Create element with slot
+      const hostEl = document.createElement('div');
+      const shadow = hostEl.attachShadow({ mode: 'open' });
+      
+      const slot = document.createElement('slot');
+      slot.name = 'title';
+      shadow.appendChild(slot);
+      
+      const slottedContent = document.createElement('p');
+      slottedContent.setAttribute('slot', 'title');
+      slottedContent.textContent = 'Slotted content as light DOM';
+      hostEl.appendChild(slottedContent);
+      
+      baseContent.appendChild(hostEl);
+
+      const html = serializeDOM({ forceShadowDomAsLightDom: true }).html;
+      
+      // When forceShadowDomAsLightDom is true, shadow content becomes light DOM
+      // The slot element from shadow DOM will be present, and slotted content remains in light DOM
+      expect(html).toMatch('Slotted content as light DOM');
+      expect(html).toMatch('<slot name="title"></slot>');
+      expect(html).not.toMatch('<template shadowrootmode="open"');
+      expect(html).not.toMatch('shadowrootserializable');
+    });
+
+    it('disableShadowDOM takes precedence over forceShadowDomAsLightDom', () => {
+      if (!navigator.userAgent.toLowerCase().includes('chrome')) {
+        return;
+      }
+      withExample('<div id="content"></div>', { withShadow: false });
+      const baseContent = document.querySelector('#content');
+      const el = createShadowEl(12);
+      baseContent.appendChild(el);
+
+      // When both flags are set, disableShadowDOM takes precedence and no shadow content is processed at all
+      // This is because disableShadowDOM prevents shadow DOM cloning entirely in clone-dom.js
+      const html = serializeDOM({ 
+        disableShadowDOM: true, 
+        forceShadowDomAsLightDom: true 
+      }).html;
+      
+      expect(html).not.toMatch('<p>Percy-12</p>');
+      expect(html).not.toMatch('<template shadowrootmode="open"');
+      expect(html).not.toMatch('data-percy-shadow-host');
+    });
+
+    it('forceShadowDomAsLightDom works independently when disableShadowDOM is false', () => {
+      if (!navigator.userAgent.toLowerCase().includes('chrome')) {
+        return;
+      }
+      withExample('<div id="content"></div>', { withShadow: false });
+      const baseContent = document.querySelector('#content');
+      const el = createShadowEl(14);
+      baseContent.appendChild(el);
+
+      // When only forceShadowDomAsLightDom is true, shadow content should be rendered as light DOM
+      const html = serializeDOM({ 
+        disableShadowDOM: false, 
+        forceShadowDomAsLightDom: true 
+      }).html;
+      
+      expect(html).toMatch('<p>Percy-14</p>');
+      expect(html).not.toMatch('<template shadowrootmode="open"');
+      expect(html).not.toMatch('data-percy-shadow-host');
+    });
   });
 
   it('renders custom image elements with src attribute properly', () => {
-    if (getTestBrowser() !== chromeBrowser) {
-      return;
-    }
-
-    class CustomImage extends window.HTMLElement {
-      static get observedAttributes() {
-        return ['src'];
+      if (getTestBrowser() !== chromeBrowser) {
+        return;
       }
 
-      constructor() {
-        super();
-        this.img = document.createElement('img');
-        this.appendChild(this.img);
-      }
+      class CustomImage extends window.HTMLElement {
+        static get observedAttributes() {
+          return ['src'];
+        }
 
-      attributeChangedCallback(name, oldValue, newValue) {
-        if (name === 'src') {
-          this.img.src = newValue || '';
+        constructor() {
+          super();
+          this.img = document.createElement('img');
+          this.appendChild(this.img);
+        }
+
+        attributeChangedCallback(name, oldValue, newValue) {
+          if (name === 'src') {
+            this.img.src = newValue || '';
+          }
         }
       }
-    }
 
-    window.customElements.define('custom-image', CustomImage);
+      window.customElements.define('custom-image', CustomImage);
 
-    withExample(`
-      <custom-image src="https://example.com/test.jpg"></custom-image>
-    `, { withShadow: false });
-
-    const html = serializeDOM().html;
-
-    expect(html).toMatch(
-      /<custom-image[^>]*><img src="https:\/\/example\.com\/test\.jpg"><\/custom-image>/
-    );
-  });
-
-  describe('with `domTransformation`', () => {
-    beforeEach(() => {
-      withExample('<span class="delete-me">Delete me</span>', { withShadow: false });
-      spyOn(console, 'error');
-    });
-
-    it('transforms the DOM without modifying the original DOM', () => {
-      let { html } = serializeDOM({
-        domTransformation(dom) {
-          dom.querySelector('.delete-me').remove();
-        }
-      });
-
-      expect(html).not.toMatch('Delete me');
-      expect(document.querySelector('.delete-me').innerText).toBe('Delete me');
-    });
-
-    it('String: transforms the DOM without modifying the original DOM', () => {
-      let { html } = serializeDOM({
-        domTransformation: "(dom) => { dom.querySelector('.delete-me').remove(); }"
-      });
-
-      expect(html).not.toMatch('Delete me');
-      expect(document.querySelector('.delete-me').innerText).toBe('Delete me');
-    });
-
-    it('String: Logs error when function is not correct', () => {
-      let { html, warnings } = serializeDOM({
-        domTransformation: "(dom) => { dom.querySelector('.delete-me').delete(); }"
-      });
-
-      expect(html).toMatch('Delete me');
-      expect(console.error)
-        .toHaveBeenCalledOnceWith('Could not transform the dom: dom.querySelector(...).delete is not a function');
-
-      expect(warnings).toEqual(['Could not transform the dom: dom.querySelector(...).delete is not a function']);
-    });
-
-    it('logs any errors and returns the serialized DOM', () => {
-      let { html, warnings } = serializeDOM({
-        domTransformation(dom) {
-          throw new Error('test error');
-          // eslint-disable-next-line no-unreachable
-          dom.querySelector('.delete-me').remove();
-        }
-      });
-
-      expect(html).toMatch('Delete me');
-      expect(console.error)
-        .toHaveBeenCalledOnceWith('Could not transform the dom: test error');
-
-      expect(warnings).toEqual(['Could not transform the dom: test error']);
-    });
-  });
-
-  describe('with `reshuffleInvalidTags`', () => {
-    beforeEach(() => {
-      withExample('', { withShadow: false, invalidTagsOutsideBody: true });
-    });
-
-    it('does not reshuffle tags outside </body>', () => {
-      const result = serializeDOM();
-      expect(result.html).toContain('P tag outside body');
-      expect(result.hints).toEqual(['DOM elements found outside </body>']);
-    });
-
-    it('reshuffles tags outside </body>', () => {
-      const result = serializeDOM({ reshuffleInvalidTags: true });
-      expect(result.html).toContain('P tag outside body');
-      expect(result.hints).toEqual([]);
-    });
-  });
-
-  describe('when `ctx.clone.body` is null for about:blank pages', () => {
-    beforeEach(() => {
-      withExample('', { withoutBody: true });
-    });
-
-    it('does not add hints and does not throw an error', () => {
-      expect(() => {
-        const result = serializeDOM();
-        expect(result.hints).toEqual([]);
-      }).not.toThrow();
-    });
-  });
-
-  describe('waitForResize', () => {
-    it('updates window.resizeCount', async () => {
-      waitForResize();
-      expect(window.resizeCount).toEqual(0);
-      // trigger resize event
-      // eslint-disable-next-line no-undef
-      window.dispatchEvent(new Event('resize'));
-      // eslint-disable-next-line no-undef
-      window.dispatchEvent(new Event('resize'));
-      // should be only updated once in 100ms
-      await new Promise((r) => setTimeout(r, 150));
-      expect(window.resizeCount).toEqual(1);
-      waitForResize();
-      expect(window.resizeCount).toEqual(0);
-      // eslint-disable-next-line no-undef
-      window.dispatchEvent(new Event('resize'));
-      await new Promise((r) => setTimeout(r, 150));
-      // there should only one event listener added
-      expect(window.resizeCount).toEqual(1);
-    });
-  });
-
-  describe('error handling', () => {
-    it('adds node details in error message and rethrow it', () => {
-      let oldURL = window.URL;
-      window.URL = undefined;
       withExample(`
-        <img id="test" class="test1 test2" src="data:image/png;base64,iVBORw0KGgo" alt="Example Image">
+        <custom-image src="https://example.com/test.jpg"></custom-image>
+      `, { withShadow: false });
+
+      const html = serializeDOM().html;
+
+      expect(html).toMatch(
+        /<custom-image[^>]*><img src="https:\/\/example\.com\/test\.jpg"><\/custom-image>/
+      );
+    });
+
+    describe('with `domTransformation`', () => {
+      beforeEach(() => {
+        withExample('<span class="delete-me">Delete me</span>', { withShadow: false });
+        spyOn(console, 'error');
+      });
+
+      it('transforms the DOM without modifying the original DOM', () => {
+        let { html } = serializeDOM({
+          domTransformation(dom) {
+            dom.querySelector('.delete-me').remove();
+          }
+        });
+
+        expect(html).not.toMatch('Delete me');
+        expect(document.querySelector('.delete-me').innerText).toBe('Delete me');
+      });
+
+      it('String: transforms the DOM without modifying the original DOM', () => {
+        let { html } = serializeDOM({
+          domTransformation: "(dom) => { dom.querySelector('.delete-me').remove(); }"
+        });
+
+        expect(html).not.toMatch('Delete me');
+        expect(document.querySelector('.delete-me').innerText).toBe('Delete me');
+      });
+
+      it('String: Logs error when function is not correct', () => {
+        let { html, warnings } = serializeDOM({
+          domTransformation: "(dom) => { dom.querySelector('.delete-me').delete(); }"
+        });
+
+        expect(html).toMatch('Delete me');
+        expect(console.error)
+          .toHaveBeenCalledOnceWith('Could not transform the dom: dom.querySelector(...).delete is not a function');
+
+        expect(warnings).toEqual(['Could not transform the dom: dom.querySelector(...).delete is not a function']);
+      });
+
+      it('logs any errors and returns the serialized DOM', () => {
+        let { html, warnings } = serializeDOM({
+          domTransformation(dom) {
+            throw new Error('test error');
+            // eslint-disable-next-line no-unreachable
+            dom.querySelector('.delete-me').remove();
+          }
+        });
+
+        expect(html).toMatch('Delete me');
+        expect(console.error)
+          .toHaveBeenCalledOnceWith('Could not transform the dom: test error');
+
+        expect(warnings).toEqual(['Could not transform the dom: test error']);
+      });
+    });
+
+    describe('with `reshuffleInvalidTags`', () => {
+      beforeEach(() => {
+        withExample('', { withShadow: false, invalidTagsOutsideBody: true });
+      });
+
+      it('does not reshuffle tags outside </body>', () => {
+        const result = serializeDOM();
+        expect(result.html).toContain('P tag outside body');
+        expect(result.hints).toEqual(['DOM elements found outside </body>']);
+      });
+
+      it('reshuffles tags outside </body>', () => {
+        const result = serializeDOM({ reshuffleInvalidTags: true });
+        expect(result.html).toContain('P tag outside body');
+        expect(result.hints).toEqual([]);
+      });
+    });
+
+    describe('when `ctx.clone.body` is null for about:blank pages', () => {
+      beforeEach(() => {
+        withExample('', { withoutBody: true });
+      });
+
+      it('does not add hints and does not throw an error', () => {
+        expect(() => {
+          const result = serializeDOM();
+          expect(result.hints).toEqual([]);
+        }).not.toThrow();
+      });
+    });
+
+    describe('waitForResize', () => {
+      it('updates window.resizeCount', async () => {
+        waitForResize();
+        expect(window.resizeCount).toEqual(0);
+        // trigger resize event
+        // eslint-disable-next-line no-undef
+        window.dispatchEvent(new Event('resize'));
+        // eslint-disable-next-line no-undef
+        window.dispatchEvent(new Event('resize'));
+        // should be only updated once in 100ms
+        await new Promise((r) => setTimeout(r, 150));
+        expect(window.resizeCount).toEqual(1);
+        waitForResize();
+        expect(window.resizeCount).toEqual(0);
+        // eslint-disable-next-line no-undef
+        window.dispatchEvent(new Event('resize'));
+        await new Promise((r) => setTimeout(r, 150));
+        // there should only one event listener added
+        expect(window.resizeCount).toEqual(1);
+      });
+    });
+
+    describe('error handling', () => {
+      it('adds node details in error message and rethrow it', () => {
+        let oldURL = window.URL;
+        window.URL = undefined;
+        withExample(`
+          <img id="test" class="test1 test2" src="data:image/png;base64,iVBORw0KGgo" alt="Example Image">
+          `);
+
+        expect(() => serializeDOM()).toThrowMatching((error) => {
+          return error.message.includes('Error cloning node:') &&
+            error.message.includes('{"nodeName":"IMG","classNames":"test1 test2","id":"test"}');
+        });
+        window.URL = oldURL;
+      });
+
+      it('ignores canvas serialization errors when flag is enabled', () => {
+        withExample(`
+          <canvas id="canvas" width="150px" height="150px"/>
         `);
 
-      expect(() => serializeDOM()).toThrowMatching((error) => {
-        return error.message.includes('Error cloning node:') &&
-          error.message.includes('{"nodeName":"IMG","classNames":"test1 test2","id":"test"}');
+        spyOn(window.HTMLCanvasElement.prototype, 'toDataURL').and.throwError(new Error('Canvas error'));
+
+        let result = serializeDOM({ ignoreCanvasSerializationErrors: true });
+        expect(result.warnings).toContain('Canvas Serialization failed, Replaced canvas with empty Image');
+        expect(result.warnings).toContain('Error: Canvas error');
+        expect(result.html).toContain('data-percy-canvas-serialized');
       });
-      window.URL = oldURL;
-    });
 
-    it('ignores canvas serialization errors when flag is enabled', () => {
-      withExample(`
-        <canvas id="canvas" width="150px" height="150px"/>
-      `);
+      it('picks ignoreCanvasSerializationErrors flag from options', () => {
+        withExample(`
+          <canvas id="canvas" width="150px" height="150px"/>
+        `);
 
-      spyOn(window.HTMLCanvasElement.prototype, 'toDataURL').and.throwError(new Error('Canvas error'));
+        spyOn(window.HTMLCanvasElement.prototype, 'toDataURL').and.throwError(new Error('Canvas error'));
 
-      let result = serializeDOM({ ignoreCanvasSerializationErrors: true });
-      expect(result.warnings).toContain('Canvas Serialization failed, Replaced canvas with empty Image');
-      expect(result.warnings).toContain('Error: Canvas error');
-      expect(result.html).toContain('data-percy-canvas-serialized');
-    });
-
-    it('picks ignoreCanvasSerializationErrors flag from options', () => {
-      withExample(`
-        <canvas id="canvas" width="150px" height="150px"/>
-      `);
-
-      spyOn(window.HTMLCanvasElement.prototype, 'toDataURL').and.throwError(new Error('Canvas error'));
-
-      let result = serializeDOM({ ignoreCanvasSerializationErrors: true });
-      expect(result.html).toContain('data-percy-canvas-serialized');
-      expect(result.warnings).toContain('Canvas Serialization failed, Replaced canvas with empty Image');
-      expect(result.warnings).toContain('Error: Canvas error');
+        let result = serializeDOM({ ignoreCanvasSerializationErrors: true });
+        expect(result.html).toContain('data-percy-canvas-serialized');
+        expect(result.warnings).toContain('Canvas Serialization failed, Replaced canvas with empty Image');
+        expect(result.warnings).toContain('Error: Canvas error');
+      });
     });
   });
-});


### PR DESCRIPTION
This pull request introduces a new configuration option, `forceShadowAsLightDOM`, which enables the serialization of shadow DOM content as regular light DOM in Percy snapshots. This feature is integrated throughout the core and DOM serialization logic, with comprehensive test coverage to ensure correct behavior in various scenarios, including nested and custom elements, slot content, and interaction with the existing `disableShadowDOM` flag.

**Configuration and Core Integration:**

* Added the `forceShadowAsLightDOM` boolean option to the `configSchema` and `snapshotSchema` in `packages/core/src/config.js`, allowing users to enable this feature via configuration. [[1]](diffhunk://#diff-e7c1269ddb64f1de14c2c79cac204c16cfc3f8d8535512d218f8e4ad8efc63b6R74-R77) [[2]](diffhunk://#diff-e7c1269ddb64f1de14c2c79cac204c16cfc3f8d8535512d218f8e4ad8efc63b6R391)
* Updated debug output and snapshot handling in `discovery.js` and `page.js` to recognize and pass through the new flag. [[1]](diffhunk://#diff-88351388dc614d2fe3f73c528d6807bb731d4bfba641f5a99d34e918d9b728b5R50) [[2]](diffhunk://#diff-8883c2a98d929aa8ae8a1010268537f5f247edbab994127b4e6e75c5e09f9a24L181-R181) [[3]](diffhunk://#diff-8883c2a98d929aa8ae8a1010268537f5f247edbab994127b4e6e75c5e09f9a24L215-R215)

**DOM Serialization Logic:**

* Modified `cloneNodeAndShadow` and related functions in `packages/dom/src/clone-dom.js` and `prepare-dom.js` to treat shadow DOM as light DOM when the flag is enabled, bypassing shadow host marking and altering the tree-walking logic. [[1]](diffhunk://#diff-02067f8a8ffa312638a2a6525baaabf925e44fc81392b24fc9de58604100be75L44-R44) [[2]](diffhunk://#diff-02067f8a8ffa312638a2a6525baaabf925e44fc81392b24fc9de58604100be75L58-R58) [[3]](diffhunk://#diff-02067f8a8ffa312638a2a6525baaabf925e44fc81392b24fc9de58604100be75R97-R100) [[4]](diffhunk://#diff-02067f8a8ffa312638a2a6525baaabf925e44fc81392b24fc9de58604100be75R114) [[5]](diffhunk://#diff-851e7e51af03acf3d860c32ce3f10fff5d935eeff22209d473d188628a8e621aL6-R6) [[6]](diffhunk://#diff-851e7e51af03acf3d860c32ce3f10fff5d935eeff22209d473d188628a8e621aR16-R19)
* Updated `getOuterHTML` and serialization routines to output shadow content as standard HTML, skipping shadow-specific markers and templates when the flag is set. [[1]](diffhunk://#diff-02067f8a8ffa312638a2a6525baaabf925e44fc81392b24fc9de58604100be75L133-R144) [[2]](diffhunk://#diff-9824ccc3183bab9098281b8ae310bcea8c81433684fc02806e735ed97c66fe3cL26-R26) [[3]](diffhunk://#diff-9824ccc3183bab9098281b8ae310bcea8c81433684fc02806e735ed97c66fe3cL44-R45) [[4]](diffhunk://#diff-9824ccc3183bab9098281b8ae310bcea8c81433684fc02806e735ed97c66fe3cR63) [[5]](diffhunk://#diff-9824ccc3183bab9098281b8ae310bcea8c81433684fc02806e735ed97c66fe3cL89-R92) [[6]](diffhunk://#diff-9824ccc3183bab9098281b8ae310bcea8c81433684fc02806e735ed97c66fe3cL101-R105)

**Testing and Validation:**

* Added extensive tests in `packages/core/test/percy.test.js` and `packages/dom/test/serialize-dom.test.js` to verify correct behavior for single, nested, and custom shadow elements, slot content, and precedence rules between `disableShadowDOM` and `forceShadowAsLightDOM`. [[1]](diffhunk://#diff-00366ac2213d6c9a9cc8c432d7d9124675e23b14e5074de56ff90e56311b9d29L83-R84) [[2]](diffhunk://#diff-00366ac2213d6c9a9cc8c432d7d9124675e23b14e5074de56ff90e56311b9d29L110-R111) [[3]](diffhunk://#diff-340065f4bc4a7c7d1a6c22b8ad7edc8928eb637ffadf577254709e89a7d50eeaL243-R243) [[4]](diffhunk://#diff-340065f4bc4a7c7d1a6c22b8ad7edc8928eb637ffadf577254709e89a7d50eeaR298-R463)

These changes provide users with greater flexibility in how shadow DOM content is captured and serialized, making Percy snapshots more customizable for modern web applications.outerHTML is used instead of getHTML/getInnerHTML