### PR TITLE
Update Windows runner version in executable.yml

### DIFF
--- a/.github/workflows/executable.yml
+++ b/.github/workflows/executable.yml
@@ -37,7 +37,7 @@ jobs:
   notify:
     needs: build
     name: Sign Win Executable
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v5
       - name: Download win artifact


### PR DESCRIPTION
Bumping down as it seems signtool is not easily found on latest runner