### PR TITLE
PPLT-5148: Add dialog serialization for showModal() support

### DIFF
--- a/packages/dom/src/prepare-dom.js
+++ b/packages/dom/src/prepare-dom.js
@@ -5,7 +5,7 @@ export function uid() {
 
 export function markElement(domElement, disableShadowDOM, forceShadowAsLightDOM) {
   // Mark elements that are to be serialized later with a data attribute.
-  if (['input', 'textarea', 'select', 'iframe', 'canvas', 'video', 'style'].includes(domElement.tagName?.toLowerCase())) {
+  if (['input', 'textarea', 'select', 'iframe', 'canvas', 'video', 'style', 'dialog'].includes(domElement.tagName?.toLowerCase())) {
     if (!domElement.getAttribute('data-percy-element-id')) {
       domElement.setAttribute('data-percy-element-id', uid());
     }

--- a/packages/dom/src/serialize-dialog.js
+++ b/packages/dom/src/serialize-dialog.js
@@ -19,10 +19,6 @@ export function serializeDialogs(ctx) {
       let cloneEl = clone.querySelector(`[data-percy-element-id="${dialogId}"]`);
       if (!cloneEl) continue;
 
-      if (!cloneEl.hasAttribute('open')) {
-        cloneEl.setAttribute('open', '');
-      }
-
       // Detect showModal() vs show()/setAttribute:
       // :modal pseudo-class matches only dialogs in the top layer (opened via showModal())
       if (!elem.matches(':modal')) continue;

--- a/packages/dom/src/serialize-dialog.js
+++ b/packages/dom/src/serialize-dialog.js
@@ -1,0 +1,38 @@
+import { handleErrors } from './utils';
+
+// Serializes open <dialog> elements opened via showModal().
+//
+// The browser's ::backdrop and top-layer positioning are lost during
+// DOM serialization. We stamp data-percy-dialog-modal so the renderer
+// can call removeAttribute('open') then showModal() to restore them.
+//
+// The open attribute is kept so the dialog is visible during Percy's
+// asset discovery and rendering phases.
+export function serializeDialogs(ctx) {
+  let { dom, clone } = ctx;
+
+  for (let elem of dom.querySelectorAll('dialog[open]')) {
+    try {
+      let dialogId = elem.getAttribute('data-percy-element-id');
+      if (!dialogId) continue;
+
+      let cloneEl = clone.querySelector(`[data-percy-element-id="${dialogId}"]`);
+      if (!cloneEl) continue;
+
+      if (!cloneEl.hasAttribute('open')) {
+        cloneEl.setAttribute('open', '');
+      }
+
+      // Detect showModal() vs show()/setAttribute:
+      // :modal pseudo-class matches only dialogs in the top layer (opened via showModal())
+      if (!elem.matches(':modal')) continue;
+
+      // Mark for renderer — it will removeAttribute('open') then showModal()
+      cloneEl.setAttribute('data-percy-dialog-modal', 'true');
+    } catch (err) {
+      handleErrors(err, 'Error serializing dialog element: ', elem);
+    }
+  }
+}
+
+export default serializeDialogs;

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -4,6 +4,7 @@ import serializeCSSOM from './serialize-cssom';
 import serializeCanvas from './serialize-canvas';
 import serializeVideos from './serialize-video';
 import { serializePseudoClasses, markPseudoClassElements } from './serialize-pseudo-classes';
+import serializeDialogs from './serialize-dialog';
 import { cloneNodeAndShadow, getOuterHTML } from './clone-dom';
 
 // Returns a copy or new doctype for a document.
@@ -37,6 +38,7 @@ function serializeElements(ctx) {
   serializeInputs(ctx);
   serializeFrames(ctx);
   serializeVideos(ctx);
+  serializeDialogs(ctx);
 
   if (!ctx.enableJavaScript) {
     serializeCSSOM(ctx);

--- a/packages/dom/test/serialize-dialog.test.js
+++ b/packages/dom/test/serialize-dialog.test.js
@@ -1,5 +1,6 @@
 import { withExample, parseDOM, platforms, platformDOM } from './helpers';
 import serializeDOM from '@percy/dom';
+import serializeDialogs from '../src/serialize-dialog';
 
 describe('serializeDialogs', () => {
   let cache = { shadow: {}, plain: {} };
@@ -138,6 +139,38 @@ describe('serializeDialogs', () => {
 
         dialog.matches = origMatches;
       });
+    });
+  });
+
+  describe('guard branches', () => {
+    it('should skip dialog without data-percy-element-id', () => {
+      let dom = document.createElement('div');
+      let dialog = document.createElement('dialog');
+      dialog.setAttribute('open', '');
+      dom.appendChild(dialog);
+
+      let clone = dom.cloneNode(true);
+      let cloneDialog = clone.querySelector('dialog');
+
+      serializeDialogs({ dom, clone });
+
+      expect(cloneDialog.hasAttribute('data-percy-dialog-modal')).toBe(false);
+    });
+
+    it('should skip dialog when clone element is not found', () => {
+      let dom = document.createElement('div');
+      let dialog = document.createElement('dialog');
+      dialog.setAttribute('open', '');
+      dialog.setAttribute('data-percy-element-id', '_missing123');
+      dom.appendChild(dialog);
+
+      // Clone without the matching element
+      let clone = document.createElement('div');
+
+      serializeDialogs({ dom, clone });
+
+      // No error thrown, function skips gracefully
+      expect(clone.querySelector('[data-percy-dialog-modal]')).toBeNull();
     });
   });
 

--- a/packages/dom/test/serialize-dialog.test.js
+++ b/packages/dom/test/serialize-dialog.test.js
@@ -1,0 +1,155 @@
+import { withExample, parseDOM, platforms, platformDOM } from './helpers';
+import serializeDOM from '@percy/dom';
+
+describe('serializeDialogs', () => {
+  let cache = { shadow: {}, plain: {} };
+
+  describe('dialog opened via showModal()', () => {
+    beforeEach(() => {
+      withExample(`
+        <dialog id="modal-dialog">
+          <p>Modal dialog content</p>
+        </dialog>
+      `);
+
+      platforms.forEach((platform) => {
+        const dom = platformDOM(platform);
+        const dialog = dom.querySelector('#modal-dialog');
+        // Open via showModal() to put it in the top layer
+        dialog.showModal();
+        cache[platform].$ = parseDOM(serializeDOM(), platform);
+      });
+    });
+
+    platforms.forEach((platform) => {
+      it(`should stamp data-percy-dialog-modal on showModal() dialog [${platform}]`, () => {
+        const $ = cache[platform].$;
+        const dialogs = $('dialog#modal-dialog');
+        expect(dialogs.length).toBe(1);
+        expect(dialogs[0].getAttribute('data-percy-dialog-modal')).toBe('true');
+        expect(dialogs[0].hasAttribute('open')).toBe(true);
+      });
+    });
+  });
+
+  describe('dialog opened via setAttribute', () => {
+    beforeEach(() => {
+      withExample(`
+        <dialog id="attr-dialog">
+          <p>Attribute dialog content</p>
+        </dialog>
+      `);
+
+      platforms.forEach((platform) => {
+        const dom = platformDOM(platform);
+        const dialog = dom.querySelector('#attr-dialog');
+        // Open via setAttribute - NOT showModal()
+        dialog.setAttribute('open', '');
+        cache[platform].$ = parseDOM(serializeDOM(), platform);
+      });
+    });
+
+    platforms.forEach((platform) => {
+      it(`should NOT stamp data-percy-dialog-modal on setAttribute dialog [${platform}]`, () => {
+        const $ = cache[platform].$;
+        const dialogs = $('dialog#attr-dialog');
+        expect(dialogs.length).toBe(1);
+        expect(dialogs[0].hasAttribute('data-percy-dialog-modal')).toBe(false);
+        expect(dialogs[0].hasAttribute('open')).toBe(true);
+      });
+    });
+  });
+
+  describe('dialog opened via show()', () => {
+    beforeEach(() => {
+      withExample(`
+        <dialog id="show-dialog">
+          <p>Show dialog content</p>
+        </dialog>
+      `);
+
+      platforms.forEach((platform) => {
+        const dom = platformDOM(platform);
+        const dialog = dom.querySelector('#show-dialog');
+        // Open via show() - NOT showModal()
+        dialog.show();
+        cache[platform].$ = parseDOM(serializeDOM(), platform);
+      });
+    });
+
+    platforms.forEach((platform) => {
+      it(`should NOT stamp data-percy-dialog-modal on show() dialog [${platform}]`, () => {
+        const $ = cache[platform].$;
+        const dialogs = $('dialog#show-dialog');
+        expect(dialogs.length).toBe(1);
+        expect(dialogs[0].hasAttribute('data-percy-dialog-modal')).toBe(false);
+        expect(dialogs[0].hasAttribute('open')).toBe(true);
+      });
+    });
+  });
+
+  describe('closed dialog', () => {
+    beforeEach(() => {
+      withExample(`
+        <dialog id="closed-dialog">
+          <p>Closed dialog content</p>
+        </dialog>
+      `);
+
+      platforms.forEach((platform) => {
+        cache[platform].$ = parseDOM(serializeDOM(), platform);
+      });
+    });
+
+    platforms.forEach((platform) => {
+      it(`should NOT stamp data-percy-dialog-modal on closed dialog [${platform}]`, () => {
+        const $ = cache[platform].$;
+        const dialogs = $('dialog#closed-dialog');
+        expect(dialogs.length).toBe(1);
+        expect(dialogs[0].hasAttribute('data-percy-dialog-modal')).toBe(false);
+        expect(dialogs[0].hasAttribute('open')).toBe(false);
+      });
+    });
+  });
+
+  describe('multiple dialogs with mixed open methods', () => {
+    beforeEach(() => {
+      withExample(`
+        <dialog id="dialog-modal">
+          <p>Modal dialog</p>
+        </dialog>
+        <dialog id="dialog-attr">
+          <p>Attribute dialog</p>
+        </dialog>
+        <dialog id="dialog-closed">
+          <p>Closed dialog</p>
+        </dialog>
+      `);
+
+      platforms.forEach((platform) => {
+        const dom = platformDOM(platform);
+        dom.querySelector('#dialog-modal').showModal();
+        dom.querySelector('#dialog-attr').setAttribute('open', '');
+        cache[platform].$ = parseDOM(serializeDOM(), platform);
+      });
+    });
+
+    platforms.forEach((platform) => {
+      it(`should only stamp the showModal() dialog [${platform}]`, () => {
+        const $ = cache[platform].$;
+
+        const modal = $('dialog#dialog-modal');
+        expect(modal[0].getAttribute('data-percy-dialog-modal')).toBe('true');
+        expect(modal[0].hasAttribute('open')).toBe(true);
+
+        const attr = $('dialog#dialog-attr');
+        expect(attr[0].hasAttribute('data-percy-dialog-modal')).toBe(false);
+        expect(attr[0].hasAttribute('open')).toBe(true);
+
+        const closed = $('dialog#dialog-closed');
+        expect(closed[0].hasAttribute('data-percy-dialog-modal')).toBe(false);
+        expect(closed[0].hasAttribute('open')).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/dom/test/serialize-dialog.test.js
+++ b/packages/dom/test/serialize-dialog.test.js
@@ -174,6 +174,41 @@ describe('serializeDialogs', () => {
     });
   });
 
+  describe('nested dialogs opened via showModal()', () => {
+    beforeEach(() => {
+      withExample(`
+        <dialog id="outer-dialog">
+          <p>Outer modal</p>
+          <dialog id="inner-dialog">
+            <p>Inner modal</p>
+          </dialog>
+        </dialog>
+      `);
+
+      platforms.forEach((platform) => {
+        const dom = platformDOM(platform);
+        // Open outer first, then inner — both via showModal()
+        dom.querySelector('#outer-dialog').showModal();
+        dom.querySelector('#inner-dialog').showModal();
+        cache[platform].$ = parseDOM(serializeDOM(), platform);
+      });
+    });
+
+    platforms.forEach((platform) => {
+      it(`should stamp data-percy-dialog-modal on both nested showModal() dialogs [${platform}]`, () => {
+        const $ = cache[platform].$;
+
+        const outer = $('dialog#outer-dialog');
+        expect(outer[0].getAttribute('data-percy-dialog-modal')).toBe('true');
+        expect(outer[0].hasAttribute('open')).toBe(true);
+
+        const inner = $('dialog#inner-dialog');
+        expect(inner[0].getAttribute('data-percy-dialog-modal')).toBe('true');
+        expect(inner[0].hasAttribute('open')).toBe(true);
+      });
+    });
+  });
+
   describe('multiple dialogs with mixed open methods', () => {
     beforeEach(() => {
       withExample(`

--- a/packages/dom/test/serialize-dialog.test.js
+++ b/packages/dom/test/serialize-dialog.test.js
@@ -112,6 +112,35 @@ describe('serializeDialogs', () => {
     });
   });
 
+  describe('error handling', () => {
+    beforeEach(() => {
+      withExample(`
+        <dialog id="error-dialog">
+          <p>Error dialog content</p>
+        </dialog>
+      `);
+    });
+
+    platforms.forEach((platform) => {
+      it(`should handle errors during dialog serialization [${platform}]`, () => {
+        const dom = platformDOM(platform);
+        const dialog = dom.querySelector('#error-dialog');
+        dialog.setAttribute('open', '');
+
+        // Override matches to throw an error
+        const origMatches = dialog.matches;
+        dialog.matches = () => { throw new Error('test error'); };
+
+        expect(() => serializeDOM()).toThrowMatching((error) => {
+          return error.message.includes('Error serializing dialog element:') &&
+            error.message.includes('DIALOG');
+        });
+
+        dialog.matches = origMatches;
+      });
+    });
+  });
+
   describe('multiple dialogs with mixed open methods', () => {
     beforeEach(() => {
       withExample(`


### PR DESCRIPTION
## Summary
- Add `serializeDialogs()` to stamp `data-percy-dialog-modal` on `<dialog>` elements opened via `showModal()`, enabling the renderer to restore top-layer positioning and `::backdrop` during visual snapshots.
- Add comprehensive tests covering `showModal()`, `show()`, `setAttribute('open')`, closed dialogs, and mixed scenarios.

1. Percy's serialization works on a clone of the DOM, not the original, so that any modifications (adding attributes, rewriting    
  elements) don't affect the live page the user is testing.                                                                         

  Looking at serialize-dom.js:115:                                                                                                  
  ctx.clone = cloneNodeAndShadow(ctx);
                                                                                                                                    
  The pattern across all serializers (serialize-inputs.js, serialize-canvas.js, serialize-video.js, etc.) is the same:              
  - Read state from dom (the original) — e.g., checking elem.matches(':modal')                                                      
  - Write changes to clone — e.g., stamping data-percy-dialog-modal                                                                 
                                                                                                                                    
  The clone is what gets serialized to HTML and sent to Percy's rendering servers. The original DOM stays untouched so the user's   
  page isn't disrupted during snapshot capture.  
  
  
  
 2. These are doing very different things. serialize-pseudo-classes handles computed CSS styles for pseudo-class elements — it's about
   capturing :hover, :focus styles and injecting CSS rules. It's complex (200 lines) with XPath lookups, style computation, and CSS 
  injection. Our dialog logic is about detecting showModal() and stamping a data attribute. It follows the same pattern as serialize-inputs.js, serialize-canvas.js, serialize-video.js — small, focused serializers that each handle one element type.       


# Output after fix 
https://storage.googleapis.com/percy-dev-images/263646a46264af1f177d1270e7e091b91810b075851050f3a38a0fee50cf33be
<img width="1170" height="1024" alt="image" src="https://github.com/user-attachments/assets/c36e7e3a-7da2-48e4-8ebe-0b490b3e88c0" />


## Test plan
- [ ] Run `yarn workspace @percy/dom test` to verify dialog serialization tests pass
- [ ] Verify no regressions in existing DOM serialization tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)