### PR TITLE
Handle base element at the time of serialization

### DIFF
--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -54,6 +54,12 @@ export function cloneNodeAndShadow(ctx) {
         }
       };
 
+      if (node.nodeName === 'BASE') {
+        let clone = node.cloneNode(false);
+        parent.appendChild(clone);
+        return;
+      }
+
       // mark the node before cloning
       markElement(node, disableShadowDOM, forceShadowAsLightDOM);
 

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -88,6 +88,32 @@ describe('serializeDOM', () => {
     expect(result.userAgent).toContain(navigator.userAgent);
   });
 
+  it('serializes base element correctly without string coercion', () => {
+    withExample('<head><base href="/"></head><body><p>Test</p></body>');
+
+    const result = serializeDOM();
+    const $ = parseDOM(result.html);
+
+    // Should NOT contain the string representation of the object
+    expect(result.html).not.toContain('[object HTMLBaseElement]');
+    expect(result.html).not.toContain('[object');
+
+    // Should contain properly serialized base element
+    expect($('base').length).toEqual(1);
+    expect($('base')[0].getAttribute('href')).toEqual('/');
+  });
+
+  it('preserves base element attributes', () => {
+    withExample('<head><base href="https://example.com/" target="_blank"></head>');
+
+    const result = serializeDOM();
+    const $ = parseDOM(result.html);
+
+    expect($('base')[0].getAttribute('href')).toEqual('https://example.com/');
+    expect($('base')[0].getAttribute('target')).toEqual('_blank');
+    expect(result.html).not.toContain('[object');
+  });
+
   it('clone node is always shallow', () => {
     class AttributeCallbackTestElement extends window.HTMLElement {
       static get observedAttributes() {


### PR DESCRIPTION
This pull request addresses an issue with serializing `<base>` elements in the DOM cloning and serialization logic. The main focus is to ensure that `<base>` elements are cloned and serialized correctly, without unintended string coercion or loss of attributes. It also adds tests to verify the correct handling of `<base>` elements.

**DOM Cloning and Serialization Improvements:**

* Updated `cloneNodeAndShadow` in `clone-dom.js` to handle `<base>` elements by shallowly cloning them and appending the clone directly, preventing issues with string coercion during serialization.

**Testing Enhancements:**

* Added tests in `serialize-dom.test.js` to verify that `<base>` elements are serialized without string coercion and that their attributes are preserved in the output HTML.