### PR TITLE
handle unsupported stylesheets gracefully in serializeCSSOM

### DIFF
--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -59,7 +59,7 @@ export function serializeCSSOM(ctx) {
         let cloneOwnerNode;
         try {
           styleId = styleSheet.ownerNode.getAttribute('data-percy-element-id');
-          if (!styleId) continue;
+          if (!styleId && process.env.PERCY_SKIP_UNSUPPORTED_STYLESHEETS) continue;
           cloneOwnerNode = clone.querySelector(`[data-percy-element-id="${styleId}"]`);
           if (styleSheetsMatch(styleSheet, styleSheetFromNode(cloneOwnerNode))) continue;
           let style = document.createElement('style');

--- a/packages/dom/test/serialize-css.test.js
+++ b/packages/dom/test/serialize-css.test.js
@@ -256,7 +256,19 @@ describe('serializeCSSOM', () => {
       let link = '<link rel="stylesheet" href="data:text/css,.box { margin: 10px; }"/>';
       withExample(`<div class="box"></div>${link}}`);
       withCSSOM('.box { height: 500px; }');
+      expect(() => serializeCSSOM({ dom: document })).toThrowMatching((error) => {
+        return error.message.includes('Error serializing stylesheet:') &&
+          error.message.includes('{"styleId":null}');
+      });
+    });
+
+    it('handles error and add stylesheet details', () => {
+      process.env.PERCY_SKIP_UNSUPPORTED_STYLESHEETS = 'true';
+      let link = '<link rel="stylesheet" href="data:text/css,.box { margin: 10px; }"/>';
+      withExample(`<div class="box"></div>${link}}`);
+      withCSSOM('.box { height: 500px; }');
       expect(() => serializeCSSOM({ dom: document })).not.toThrow();
+      delete process.env.PERCY_SKIP_UNSUPPORTED_STYLESHEETS;
     });
 
     it('falls back when stylesheet cssRules access throws', () => {


### PR DESCRIPTION
This PR adds graceful handling for unsupported stylesheets in the serializeCSSOM function by introducing a new environment variable PERCY_SKIP_UNSUPPORTED_STYLESHEETS that allows skipping stylesheets without a styleId.

Adds conditional logic to skip stylesheets without styleId when the environment variable is set
Includes a test case to verify the new error handling behavior