### PR TITLE
Fix: Add null check for cloneOwnerNode in serializeCSSOM

### DIFF
--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -61,6 +61,7 @@ export function serializeCSSOM(ctx) {
           styleId = styleSheet.ownerNode.getAttribute('data-percy-element-id');
           if (!styleId && ignoreStyleSheetSerializationErrors) continue;
           cloneOwnerNode = clone.querySelector(`[data-percy-element-id="${styleId}"]`);
+          if (!cloneOwnerNode) continue; // Skip if element not found in clone
           if (styleSheetsMatch(styleSheet, styleSheetFromNode(cloneOwnerNode))) continue;
           let style = document.createElement('style');
 


### PR DESCRIPTION
## Description

Fixes a bug where DOM serialization crashes with `"Cannot read properties of null (reading 'sheet')"` error when processing stylesheets on complex pages (e.g., Confluence).

## Root Cause

In `packages/dom/src/serialize-cssom.js`, the code attempts to find cloned style elements using `querySelector()` but does not check if the element exists before passing it to `styleSheetFromNode()`. When the element is not found in the clone, `cloneOwnerNode` becomes `null`, causing the error.

This typically happens with:
- Style elements in shadow DOM that weren't properly cloned
- Dynamically inserted styles after initial cloning  
- Complex DOM structures with late-loaded stylesheets
- Styles in ignored tags

## Changes

### Code Changes
- **packages/dom/src/serialize-cssom.js**: Added null check at line 64 to skip stylesheets when `cloneOwnerNode` is not found in the cloned DOM

### Test Changes
- **packages/dom/test/serialize-css.test.js**: Added test case `"skips stylesheet when cloneOwnerNode is not found in clone"` to verify the fix handles missing elements gracefully

## Testing

✅ All existing tests pass (212/212 on Chrome)  
✅ New test case validates the fix  
✅ Linting passes on modified files  

## Related

- **Jira**: [PER-6656](https://browserstack.atlassian.net/browse/PER-6656)
- **Customer**: NVIDIA experiencing this error on Confluence pages
- **Workaround**: Use `ignoreStyleSheetSerializationErrors: true` option

## Impact

- Low risk: Only adds a safety check to prevent crashes
- No breaking changes
- Improves reliability for complex DOM structures

[PER-6656]: https://browserstack.atlassian.net/browse/PER-6656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ