### PR TITLE
driver-executorUrl: Normalize and remove trailing slashes.

### DIFF
--- a/packages/webdriver-utils/src/driver.js
+++ b/packages/webdriver-utils/src/driver.js
@@ -6,7 +6,7 @@ const log = utils.logger('webdriver-utils:driver');
 export default class Driver {
   constructor(sessionId, executorUrl, passedCapabilities) {
     this.sessionId = sessionId;
-    this.executorUrl = executorUrl.includes('@') ? `https://${executorUrl.split('@')[1]}` : executorUrl;
+    this.executorUrl = (executorUrl.includes('@') ? `https://${executorUrl.split('@')[1]}` : executorUrl).replace(/\/+$/, '');
     this.passedCapabilities = passedCapabilities;
   }
 


### PR DESCRIPTION
This pull request makes a small but important change to the construction of the `executorUrl` in the `Driver` class. The change ensures that any trailing slashes are removed from the `executorUrl`, which helps maintain consistency and prevents potential issues with URL formatting.