### PR TITLE
PPLT-5095: Serialize dialog showModal() elements for Percy snapshots

### DIFF
--- a/packages/dom/src/prepare-dom.js
+++ b/packages/dom/src/prepare-dom.js
@@ -5,7 +5,7 @@ export function uid() {
 
 export function markElement(domElement, disableShadowDOM, forceShadowAsLightDOM) {
   // Mark elements that are to be serialized later with a data attribute.
-  if (['input', 'textarea', 'select', 'iframe', 'canvas', 'video', 'style'].includes(domElement.tagName?.toLowerCase())) {
+  if (['input', 'textarea', 'select', 'iframe', 'canvas', 'video', 'style', 'dialog'].includes(domElement.tagName?.toLowerCase())) {
     if (!domElement.getAttribute('data-percy-element-id')) {
       domElement.setAttribute('data-percy-element-id', uid());
     }

--- a/packages/dom/src/serialize-dialog.js
+++ b/packages/dom/src/serialize-dialog.js
@@ -1,0 +1,92 @@
+import { handleErrors } from './utils';
+
+// Serializes open <dialog> elements opened via showModal().
+//
+// When the renderer re-renders the serialized HTML, it runs
+// dialog-element-helper.js which calls close() then showModal()
+// to restore ::backdrop. However, close() fires a 'close' event
+// that frameworks (React, etc.) may listen to, destroying the
+// dialog DOM. We mark the dialog with data-percy-dialog-modal
+// so the renderer can skip the close/showModal cycle.
+//
+// The renderer then handles ::backdrop natively via showModal().
+// We only need to handle positioning (top-layer simulation) and
+// move the dialog to <body> to escape parent stacking contexts.
+export function serializeDialogs(ctx) {
+  let { dom, clone } = ctx;
+  let cssRules = [];
+
+  for (let elem of dom.querySelectorAll('dialog[open]')) {
+    try {
+      let dialogId = elem.getAttribute('data-percy-element-id');
+      if (!dialogId) continue;
+
+      let cloneEl = clone.querySelector(`[data-percy-element-id="${dialogId}"]`);
+      if (!cloneEl) continue;
+
+      if (!cloneEl.hasAttribute('open')) {
+        cloneEl.setAttribute('open', '');
+      }
+
+      // Detect if dialog was opened via showModal() by checking
+      // if ::backdrop has non-default styles
+      let isModal = false;
+      try {
+        let backdropStyles = window.getComputedStyle(elem, '::backdrop');
+        if (backdropStyles) {
+          let bg = backdropStyles.getPropertyValue('background-color') ||
+                   backdropStyles.getPropertyValue('background');
+          if (bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent') {
+            isModal = true;
+          }
+          let filter = backdropStyles.getPropertyValue('backdrop-filter') ||
+                       backdropStyles.getPropertyValue('-webkit-backdrop-filter');
+          if (filter && filter !== 'none') {
+            isModal = true;
+          }
+        }
+      } catch (_) { /* not a modal */ }
+
+      if (!isModal) continue;
+
+      let cloneBody = clone.body || clone.querySelector('body');
+      if (!cloneBody) continue;
+
+      // Mark dialog so the renderer skips the close/showModal cycle
+      // and caps screenshot height to viewport
+      cloneEl.setAttribute('data-percy-dialog-modal', 'true');
+
+      // Move dialog to end of body to escape parent stacking contexts
+      cloneBody.appendChild(cloneEl);
+
+      // Dialog positioning to simulate top-layer behavior
+      cssRules.push(`[data-percy-element-id="${dialogId}"][data-percy-dialog-modal] {
+        position: fixed !important;
+        top: 50% !important;
+        left: 50% !important;
+        transform: translate(-50%, -50%) !important;
+        z-index: 2147483647 !important;
+        margin: 0 !important;
+        max-height: 90vh !important;
+        max-width: 90vw !important;
+        overflow: auto !important;
+      }`);
+    } catch (err) {
+      handleErrors(err, 'Error serializing dialog element: ', elem);
+    }
+  }
+
+  // Inject CSS rules via a single <style> tag
+  if (cssRules.length > 0) {
+    let styleElement = dom.createElement('style');
+    styleElement.setAttribute('data-percy-dialog-styles', 'true');
+    styleElement.textContent = cssRules.join('\n');
+
+    let head = clone.head || clone.querySelector('head');
+    if (head) {
+      head.appendChild(styleElement);
+    }
+  }
+}
+
+export default serializeDialogs;

--- a/packages/dom/src/serialize-dialog.js
+++ b/packages/dom/src/serialize-dialog.js
@@ -2,19 +2,14 @@ import { handleErrors } from './utils';
 
 // Serializes open <dialog> elements opened via showModal().
 //
-// When the renderer re-renders the serialized HTML, it runs
-// dialog-element-helper.js which calls close() then showModal()
-// to restore ::backdrop. However, close() fires a 'close' event
-// that frameworks (React, etc.) may listen to, destroying the
-// dialog DOM. We mark the dialog with data-percy-dialog-modal
-// so the renderer can skip the close/showModal cycle.
+// The browser's ::backdrop and top-layer positioning are lost during
+// DOM serialization. We stamp data-percy-dialog-modal so the renderer
+// can call removeAttribute('open') then showModal() to restore them.
 //
-// The renderer then handles ::backdrop natively via showModal().
-// We only need to handle positioning (top-layer simulation) and
-// move the dialog to <body> to escape parent stacking contexts.
+// The open attribute is kept so the dialog is visible during Percy's
+// asset discovery and rendering phases.
 export function serializeDialogs(ctx) {
   let { dom, clone } = ctx;
-  let cssRules = [];
 
   for (let elem of dom.querySelectorAll('dialog[open]')) {
     try {
@@ -28,63 +23,17 @@ export function serializeDialogs(ctx) {
         cloneEl.setAttribute('open', '');
       }
 
-      // Detect if dialog was opened via showModal() by checking
-      // if ::backdrop has non-default styles
-      let isModal = false;
-      try {
-        let backdropStyles = window.getComputedStyle(elem, '::backdrop');
-        if (backdropStyles) {
-          let bg = backdropStyles.getPropertyValue('background-color') ||
-                   backdropStyles.getPropertyValue('background');
-          if (bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent') {
-            isModal = true;
-          }
-          let filter = backdropStyles.getPropertyValue('backdrop-filter') ||
-                       backdropStyles.getPropertyValue('-webkit-backdrop-filter');
-          if (filter && filter !== 'none') {
-            isModal = true;
-          }
-        }
-      } catch (_) { /* not a modal */ }
+      // Detect showModal() vs show():
+      // showModal() sets position:fixed (top layer). show() is position:absolute.
+      let dialogPosition = window.getComputedStyle(elem).getPropertyValue('position');
+      if (dialogPosition !== 'fixed') continue;
 
-      if (!isModal) continue;
-
-      let cloneBody = clone.body || clone.querySelector('body');
-      if (!cloneBody) continue;
-
-      // Mark dialog so the renderer skips the close/showModal cycle
-      // and caps screenshot height to viewport
+      // Mark for renderer — it will removeAttribute('open') then showModal()
       cloneEl.setAttribute('data-percy-dialog-modal', 'true');
-
-      // Move dialog to end of body to escape parent stacking contexts
-      cloneBody.appendChild(cloneEl);
-
-      // Dialog positioning to simulate top-layer behavior
-      cssRules.push(`[data-percy-element-id="${dialogId}"][data-percy-dialog-modal] {
-        position: fixed !important;
-        top: 50% !important;
-        left: 50% !important;
-        transform: translate(-50%, -50%) !important;
-        z-index: 2147483647 !important;
-        margin: 0 !important;
-        max-height: 90vh !important;
-        max-width: 90vw !important;
-        overflow: auto !important;
-      }`);
+      // Pass original viewport height so renderer caps screenshot to viewport
+      cloneEl.setAttribute('data-percy-dialog-viewport-height', String(window.innerHeight));
     } catch (err) {
       handleErrors(err, 'Error serializing dialog element: ', elem);
-    }
-  }
-
-  // Inject CSS rules via a single <style> tag
-  if (cssRules.length > 0) {
-    let styleElement = dom.createElement('style');
-    styleElement.setAttribute('data-percy-dialog-styles', 'true');
-    styleElement.textContent = cssRules.join('\n');
-
-    let head = clone.head || clone.querySelector('head');
-    if (head) {
-      head.appendChild(styleElement);
     }
   }
 }

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -3,6 +3,7 @@ import serializeFrames from './serialize-frames';
 import serializeCSSOM from './serialize-cssom';
 import serializeCanvas from './serialize-canvas';
 import serializeVideos from './serialize-video';
+import serializeDialogs from './serialize-dialog';
 import { serializePseudoClasses, markPseudoClassElements } from './serialize-pseudo-classes';
 import { cloneNodeAndShadow, getOuterHTML } from './clone-dom';
 
@@ -37,6 +38,7 @@ function serializeElements(ctx) {
   serializeInputs(ctx);
   serializeFrames(ctx);
   serializeVideos(ctx);
+  serializeDialogs(ctx);
 
   if (!ctx.enableJavaScript) {
     serializeCSSOM(ctx);


### PR DESCRIPTION
## Summary

- Adds `serialize-dialog.js` to detect and stamp `<dialog>` elements opened via `showModal()`
- Stamps `data-percy-dialog-modal` so the renderer can restore `::backdrop` via `showModal()`
- Stamps `data-percy-dialog-viewport-height` with the user's actual browser viewport height so the renderer caps screenshot height correctly
- Detects `showModal()` vs `show()` via `position: fixed` (top-layer indicator)
- Adds `dialog` to the element ID marking list in `prepare-dom.js`
- Wires `serializeDialogs()` into the serialization pipeline in `serialize-dom.js`

### Files changed

| File | Change |
|------|--------|
| `packages/dom/src/serialize-dialog.js` | New file — dialog serialization |
| `packages/dom/src/prepare-dom.js` | Add `dialog` to marked elements |
| `packages/dom/src/serialize-dom.js` | Call `serializeDialogs()` in pipeline |

### How it works

1. Find all `dialog[open]` elements
2. Check `position: fixed` → indicates `showModal()` (top layer)
3. Stamp `data-percy-dialog-modal="true"` on the clone
4. Stamp `data-percy-dialog-viewport-height` with `window.innerHeight`
5. Keep `open` attribute so dialog is visible during asset discovery

### Depends on
- Renderer PR: percy/percy-renderer#1807

## Test plan
- [ ] Dialog with `showModal()` gets `data-percy-dialog-modal` stamped
- [ ] Dialog with `show()` (position: absolute) is NOT stamped
- [ ] `data-percy-dialog-viewport-height` matches `window.innerHeight`
- [ ] Pages without dialogs are unaffected
- [ ] Existing serialization pipeline not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)