### PR TITLE
[PPLT-4565] | Add Proxy support for PoA Session for communication with `hub.browserstack.com`

### DIFF
--- a/karma.config.cjs
+++ b/karma.config.cjs
@@ -24,8 +24,10 @@ module.exports = async config => {
       { pattern: 'test/assets/**', watched: false, included: false }
     ],
 // NOTE: Although sdk-utils test run in browser as well, we do not run sdk-utils/request test in browsers as we require creation of https server for this test
+    // NOTE: proxy.test.js is excluded because proxy functionality uses Node.js-specific modules (http, https)
     exclude: [
       '**/test/request.test.js',
+      '**/test/proxy.test.js',
     ],
     proxies: {
       // useful when the contents of a fake asset do not matter

--- a/packages/client/src/proxy.js
+++ b/packages/client/src/proxy.js
@@ -6,6 +6,14 @@ import logger from '@percy/logger';
 import { stripQuotesAndSpaces } from '@percy/env/utils';
 import { PacProxyAgent } from 'pac-proxy-agent';
 
+/**
+ * Primary proxy implementation for Percy CLI
+ *
+ * NOTE: A simplified copy exists in @percy/sdk-utils/src/proxy.js due to module
+ * compatibility constraints. When modifying core proxy logic here, also update
+ * the sdk-utils version.
+ */
+
 const CRLF = '\r\n';
 const STATUS_REG = /^HTTP\/1.[01] (\d*)/;
 

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -50,5 +50,8 @@
         "test/server(.js)?"
       ]
     }
+  },
+  "dependencies": {
+    "pac-proxy-agent": "^5.0.0"
   }
 }

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -38,9 +38,6 @@
     "test": "percy exec --testing -- node ../../scripts/test",
     "test:coverage": "yarn test --coverage"
   },
-  "dependencies": {
-    "@percy/client": "1.31.3-beta.3"
-  },
   "rollup": {
     "external": [
       "ws"

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -38,6 +38,9 @@
     "test": "percy exec --testing -- node ../../scripts/test",
     "test:coverage": "yarn test --coverage"
   },
+  "dependencies": {
+    "@percy/client": "1.31.3-beta.3"
+  },
   "rollup": {
     "external": [
       "ws"

--- a/packages/sdk-utils/src/proxy.js
+++ b/packages/sdk-utils/src/proxy.js
@@ -1,0 +1,287 @@
+import net from 'net';
+import tls from 'tls';
+import http from 'http';
+import https from 'https';
+import logger from './logger.js';
+
+const CRLF = '\r\n';
+const STATUS_REG = /^HTTP\/1.[01] (\d*)/;
+
+/**
+ * Local proxy implementation for sdk-utils package
+ *
+ * WHY THIS EXISTS:
+ * ================
+ * This is a self-contained proxy implementation copied and simplified from
+ * @percy/client/src/proxy.js. We cannot directly import from @percy/client/utils
+ * due to several module compatibility and build system issues:
+ *
+ * 1. MODULE TYPE MISMATCH:
+ *    - @percy/client is built as an ES module ("type": "module")
+ *    - @percy/sdk-utils gets built as CommonJS by Rollup/Babel
+ *    - Runtime import() calls get transformed to require() calls by the build system
+ *    - This causes "require() of ES Module not supported" errors at runtime
+ *
+ * 2. BUILD SYSTEM TRANSFORMATION:
+ *    - Rollup/Babel transforms dynamic imports even when marked as external
+ *    - Attempts to use eval() or Function constructor to bypass transformation
+ *      either fail with "experimental-vm-modules" requirements or still get transformed
+ *
+ * 3. DEPENDENCY RESOLUTION:
+ *    - Cross-package imports create complex dependency resolution issues
+ *    - The sdk-utils package needs to be self-contained for broader compatibility
+ *
+ * 4. RUNTIME ENVIRONMENT DIFFERENCES:
+ *    - sdk-utils may run in different environments than the main Percy CLI
+ *    - A local implementation ensures consistent behavior regardless of environment
+ *
+ * WHAT'S DIFFERENT FROM CLIENT VERSION:
+ * ====================================
+ * - Removed PAC proxy support (pac-proxy-agent dependency)
+ * - Removed @percy/env dependency (inlined stripQuotesAndSpaces function)
+ * - Uses local logger instead of @percy/logger
+ * - Simplified error handling and logging
+ * - Removed some advanced features to keep it lightweight
+ *
+ * This approach ensures proxy functionality works reliably without external
+ * import complications while maintaining the same core HTTP/HTTPS proxy features.
+ */
+
+// Returns true if the URL hostname matches any patterns
+export function hostnameMatches(patterns, url) {
+  let subject = new URL(url);
+
+  patterns = typeof patterns === 'string'
+    ? patterns.split(/[\s,]+/)
+    : [].concat(patterns);
+
+  for (let pattern of patterns) {
+    if (pattern === '*') return true;
+    if (!pattern) continue;
+
+    // parse pattern
+    let { groups: rule } = pattern.match(
+      /^(?<hostname>.+?)(?::(?<port>\d+))?$/
+    );
+
+    // missing a hostname or ports do not match
+    if (!rule.hostname || (rule.port && rule.port !== subject.port)) {
+      continue;
+    }
+
+    // wildcards are treated the same as leading dots
+    rule.hostname = rule.hostname.replace(/^\*/, '');
+
+    // hostnames are equal or end with a wildcard rule
+    if (rule.hostname === subject.hostname ||
+        (rule.hostname.startsWith('.') &&
+         subject.hostname.endsWith(rule.hostname))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// Returns the port number of a URL object. Defaults to port 443 for https
+// protocols or port 80 otherwise.
+export function port(options) {
+  if (options.port) return options.port;
+  return options.protocol === 'https:' ? 443 : 80;
+}
+
+// Returns a string representation of a URL-like object
+export function href(options) {
+  let { protocol, hostname, path, pathname, search, hash } = options;
+  return `${protocol}//${hostname}:${port(options)}` +
+    (path || `${pathname || ''}${search || ''}${hash || ''}`);
+}
+
+// Strip quotes and spaces from environment variables
+function stripQuotesAndSpaces(str) {
+  if (typeof str !== 'string') return str;
+  return str.replace(/^["'\s]+|["'\s]+$/g, '');
+}
+
+// Returns the proxy URL for a set of request options
+export function getProxy(options) {
+  let proxyUrl = (options.protocol === 'https:' &&
+    (process.env.https_proxy || process.env.HTTPS_PROXY)) ||
+    (process.env.http_proxy || process.env.HTTP_PROXY);
+
+  let shouldProxy = !!proxyUrl && !hostnameMatches(
+    stripQuotesAndSpaces(process.env.no_proxy || process.env.NO_PROXY),
+    href(options));
+
+  if (proxyUrl && typeof proxyUrl === 'string') {
+    proxyUrl = stripQuotesAndSpaces(proxyUrl);
+  }
+
+  if (shouldProxy) {
+    proxyUrl = new URL(proxyUrl);
+    let isHttps = proxyUrl.protocol === 'https:';
+
+    if (!isHttps && proxyUrl.protocol !== 'http:') {
+      throw new Error(`Unsupported proxy protocol: ${proxyUrl.protocol}`);
+    }
+
+    let proxy = { isHttps };
+    proxy.auth = !!proxyUrl.username && 'Basic ' + (proxyUrl.password
+      ? Buffer.from(`${proxyUrl.username}:${proxyUrl.password}`)
+      : Buffer.from(proxyUrl.username)).toString('base64');
+    proxy.host = proxyUrl.hostname;
+    proxy.port = port(proxyUrl);
+
+    proxy.connect = () => (isHttps ? tls : net).connect({
+      rejectUnauthorized: options.rejectUnauthorized,
+      host: proxy.host,
+      port: proxy.port
+    });
+
+    return proxy;
+  }
+}
+
+// Proxified http agent
+export class ProxyHttpAgent extends http.Agent {
+  // needed for https proxies
+  httpsAgent = new https.Agent({ keepAlive: true });
+
+  addRequest(request, options) {
+    let proxy = getProxy(options);
+    if (!proxy) return super.addRequest(request, options);
+    logger('sdk-utils:proxy').debug(`Proxying request: ${options.href}`);
+
+    // modify the request for proxying
+    request.path = href(options);
+
+    if (proxy.auth) {
+      request.setHeader('Proxy-Authorization', proxy.auth);
+    }
+
+    // regenerate headers since we just changed things
+    delete request._header;
+    request._implicitHeader();
+
+    if (request.outputData?.length > 0) {
+      let first = request.outputData[0].data;
+      let endOfHeaders = first.indexOf(CRLF.repeat(2)) + 4;
+      request.outputData[0].data = request._header +
+        first.substring(endOfHeaders);
+    }
+
+    // coerce the connection to the proxy
+    options.port = proxy.port;
+    options.host = proxy.host;
+    delete options.path;
+
+    if (proxy.isHttps) {
+      // use the underlying https agent to complete the connection
+      request.agent = this.httpsAgent;
+      return this.httpsAgent.addRequest(request, options);
+    } else {
+      return super.addRequest(request, options);
+    }
+  }
+}
+
+// Proxified https agent
+export class ProxyHttpsAgent extends https.Agent {
+  constructor(options) {
+    // default keep-alive
+    super({ keepAlive: true, ...options });
+  }
+
+  createConnection(options, callback) {
+    let proxy = getProxy(options);
+    if (!proxy) return super.createConnection(options, callback);
+    logger('sdk-utils:proxy').debug(`Proxying request: ${href(options)}`);
+
+    // generate proxy connect message
+    let host = `${options.hostname}:${port(options)}`;
+    let connectMessage = [`CONNECT ${host} HTTP/1.1`, `Host: ${host}`];
+
+    if (proxy.auth) {
+      connectMessage.push(`Proxy-Authorization: ${proxy.auth}`);
+    }
+
+    connectMessage = connectMessage.join(CRLF);
+    connectMessage += CRLF.repeat(2);
+
+    // start the proxy connection and setup listeners
+    let socket = proxy.connect();
+
+    let handleError = err => {
+      socket.destroy(err);
+      logger('sdk-utils:proxy').error(`Proxying request ${href(options)} failed: ${err}`);
+
+      // We don't get statusCode here, relying on checking error message only
+      if (!!err.message && (err.message?.includes('ECONNREFUSED') || err.message?.includes('EHOSTUNREACH'))) {
+        logger('sdk-utils:proxy').warn('If needed, Please verify if your proxy credentials are correct');
+        logger('sdk-utils:proxy').warn('Please check if your proxy is set correctly and reachable');
+      }
+
+      logger('sdk-utils:proxy').warn('Please check network connection, proxy and ensure that following domains are whitelisted: github.com, percy.io, storage.googleapis.com. In case you are an enterprise customer make sure to whitelist "percy-enterprise.browserstack.com" as well.');
+      callback(err);
+    };
+
+    let handleClose = () => handleError(
+      new Error('Connection closed while sending request to upstream proxy')
+    );
+
+    let buffer = '';
+    let handleData = data => {
+      buffer += data.toString();
+      // haven't received end of headers yet, keep buffering
+      if (!buffer.includes(CRLF.repeat(2))) return;
+      // stop listening after end of headers
+      socket.off('data', handleData);
+
+      if (buffer.match(STATUS_REG)?.[1] !== '200') {
+        return handleError(new Error(
+          'Error establishing proxy connection. ' +
+            `Response from server was: ${buffer}`
+        ));
+      }
+
+      options.socket = socket;
+      options.servername = options.hostname;
+      // callback not passed in so not to be added as a listener
+      callback(null, super.createConnection(options));
+    };
+
+    // send and handle the connect message
+    socket
+      .on('error', handleError)
+      .on('close', handleClose)
+      .on('data', handleData)
+      .write(connectMessage);
+  }
+}
+
+export function proxyAgentFor(url, options) {
+  let cache = (proxyAgentFor.cache ||= new Map());
+  let { protocol, hostname } = new URL(url);
+  let cachekey = `${protocol}//${hostname}`;
+
+  // If we already have a cached agent, return it
+  if (cache.has(cachekey)) {
+    return cache.get(cachekey);
+  }
+
+  try {
+    let agent;
+
+    // Create the appropriate proxy agent based on protocol
+    agent = protocol === 'https:'
+      ? new ProxyHttpsAgent(options)
+      : new ProxyHttpAgent(options);
+
+    // Cache the created agent
+    cache.set(cachekey, agent);
+    return agent;
+  } catch (error) {
+    logger('sdk-utils:proxy').error(`Failed to create proxy agent: ${error.message}`);
+    throw error;
+  }
+}

--- a/packages/sdk-utils/src/request.js
+++ b/packages/sdk-utils/src/request.js
@@ -65,6 +65,7 @@ if (process.env.__PERCY_BROWSERIFIED__) {
     } catch (error) {
       // Failed to load proxy module or create proxy agent (e.g., missing proxy.js, invalid proxy config)
       // Continue without proxy support - requests will go directly without proxy
+      /* istanbul ignore next */
       logger('sdk-utils:request').debug(`Proxy agent unavailable: ${error.message}`);
     }
 

--- a/packages/sdk-utils/src/request.js
+++ b/packages/sdk-utils/src/request.js
@@ -54,8 +54,27 @@ if (process.env.__PERCY_BROWSERIFIED__) {
     // rollup throws error for -> await import(protocol === 'https:' ? 'https' : 'http')
     let { default: http } = protocol === 'https:' ? await import('https') : await import('http');
 
-    return new Promise((resolve, reject) => {
-      http.request(url, options)
+    return new Promise(async (resolve, reject) => {
+      // Use proxy agent if available
+      const requestOptions = { ...options };
+      
+      // Try to get proxy agent using Function constructor to avoid Babel transformation
+      try {
+        const dynamicImport = new Function('specifier', 'return import(specifier)');
+        const { proxyAgentFor } = await dynamicImport('@percy/client/utils');
+        const agent = proxyAgentFor(url);
+        if (agent) {
+          requestOptions.agent = agent;
+        }
+      } catch (error) {
+        // Silently continue without proxy - this is expected when @percy/client is not available
+        // Only log in development/debug scenarios
+        if (process.env.NODE_ENV === 'development' && typeof window === 'undefined') {
+          console.warn('Proxy agent not available:', error.message);
+        }
+      }
+
+      http.request(url, requestOptions)
         .on('response', response => {
           let body = '';
 

--- a/packages/sdk-utils/test/proxy.test.js
+++ b/packages/sdk-utils/test/proxy.test.js
@@ -508,8 +508,8 @@ describe('sdk-utils proxy', () => {
         const warnCalls = logSpy.calls.all().filter(call => call.args[1] === 'warn');
         expect(warnCalls.length).toBeGreaterThan(0);
         const warnMessages = warnCalls.map(call => call.args[2]);
-        expect(warnMessages).toContain('If needed, Please verify if your proxy credentials are correct');
-        expect(warnMessages).toContain('Please check if your proxy is set correctly and reachable');
+        expect(warnMessages).toContain('If needed, please verify that your proxy credentials are correct.');
+        expect(warnMessages).toContain('Please check that your proxy is configured correctly and reachable.');
         done();
       }, 20);
     });

--- a/packages/sdk-utils/test/proxy.test.js
+++ b/packages/sdk-utils/test/proxy.test.js
@@ -1,0 +1,506 @@
+// NOTE: Proxy tests only run in Node.js environments since they use Node.js-specific modules
+// This file is excluded from browser tests in karma.config.cjs
+import {
+  hostnameMatches,
+  port,
+  href,
+  getProxy,
+  ProxyHttpAgent,
+  ProxyHttpsAgent,
+  proxyAgentFor
+} from '../src/proxy.js';
+import http from 'http';
+import https from 'https';
+
+describe('sdk-utils proxy', () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    // Store original environment variables
+    originalEnv = {
+      HTTP_PROXY: process.env.HTTP_PROXY,
+      HTTPS_PROXY: process.env.HTTPS_PROXY,
+      http_proxy: process.env.http_proxy,
+      https_proxy: process.env.https_proxy,
+      NO_PROXY: process.env.NO_PROXY,
+      no_proxy: process.env.no_proxy
+    };
+
+    // Clear all proxy environment variables
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+
+    // Clear proxy agent cache
+    if (proxyAgentFor && proxyAgentFor.cache) {
+      proxyAgentFor.cache.clear();
+    }
+  });
+
+  afterEach(() => {
+    // Clear proxy agent cache
+    if (proxyAgentFor && proxyAgentFor.cache) {
+      proxyAgentFor.cache.clear();
+    }
+
+    // Restore original environment variables
+    Object.keys(originalEnv).forEach(key => {
+      if (originalEnv[key] !== undefined) {
+        process.env[key] = originalEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    });
+  });
+
+  describe('utility functions', () => {
+    describe('hostnameMatches', () => {
+      it('returns true for exact hostname matches', () => {
+        expect(hostnameMatches('example.com', 'http://example.com')).toBe(true);
+        expect(hostnameMatches('example.com:8080', 'http://example.com:8080')).toBe(true);
+      });
+
+      it('returns false for non-matching hostnames', () => {
+        expect(hostnameMatches('example.com', 'http://other.com')).toBe(false);
+        expect(hostnameMatches('example.com:8080', 'http://example.com:3000')).toBe(false);
+      });
+
+      it('supports wildcard patterns', () => {
+        expect(hostnameMatches('*', 'http://example.com')).toBe(true);
+        expect(hostnameMatches('*.example.com', 'http://sub.example.com')).toBe(true);
+        expect(hostnameMatches('.example.com', 'http://sub.example.com')).toBe(true);
+      });
+
+      it('supports comma-separated patterns', () => {
+        expect(hostnameMatches('localhost,127.0.0.1', 'http://localhost')).toBe(true);
+        expect(hostnameMatches('localhost,127.0.0.1', 'http://127.0.0.1')).toBe(true);
+        expect(hostnameMatches('localhost,127.0.0.1', 'http://example.com')).toBe(false);
+      });
+
+      it('supports array of patterns', () => {
+        expect(hostnameMatches(['localhost', '127.0.0.1'], 'http://localhost')).toBe(true);
+        expect(hostnameMatches(['localhost', '127.0.0.1'], 'http://example.com')).toBe(false);
+      });
+
+      it('handles empty patterns gracefully', () => {
+        expect(hostnameMatches('', 'http://example.com')).toBe(false);
+        expect(hostnameMatches([], 'http://example.com')).toBe(false);
+      });
+    });
+
+    describe('port', () => {
+      it('returns the port if specified', () => {
+        expect(port({ port: 8080 })).toBe(8080);
+        expect(port({ port: '3000' })).toBe('3000');
+      });
+
+      it('returns 443 for https protocols', () => {
+        expect(port({ protocol: 'https:' })).toBe(443);
+      });
+
+      it('returns 80 for non-https protocols', () => {
+        expect(port({ protocol: 'http:' })).toBe(80);
+        expect(port({ protocol: 'ftp:' })).toBe(80);
+        expect(port({})).toBe(80);
+      });
+    });
+
+    describe('href', () => {
+      it('constructs URL from options with port', () => {
+        const options = {
+          protocol: 'https:',
+          hostname: 'example.com',
+          port: 8080,
+          path: '/api/test'
+        };
+        expect(href(options)).toBe('https://example.com:8080/api/test');
+      });
+
+      it('constructs URL with default ports', () => {
+        expect(href({
+          protocol: 'https:',
+          hostname: 'example.com',
+          pathname: '/test',
+          search: '?q=1'
+        })).toBe('https://example.com:443/test?q=1');
+      });
+
+      it('handles missing path components', () => {
+        expect(href({
+          protocol: 'http:',
+          hostname: 'example.com'
+        })).toBe('http://example.com:80');
+      });
+    });
+
+    describe('getProxy', () => {
+      it('returns undefined when no proxy is configured', () => {
+        const options = { protocol: 'http:', hostname: 'example.com' };
+        expect(getProxy(options)).toBeUndefined();
+      });
+
+      it('returns proxy object for http requests with http_proxy', () => {
+        process.env.http_proxy = 'http://proxy.example.com:8080';
+        const options = { protocol: 'http:', hostname: 'example.com' };
+        const proxy = getProxy(options);
+
+        expect(proxy).toBeDefined();
+        expect(proxy.host).toBe('proxy.example.com');
+        expect(proxy.port).toBe('8080');
+        expect(proxy.isHttps).toBe(false);
+        expect(proxy.auth).toBeFalsy();
+      });
+
+      it('returns proxy object for https requests with https_proxy', () => {
+        process.env.https_proxy = 'http://proxy.example.com:8080';
+        const options = { protocol: 'https:', hostname: 'example.com' };
+        const proxy = getProxy(options);
+
+        expect(proxy).toBeDefined();
+        expect(proxy.host).toBe('proxy.example.com');
+        expect(proxy.port).toBe('8080');
+        expect(proxy.isHttps).toBe(false);
+      });
+
+      it('supports uppercase environment variables', () => {
+        process.env.HTTPS_PROXY = 'http://proxy.example.com:3128';
+        const options = { protocol: 'https:', hostname: 'example.com' };
+        const proxy = getProxy(options);
+
+        expect(proxy).toBeDefined();
+        expect(proxy.host).toBe('proxy.example.com');
+        expect(proxy.port).toBe('3128');
+      });
+
+      it('includes auth when proxy URL has credentials', () => {
+        process.env.http_proxy = 'http://user:pass@proxy.example.com:8080';
+        const options = { protocol: 'http:', hostname: 'example.com' };
+        const proxy = getProxy(options);
+
+        expect(proxy).toBeDefined();
+        expect(proxy.auth).toBeTruthy();
+        expect(proxy.auth).toMatch(/^Basic /);
+      });
+
+      it('includes auth when proxy URL has username only', () => {
+        process.env.http_proxy = 'http://user@proxy.example.com:8080';
+        const options = { protocol: 'http:', hostname: 'example.com' };
+        const proxy = getProxy(options);
+
+        expect(proxy).toBeDefined();
+        expect(proxy.auth).toBeTruthy();
+        expect(proxy.auth).toMatch(/^Basic /);
+      });
+
+      it('supports https proxy URLs', () => {
+        process.env.http_proxy = 'https://proxy.example.com:8080';
+        const options = { protocol: 'http:', hostname: 'example.com' };
+        const proxy = getProxy(options);
+
+        expect(proxy).toBeDefined();
+        expect(proxy.isHttps).toBe(true);
+      });
+
+      it('throws error for unsupported proxy protocols', () => {
+        process.env.http_proxy = 'socks5://proxy.example.com:1080';
+        const options = { protocol: 'http:', hostname: 'example.com' };
+
+        expect(() => getProxy(options)).toThrow();
+
+        // Verify the error message contains the expected text
+        try {
+          getProxy(options);
+        } catch (error) {
+          expect(error.message).toContain('Unsupported proxy protocol: socks5:');
+        }
+      });
+
+      it('respects NO_PROXY environment variable', () => {
+        process.env.http_proxy = 'http://proxy.example.com:8080';
+        process.env.NO_PROXY = 'localhost,127.0.0.1,example.com';
+
+        const options = { protocol: 'http:', hostname: 'example.com' };
+        expect(getProxy(options)).toBeUndefined();
+
+        const options2 = { protocol: 'http:', hostname: 'other.com' };
+        expect(getProxy(options2)).toBeDefined();
+      });
+
+      it('respects no_proxy environment variable (lowercase)', () => {
+        process.env.http_proxy = 'http://proxy.example.com:8080';
+        process.env.no_proxy = 'localhost,127.0.0.1,example.com';
+
+        const options = { protocol: 'http:', hostname: 'example.com' };
+        expect(getProxy(options)).toBeUndefined();
+      });
+
+      it('strips quotes and spaces from proxy URLs', () => {
+        process.env.http_proxy = '  "http://proxy.example.com:8080"  ';
+        const options = { protocol: 'http:', hostname: 'example.com' };
+        const proxy = getProxy(options);
+
+        expect(proxy).toBeDefined();
+        expect(proxy.host).toBe('proxy.example.com');
+      });
+
+      it('provides connect function for socket connection', () => {
+        process.env.http_proxy = 'http://proxy.example.com:8080';
+        const options = { protocol: 'http:', hostname: 'example.com' };
+        const proxy = getProxy(options);
+
+        expect(proxy).toBeDefined();
+        expect(typeof proxy.connect).toBe('function');
+      });
+    });
+  });
+
+  describe('ProxyHttpAgent', () => {
+    let agent;
+
+    beforeEach(() => {
+      agent = new ProxyHttpAgent();
+    });
+
+    it('should be an instance of http.Agent', () => {
+      expect(agent).toBeInstanceOf(http.Agent);
+    });
+
+    it('should have an httpsAgent property', () => {
+      expect(agent.httpsAgent).toBeInstanceOf(https.Agent);
+      expect(agent.httpsAgent.keepAlive).toBe(true);
+    });
+
+    it('should call super.addRequest when no proxy is configured', () => {
+      const mockRequest = {
+        setHeader: jasmine.createSpy('setHeader'),
+        _implicitHeader: jasmine.createSpy('_implicitHeader'),
+        outputData: []
+      };
+      const options = { protocol: 'http:', hostname: 'example.com', href: 'http://example.com' };
+
+      spyOn(http.Agent.prototype, 'addRequest');
+      agent.addRequest(mockRequest, options);
+
+      expect(http.Agent.prototype.addRequest).toHaveBeenCalledWith(mockRequest, options);
+    });
+
+    it('should modify request path when proxy is configured', () => {
+      process.env.http_proxy = 'http://proxy.example.com:8080';
+
+      const mockRequest = {
+        path: '/api/test',
+        setHeader: jasmine.createSpy('setHeader'),
+        _implicitHeader: jasmine.createSpy('_implicitHeader'),
+        outputData: []
+      };
+      const options = {
+        protocol: 'http:',
+        hostname: 'example.com',
+        href: 'http://example.com/api/test',
+        port: 80,
+        path: '/api/test'
+      };
+
+      spyOn(http.Agent.prototype, 'addRequest');
+      agent.addRequest(mockRequest, options);
+
+      expect(mockRequest.path).toBe('http://example.com:80/api/test');
+    });
+
+    it('should set Proxy-Authorization header when proxy has auth', () => {
+      process.env.http_proxy = 'http://user:pass@proxy.example.com:8080';
+
+      const mockRequest = {
+        path: '/api/test',
+        setHeader: jasmine.createSpy('setHeader'),
+        _implicitHeader: jasmine.createSpy('_implicitHeader'),
+        outputData: []
+      };
+      const options = {
+        protocol: 'http:',
+        hostname: 'example.com',
+        href: 'http://example.com/api/test'
+      };
+
+      spyOn(http.Agent.prototype, 'addRequest');
+      agent.addRequest(mockRequest, options);
+
+      expect(mockRequest.setHeader).toHaveBeenCalledWith('Proxy-Authorization', jasmine.any(String));
+    });
+
+    it('should use httpsAgent for https proxy', () => {
+      process.env.http_proxy = 'https://proxy.example.com:8080';
+
+      const mockRequest = {
+        path: '/api/test',
+        setHeader: jasmine.createSpy('setHeader'),
+        _implicitHeader: jasmine.createSpy('_implicitHeader'),
+        outputData: [],
+        agent: null
+      };
+      const options = {
+        protocol: 'http:',
+        hostname: 'example.com',
+        href: 'http://example.com/api/test'
+      };
+
+      spyOn(agent.httpsAgent, 'addRequest');
+      agent.addRequest(mockRequest, options);
+
+      expect(mockRequest.agent).toBe(agent.httpsAgent);
+      expect(agent.httpsAgent.addRequest).toHaveBeenCalled();
+    });
+
+    it('should handle request with existing outputData', () => {
+      process.env.http_proxy = 'http://proxy.example.com:8080';
+
+      const mockRequest = {
+        path: '/api/test',
+        setHeader: jasmine.createSpy('setHeader'),
+        _implicitHeader: jasmine.createSpy('_implicitHeader'),
+        _header: 'GET /api/test HTTP/1.1\r\nHost: example.com\r\n\r\n',
+        outputData: [{
+          data: 'GET /api/test HTTP/1.1\r\nHost: example.com\r\n\r\nrequest body'
+        }]
+      };
+      const options = {
+        protocol: 'http:',
+        hostname: 'example.com',
+        href: 'http://example.com/api/test'
+      };
+
+      spyOn(http.Agent.prototype, 'addRequest');
+      agent.addRequest(mockRequest, options);
+
+      expect(mockRequest.outputData[0].data).toContain('request body');
+    });
+  });
+
+  describe('ProxyHttpsAgent', () => {
+    let agent;
+
+    beforeEach(() => {
+      agent = new ProxyHttpsAgent();
+    });
+
+    it('should be an instance of https.Agent', () => {
+      expect(agent).toBeInstanceOf(https.Agent);
+    });
+
+    it('should have keepAlive enabled by default', () => {
+      expect(agent.keepAlive).toBe(true);
+    });
+
+    it('should accept custom options', () => {
+      const customAgent = new ProxyHttpsAgent({ maxSockets: 10 });
+      expect(customAgent.maxSockets).toBe(10);
+      expect(customAgent.keepAlive).toBe(true); // should still have keepAlive
+    });
+
+    it('should call super.createConnection when no proxy is configured', () => {
+      const options = { hostname: 'example.com', port: 443 };
+      const callback = jasmine.createSpy('callback');
+
+      spyOn(https.Agent.prototype, 'createConnection');
+      agent.createConnection(options, callback);
+
+      expect(https.Agent.prototype.createConnection).toHaveBeenCalledWith(options, callback);
+    });
+
+    it('should handle proxy connection setup', () => {
+      // This test verifies that the ProxyHttpsAgent can be instantiated
+      // and has the expected structure for proxy connections
+      // Full integration testing of proxy connections is complex and
+      // better handled by integration tests
+      expect(typeof agent.createConnection).toBe('function');
+    });
+  });
+
+  describe('proxyAgentFor', () => {
+    beforeEach(() => {
+      // Clear cache before each test
+      if (proxyAgentFor && proxyAgentFor.cache) {
+        proxyAgentFor.cache.clear();
+      }
+    });
+
+    it('should create and cache HTTP agent for http URLs', () => {
+      const url = 'http://example.com';
+      const options = {};
+
+      const agent = proxyAgentFor(url, options);
+
+      expect(agent).toBeInstanceOf(ProxyHttpAgent);
+      expect(proxyAgentFor.cache.has('http://example.com')).toBe(true);
+      expect(proxyAgentFor.cache.get('http://example.com')).toBe(agent);
+    });
+
+    it('should create and cache HTTPS agent for https URLs', () => {
+      const url = 'https://example.com';
+      const options = {};
+
+      const agent = proxyAgentFor(url, options);
+
+      expect(agent).toBeInstanceOf(ProxyHttpsAgent);
+      expect(proxyAgentFor.cache.has('https://example.com')).toBe(true);
+      expect(proxyAgentFor.cache.get('https://example.com')).toBe(agent);
+    });
+
+    it('should return cached agent when available', () => {
+      const url = 'http://example.com';
+      const options = {};
+
+      const agent1 = proxyAgentFor(url, options);
+      const agent2 = proxyAgentFor(url, options);
+
+      expect(agent1).toBe(agent2);
+      expect(proxyAgentFor.cache.size).toBe(1);
+    });
+
+    it('should cache agents by protocol and hostname', () => {
+      const httpUrl = 'http://example.com/path1';
+      const httpsUrl = 'https://example.com/path2';
+      const httpUrl2 = 'http://example.com/different-path';
+
+      const httpAgent = proxyAgentFor(httpUrl);
+      const httpsAgent = proxyAgentFor(httpsUrl);
+      const httpAgent2 = proxyAgentFor(httpUrl2);
+
+      expect(httpAgent).toBe(httpAgent2); // same protocol+hostname should return same agent
+      expect(httpAgent).not.toBe(httpsAgent); // different protocol should be different agent
+      expect(proxyAgentFor.cache.size).toBe(2);
+    });
+
+    it('should pass options to agent constructor', () => {
+      const url = 'https://example.com';
+      const options = { maxSockets: 15 };
+
+      const agent = proxyAgentFor(url, options);
+
+      expect(agent).toBeInstanceOf(ProxyHttpsAgent);
+      expect(agent.maxSockets).toBe(15);
+    });
+
+    it('should handle URL parsing correctly', () => {
+      const url = 'https://sub.example.com:8443/api/test?param=value';
+
+      const agent = proxyAgentFor(url);
+
+      expect(agent).toBeInstanceOf(ProxyHttpsAgent);
+      expect(proxyAgentFor.cache.has('https://sub.example.com')).toBe(true);
+    });
+
+    it('should handle errors gracefully', () => {
+      // Test that proxyAgentFor handles errors properly
+      // This is a basic test to ensure the function structure is correct
+      expect(typeof proxyAgentFor).toBe('function');
+    });
+
+    it('should have a cache property that is a Map', () => {
+      expect(proxyAgentFor.cache).toBeInstanceOf(Map);
+    });
+  });
+});

--- a/packages/sdk-utils/test/request.test.js
+++ b/packages/sdk-utils/test/request.test.js
@@ -117,7 +117,7 @@ describe('Utils Requests', () => {
         NO_PROXY: process.env.NO_PROXY,
         no_proxy: process.env.no_proxy
       };
-      
+
       // Clear proxy environment variables
       delete process.env.HTTP_PROXY;
       delete process.env.HTTPS_PROXY;
@@ -143,7 +143,7 @@ describe('Utils Requests', () => {
       if (proxyAgentFor && proxyAgentFor.cache) {
         proxyAgentFor.cache.clear();
       }
-      
+
       // Restore original environment variables
       Object.keys(originalEnv).forEach(key => {
         if (originalEnv[key] !== undefined) {
@@ -163,7 +163,7 @@ describe('Utils Requests', () => {
       // Set proxy but exclude localhost from proxying
       process.env.https_proxy = 'http://nonexistent-proxy:8080';
       process.env.NO_PROXY = 'localhost,127.0.0.1';
-      
+
       // Request should work because localhost is in NO_PROXY
       let res = await utils.request(server.address);
       expect(res.body).toBe('test');
@@ -172,7 +172,7 @@ describe('Utils Requests', () => {
     it('handles proxy configuration gracefully when proxy is unavailable', async () => {
       // Set a proxy that doesn't exist
       process.env.https_proxy = 'http://nonexistent-proxy:8080';
-      
+
       // The request should fail gracefully with a meaningful error
       try {
         await utils.request(server.address);

--- a/packages/sdk-utils/test/request.test.js
+++ b/packages/sdk-utils/test/request.test.js
@@ -102,4 +102,86 @@ describe('Utils Requests', () => {
     let res = await utils.request(server.address);
     expect(res.body).toBe('test');
   });
+
+  describe('with proxy configuration', () => {
+    let originalEnv;
+    let proxyAgentFor;
+
+    beforeEach(async () => {
+      // Store original environment variables
+      originalEnv = {
+        HTTP_PROXY: process.env.HTTP_PROXY,
+        HTTPS_PROXY: process.env.HTTPS_PROXY,
+        http_proxy: process.env.http_proxy,
+        https_proxy: process.env.https_proxy,
+        NO_PROXY: process.env.NO_PROXY,
+        no_proxy: process.env.no_proxy
+      };
+      
+      // Clear proxy environment variables
+      delete process.env.HTTP_PROXY;
+      delete process.env.HTTPS_PROXY;
+      delete process.env.http_proxy;
+      delete process.env.https_proxy;
+      delete process.env.NO_PROXY;
+      delete process.env.no_proxy;
+
+      // Import and clear proxy agent cache
+      try {
+        const proxyModule = await import('../src/proxy.js');
+        proxyAgentFor = proxyModule.proxyAgentFor;
+        if (proxyAgentFor && proxyAgentFor.cache) {
+          proxyAgentFor.cache.clear();
+        }
+      } catch (e) {
+        // Ignore if proxy module doesn't exist
+      }
+    });
+
+    afterEach(() => {
+      // Clear proxy agent cache again after each test
+      if (proxyAgentFor && proxyAgentFor.cache) {
+        proxyAgentFor.cache.clear();
+      }
+      
+      // Restore original environment variables
+      Object.keys(originalEnv).forEach(key => {
+        if (originalEnv[key] !== undefined) {
+          process.env[key] = originalEnv[key];
+        } else {
+          delete process.env[key];
+        }
+      });
+    });
+
+    it('makes request successfully when no proxy is configured', async () => {
+      let res = await utils.request(server.address);
+      expect(res.body).toBe('test');
+    });
+
+    it('skips proxy when hostname matches NO_PROXY', async () => {
+      // Set proxy but exclude localhost from proxying
+      process.env.https_proxy = 'http://nonexistent-proxy:8080';
+      process.env.NO_PROXY = 'localhost,127.0.0.1';
+      
+      // Request should work because localhost is in NO_PROXY
+      let res = await utils.request(server.address);
+      expect(res.body).toBe('test');
+    });
+
+    it('handles proxy configuration gracefully when proxy is unavailable', async () => {
+      // Set a proxy that doesn't exist
+      process.env.https_proxy = 'http://nonexistent-proxy:8080';
+      
+      // The request should fail gracefully with a meaningful error
+      try {
+        await utils.request(server.address);
+        // If we get here, the proxy was bypassed somehow
+        fail('Expected request to fail with proxy error');
+      } catch (error) {
+        // Should be a meaningful proxy-related error
+        expect(error.message).toMatch(/socket hang up|ENOTFOUND|ECONNREFUSED|EHOSTUNREACH|Connection closed/i);
+      }
+    });
+  });
 });

--- a/packages/sdk-utils/test/request.test.js
+++ b/packages/sdk-utils/test/request.test.js
@@ -180,7 +180,7 @@ describe('Utils Requests', () => {
         fail('Expected request to fail with proxy error');
       } catch (error) {
         // Should be a meaningful proxy-related error
-        expect(error.message).toMatch(/socket hang up|ENOTFOUND|ECONNREFUSED|EHOSTUNREACH|Connection closed/i);
+        expect(error.message).toMatch(/socket hang up|ENOTFOUND|ECONNREFUSED|EHOSTUNREACH|EAI_AGAIN|Connection closed/i);
       }
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2368,6 +2368,11 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz#821f8442f4175d8f0467b9daf26e3a18e2d02af2"
   integrity sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==
 
+"@tootallnate/once@1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
+  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
@@ -2514,10 +2519,22 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
+acorn-walk@^8.2.0:
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
+  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+  dependencies:
+    acorn "^8.11.0"
+
 acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.11.0, acorn@^8.7.0:
+  version "8.15.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
+  integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -2760,7 +2777,7 @@ asap@^2.0.0:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
-ast-types@^0.13.4:
+ast-types@^0.13.2, ast-types@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782"
   integrity sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==
@@ -3513,6 +3530,11 @@ dargs@^7.0.0:
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
 
+data-uri-to-buffer@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
+  integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
+
 data-uri-to-buffer@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz#8a58bb67384b261a38ef18bea1810cb01badd28b"
@@ -3616,6 +3638,11 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deep-is@~0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
 deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
@@ -3664,6 +3691,16 @@ define-properties@^1.2.0, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+degenerator@^3.0.2:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-3.0.4.tgz#07ccf95bc11044a37a6efc2f66029fb636e31f24"
+  integrity sha512-Z66uPeBfHZAHVmue3HPfyKu2Q0rC2cRxbTOsvmU/po5fvvcx27W4mIu9n0PUlQih4oUYvcG1BsbtVv8x7KDOSw==
+  dependencies:
+    ast-types "^0.13.2"
+    escodegen "^1.8.1"
+    esprima "^4.0.0"
+    vm2 "^3.9.17"
 
 degenerator@^5.0.0:
   version "5.0.1"
@@ -4099,6 +4136,18 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+escodegen@^1.8.1:
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
+  integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 escodegen@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17"
@@ -4310,7 +4359,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.1.1:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -4412,7 +4461,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@^2.0.6:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -4449,6 +4498,11 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-uri-to-path@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz#7b415aeba227d575851e0a5b0c640d7656403fba"
+  integrity sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==
 
 filelist@^1.0.1:
   version "1.0.4"
@@ -4606,6 +4660,15 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
@@ -4642,6 +4705,14 @@ fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
+ftp@^0.3.10:
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/ftp/-/ftp-0.3.10.tgz#9197d861ad8142f3e63d5a83bfe4c59f7330885d"
+  integrity sha512-faFVML1aBx2UoDStmLwv2Wptt4vw5x03xxX172nhA5Y5HBshW5JweqQ2W4xL4dezQTG8inJsuYcpPHHU3X5OTQ==
+  dependencies:
+    readable-stream "1.1.x"
+    xregexp "2.0.0"
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -4806,6 +4877,18 @@ get-symbol-description@^1.0.2:
     call-bind "^1.0.5"
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
+
+get-uri@3:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-3.0.2.tgz#f0ef1356faabc70e1f9404fa3b66b2ba9bfc725c"
+  integrity sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==
+  dependencies:
+    "@tootallnate/once" "1"
+    data-uri-to-buffer "3"
+    debug "4"
+    file-uri-to-path "2"
+    fs-extra "^8.1.0"
+    ftp "^0.3.10"
 
 get-uri@^6.0.1:
   version "6.0.4"
@@ -5150,6 +5233,15 @@ http-errors@2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
+http-proxy-agent@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
+  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
+  dependencies:
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
+
 http-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
@@ -5175,6 +5267,14 @@ http-proxy@^1.18.1:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
+
+https-proxy-agent@5:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 https-proxy-agent@^5.0.0:
   version "5.0.0"
@@ -5286,7 +5386,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5343,6 +5443,11 @@ internal-slot@^1.0.7:
     es-errors "^1.3.0"
     hasown "^2.0.0"
     side-channel "^1.0.4"
+
+ip-address@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.0.1.tgz#a8180b783ce7788777d796286d61bce4276818ed"
+  integrity sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==
 
 ip-address@^9.0.5:
   version "9.0.5"
@@ -5631,6 +5736,11 @@ is-wsl@^2.2.0:
   dependencies:
     is-docker "^2.0.0"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
+
 isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
@@ -5870,6 +5980,13 @@ jsonc-parser@3.2.0:
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -6004,6 +6121,14 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
+
+levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
 
 libnpmaccess@^6.0.3:
   version "6.0.3"
@@ -6889,6 +7014,18 @@ open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
+optionator@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
+  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.6"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    word-wrap "~1.2.3"
+
 optionator@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
@@ -7022,6 +7159,21 @@ p-waterfall@^2.1.1:
   dependencies:
     p-reduce "^2.0.0"
 
+pac-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz#b718f76475a6a5415c2efbe256c1c971c84f635e"
+  integrity sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==
+  dependencies:
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
+    get-uri "3"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "5"
+    pac-resolver "^5.0.0"
+    raw-body "^2.2.0"
+    socks-proxy-agent "5"
+
 pac-proxy-agent@^7.0.2:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz#9cfaf33ff25da36f6147a20844230ec92c06e5df"
@@ -7035,6 +7187,15 @@ pac-proxy-agent@^7.0.2:
     https-proxy-agent "^7.0.6"
     pac-resolver "^7.0.1"
     socks-proxy-agent "^8.0.5"
+
+pac-resolver@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-5.0.1.tgz#c91efa3a9af9f669104fa2f51102839d01cde8e7"
+  integrity sha512-cy7u00ko2KVgBAjuhevqpPeHIkCIqPe1v24cydhWjmeuzaBfmUWFCZJ1iAh5TuVzVZoUzXIW7K8sMYOZ84uZ9Q==
+  dependencies:
+    degenerator "^3.0.2"
+    ip "^1.1.5"
+    netmask "^2.0.2"
 
 pac-resolver@^7.0.1:
   version "7.0.1"
@@ -7272,6 +7433,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
+
 pretty-format@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.5.0.tgz#283134e74f70e2e3e7229336de0e4fce94ccde5a"
@@ -7400,7 +7566,7 @@ range-parser@^1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-raw-body@2.5.2:
+raw-body@2.5.2, raw-body@^2.2.0:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.2.tgz#99febd83b90e08975087e8f1f9419a149366b68a"
   integrity sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==
@@ -7480,6 +7646,16 @@ read@1, read@^1.0.7:
   integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
   dependencies:
     mute-stream "~0.0.4"
+
+readable-stream@1.1.x:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  integrity sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
@@ -7920,6 +8096,15 @@ socket.io@^4.7.2:
     socket.io-adapter "~2.5.2"
     socket.io-parser "~4.2.4"
 
+socks-proxy-agent@5:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz#032fb583048a29ebffec2e6a73fca0761f48177e"
+  integrity sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==
+  dependencies:
+    agent-base "^6.0.2"
+    debug "4"
+    socks "^2.3.3"
+
 socks-proxy-agent@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz#dc069ecf34436621acb41e3efa66ca1b5fed15b6"
@@ -7937,6 +8122,14 @@ socks-proxy-agent@^8.0.5:
     agent-base "^7.1.2"
     debug "^4.3.4"
     socks "^2.8.3"
+
+socks@^2.3.3:
+  version "2.8.7"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.7.tgz#e2fb1d9a603add75050a2067db8c381a0b5669ea"
+  integrity sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==
+  dependencies:
+    ip-address "^10.0.1"
+    smart-buffer "^4.2.0"
 
 socks@^2.6.2:
   version "2.6.2"
@@ -8153,6 +8346,11 @@ string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -8415,6 +8613,13 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  integrity sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==
+  dependencies:
+    prelude-ls "~1.1.2"
+
 type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
@@ -8593,6 +8798,11 @@ universal-user-agent@^6.0.0:
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
   integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
@@ -8679,6 +8889,14 @@ vary@^1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
+
+vm2@^3.9.17:
+  version "3.9.19"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.19.tgz#be1e1d7a106122c6c492b4d51c2e8b93d3ed6a4a"
+  integrity sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==
+  dependencies:
+    acorn "^8.7.0"
+    acorn-walk "^8.2.0"
 
 void-elements@^2.0.0:
   version "2.0.1"
@@ -8769,6 +8987,11 @@ word-wrap@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.4.tgz#cb4b50ec9aca570abd1f52f33cd45b6c61739a9f"
   integrity sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==
+
+word-wrap@~1.2.3:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
+  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
 wordwrap@^1.0.0:
   version "1.0.0"
@@ -8867,6 +9090,11 @@ ws@~8.17.1:
   version "8.17.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
   integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+
+xregexp@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-2.0.0.tgz#52a63e56ca0b84a7f3a5f3d61872f126ad7a5943"
+  integrity sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
### Changes - 
1. Added support for proxy for PoA session for communication with browserstack hub.
2. The proxy usage changes are similar to proxy present in `@percy/client` package
3. Why it was needed to be implemented separately for sdk-utils - [[here](https://github.com/percy/cli/pull/2000/files#diff-60d1759380643130d5b97b609ceaa4edf89edc6a5308040e68a4fe0c2979a037R15)] 

### Dev Testing - 
1. Have setup a local proxy and analysed the logs of proxy
2. With current CLI, only percy.io calls are going via proxy
3. With this change `percy.io` and `hub-cloud.browserstack.com` both goes via proxy
<img width="1119" height="186" alt="image" src="https://github.com/user-attachments/assets/d5a236e9-0f1c-4d0b-ba3d-4165252d9f8b" />
