### PR TITLE
fix: Declare missing @percy/client dependency in cli-exec for Yarn PnP

### DIFF
--- a/packages/cli-exec/package.json
+++ b/packages/cli-exec/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@percy/cli-command": "1.31.10-beta.2",
+    "@percy/client": "1.31.10-beta.2",
     "@percy/logger": "1.31.10-beta.2",
     "cross-spawn": "^7.0.3",
     "which": "^2.0.2"

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@percy/config": "1.31.10-beta.2",
     "@percy/logger": "1.31.10-beta.2",
-    "@percy/sdk-utils": "1.31.10-beta.2",
     "systeminformation": "^5.25.11"
   }
 }


### PR DESCRIPTION
## Summary

- **Adds `@percy/client`** as a declared dependency in `@percy/cli-exec/package.json` — it was already imported (`waitForTimeout` from `@percy/client/utils`) but not declared, breaking Yarn PnP strict resolution
- **Removes unused `@percy/sdk-utils`** from `@percy/monitoring/package.json` — declared but never imported in any source file

## Root Cause

Yarn workspaces hoist dependencies to the root `node_modules`, so the missing declaration worked in traditional npm/yarn. Yarn PnP enforces strict resolution where each package can only see its own declared dependencies, causing:

```
[percy] Error: @percy/cli-exec tried to access @percy/client, but it isn't declared
in its dependencies; this makes the require call ambiguous and unsound.
```

## Testing

- `@percy/cli-exec` tests: 33/33 pass
- `@percy/monitoring` tests: 40/40 pass
- Full monorepo audit confirmed this is the only undeclared cross-package dependency

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a package.json metadata-only change with no runtime behavior change — it makes an already-used dependency explicitly declared.

Closes #1612

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>