### PR TITLE
fixed canvas maxWidth resize issue

### DIFF
--- a/packages/dom/src/serialize-canvas.js
+++ b/packages/dom/src/serialize-canvas.js
@@ -13,9 +13,13 @@ function createAndInsertImageElement(canvas, clone, percyElementId, imageUrl) {
   img.setAttribute('data-percy-canvas-serialized', '');
   img.setAttribute('data-percy-serialized-attribute-src', imageUrl);
 
-  // set the maxWidth only if it was set on the canvas
-  if (canvas.style.maxWidth) {
-    img.style.maxWidth = canvas.style.maxWidth;
+  // set a default max width to account for canvases that might resize with JS
+  // Check if width is "static" (fixed pixels) vs "dynamic" (%, vw, etc.)
+  const hasStaticWidth = canvas.style.width &&
+                      canvas.style.width.match(/^\d+px$/);
+
+  if (!hasStaticWidth) {
+    img.style.maxWidth = img.style.maxWidth || '100%';
   }
 
   // insert the image into the cloned DOM and remove the cloned canvas element


### PR DESCRIPTION
This pull request improves the handling of canvas serialization by ensuring that the `max-width` style is only applied to serialized canvas images when appropriate. Specifically, it adds logic to distinguish between canvases with static pixel widths and those with dynamic or no explicit widths, and updates the tests to cover these scenarios.

The most important changes include:

**Canvas Serialization Logic:**
* Updated `createAndInsertImageElement` in `serialize-canvas.js` to only apply a default `max-width: 100%` to the serialized image if the original canvas does not have a static pixel width (i.e., a fixed width in pixels). This prevents unnecessary style overrides for canvases that already have a fixed width.

**Test Coverage Enhancements:**
* Added a new canvas element with a static pixel width to the test fixture in `serialize-canvas.test.js` to verify correct handling of this case.
* Added drawing logic and resource caching for the new static-width canvas in the test setup.
* Enhanced existing tests to assert that `max-width: 100%` is only applied when the canvas does not have a static width, and that the original `max-width` is preserved if present. [[1]](diffhunk://#diff-6931596960451a8f637e070b0e0d68b673fdf9d76c8069ecac454b298b01feefL71-R88) [[2]](diffhunk://#diff-6931596960451a8f637e070b0e0d68b673fdf9d76c8069ecac454b298b01feefR105-R106)
* Added a new test to explicitly verify that `max-width` is not added when the canvas has a static pixel width, ensuring the new logic behaves as expected.