### PR TITLE
Display usage warning from API

### DIFF
--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -345,12 +345,12 @@ export function createSnapshotsQueue(percy) {
         let usageWarning = data.attributes['usage-warning'];
         percy.client.buildType = data.attributes?.type;
         Object.assign(build, { id: data.id, url, number });
-        
+
         // Display usage warning if present
         if (usageWarning) {
           percy.log.warn(usageWarning);
         }
-        
+
         // immediately run the queue if not delayed or deferred
         if (!percy.delayUploads && !percy.deferUploads) queue.run();
       } catch (err) {


### PR DESCRIPTION
 https://browserstack.atlassian.net/browse/PPLT-4879
This pull request introduces a new feature that displays a usage warning when the Percy build API returns a `usage-warning` attribute. The implementation ensures that users are notified if their usage limits are exceeded, and includes comprehensive tests to verify this behavior.

**Feature: Usage Warning Notification**

* Added logic in `createSnapshotsQueue` to check for a `usage-warning` attribute in the build response and log a warning if present.

**Testing: Usage Warning Behavior**

* Added tests to verify that a usage warning is displayed when the `usage-warning` attribute is present in the build response, and not displayed when absent.