### PR TITLE
feat: add projectId configuration with validation tests

### DIFF
--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -449,6 +449,9 @@ export const configSchema = {
         default: true
       }
     }
+  },
+  projectId: {
+    type: 'number'
   }
 };
 

--- a/packages/core/test/unit/config.test.js
+++ b/packages/core/test/unit/config.test.js
@@ -319,3 +319,29 @@ describe('Discovery config', () => {
     expect(errors[0].message).toMatch(/must be a boolean/);
   });
 });
+
+describe('ProjectId config', () => {
+  beforeEach(() => {
+    PercyConfig.addSchema(CoreConfig.schemas);
+  });
+
+  it('should accept projectId as a number', () => {
+    const config = {
+      projectId: 12345
+    };
+
+    const errors = PercyConfig.validate(config, '/config');
+    expect(errors).toBe(undefined);
+  });
+
+  it('should reject non-numeric values for projectId', () => {
+    const config = {
+      projectId: 'abc'
+    };
+
+    const errors = PercyConfig.validate(config, '/config');
+    expect(errors).toBeDefined();
+    expect(errors[0].path).toBe('projectId');
+    expect(errors[0].message).toMatch(/must be a number/);
+  });
+});


### PR DESCRIPTION
feat: add projectId configuration with validation tests

This is added as a part of our storybook addon. 
This is done so that user working project can be comitted so that if they start storybook again, they see this project again.