### PR TITLE
Fix: Normalize the POA comparison to major version for percyBrowserCustomName support

### DIFF
--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -474,7 +474,7 @@ export default class GenericProvider {
       const percyBrowserCustomName = platform.percyBrowserCustomName;
 
       const pDevice = platform.deviceName || '';
-      const pOsName = normalizeTags.osRollUp(platform.osName || '');
+      const pOsName = normalizeTags.osRollUp(platform.os || '');
       const pOsVersion = normalizeTags.osVersionRollUp(((platform.osVersion || '').toString()).split('.')[0]);
       const pBrowserName = normalizeTags.browserRollUp(platform.browserName || '', isMobile);
       const pBrowserVersion = (platform.browserVersion || '').toString().split('.')[0];

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -135,10 +135,10 @@ describe('GenericProvider', () => {
 
     it('matches by normalized fields, includes version, and device when mobile', () => {
       const platforms = [
-        { osName: 'Windows', browserName: 'Chrome', browserVersion: 118, percyBrowserCustomName: 'win-chrome-118' },
-        { osName: 'Windows', browserName: 'Chrome', browserVersion: 'latest', percyBrowserCustomName: 'win-chrome-latest' },
-        { osName: 'iOS', deviceName: 'iPhone 12', browserName: 'Safari', browserVersion: 'latest', percyBrowserCustomName: 'ios-safari-iphone12' },
-        { osName: 'iOS', deviceName: 'iPhone 13', percyBrowserCustomName: 'ios-safari-iphone13' }
+        { os: 'Windows', browserName: 'Chrome', browserVersion: 118, percyBrowserCustomName: 'win-chrome-118' },
+        { os: 'Windows', browserName: 'Chrome', browserVersion: 'latest', percyBrowserCustomName: 'win-chrome-latest' },
+        { os: 'iOS', deviceName: 'iPhone 12', browserName: 'Safari', browserVersion: 'latest', percyBrowserCustomName: 'ios-safari-iphone12' },
+        { os: 'iOS', deviceName: 'iPhone 13', percyBrowserCustomName: 'ios-safari-iphone13' }
       ];
       const provider = new GenericProvider({ options: { platforms } });
       // exact specific version wins over latest


### PR DESCRIPTION
## Overview
This pull request improves the platform matching logic in the `GenericProvider` class by introducing normalization for platform properties, ensuring more accurate and flexible matching when resolving custom Percy browser names. It also adds comprehensive tests to verify the normalization behavior for various platform attributes.

## Jira Ticket
🔗 [PPLT-4761: Custom browser name tagging support for POA](https://browserstack.atlassian.net/browse/PPLT-4761)

## What Changed?

### Enhancements to platform normalization and matching:

• **Updated `GenericProvider`** to use a new `NormalizeData` utility for normalizing `osName`, `osVersion`, `browserName`, and `browserVersion` before matching, improving the accuracy of custom browser name resolution.

• **Platform property normalization**:
  - `osName` normalization using `normalizeTags.osRollUp` (e.g., 'mac' → 'OS X', 'Windows 10' → 'Windows')
  - `osVersion` normalization using `normalizeTags.osVersionRollUp`, extracting only major versions
  - `browserName` normalization using `normalizeTags.browserRollUp` with mobile detection support
  - `browserVersion` normalization by extracting only major versions (split on '.' and take first part)

• **Added debug logging** to trace normalized platform values for better debugging and transparency

### Expanded test coverage:

• Added multiple tests in `genericProvider.test.js` to verify that platform matching correctly normalizes:
  - `osName` using `normalizeTags.osRollUp`
  - `osVersion` using `normalizeTags.osVersionRollUp`
  - `browserName` using `normalizeTags.browserRollUp`
  - `browserVersion` using `normalizeTags.browserVersionOrDeviceNameRollup`
  - All properties together for full normalization and accurate matching

## Files Changed
- `packages/webdriver-utils/src/providers/genericProvider.js` (+13, -4)
- `packages/webdriver-utils/test/providers/genericProvider.test.js` (+83, -0)

## Impact
This enhancement allows users to specify custom browser names (`percyBrowserCustomName`) that will be matched accurately across different browser versions, OS versions, and platform variations, enabling better comparison workflows for Percy visual testing.