### PR TITLE
🔖 Release 1.31.12

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "packages": [
     "packages/*"
   ],

--- a/packages/cli-app/package.json
+++ b/packages/cli-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-app",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -33,7 +33,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12-beta.0",
-    "@percy/cli-exec": "1.31.12-beta.0"
+    "@percy/cli-command": "1.31.12",
+    "@percy/cli-exec": "1.31.12"
   }
 }

--- a/packages/cli-build/package.json
+++ b/packages/cli-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-build",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -36,6 +36,6 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12-beta.0"
+    "@percy/cli-command": "1.31.12"
   }
 }

--- a/packages/cli-command/package.json
+++ b/packages/cli-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-command",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "files": [
     "dist",
@@ -36,8 +36,8 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.31.12-beta.0",
-    "@percy/core": "1.31.12-beta.0",
-    "@percy/logger": "1.31.12-beta.0"
+    "@percy/config": "1.31.12",
+    "@percy/core": "1.31.12",
+    "@percy/logger": "1.31.12"
   }
 }

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-config",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -33,6 +33,6 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12-beta.0"
+    "@percy/cli-command": "1.31.12"
   }
 }

--- a/packages/cli-doctor/package.json
+++ b/packages/cli-doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-doctor",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -35,13 +35,13 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12-beta.0",
-    "@percy/client": "1.31.12-beta.0",
-    "@percy/config": "1.31.12-beta.0",
-    "@percy/core": "1.31.12-beta.0",
-    "@percy/env": "1.31.12-beta.0",
-    "@percy/logger": "1.31.12-beta.0",
-    "@percy/monitoring": "1.31.12-beta.0",
+    "@percy/cli-command": "1.31.12",
+    "@percy/client": "1.31.12",
+    "@percy/config": "1.31.12",
+    "@percy/core": "1.31.12",
+    "@percy/env": "1.31.12",
+    "@percy/logger": "1.31.12",
+    "@percy/monitoring": "1.31.12",
     "minimatch": "^9.0.0",
     "ws": "^8.17.1"
   }

--- a/packages/cli-exec/package.json
+++ b/packages/cli-exec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-exec",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -33,8 +33,8 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12-beta.0",
-    "@percy/logger": "1.31.12-beta.0",
+    "@percy/cli-command": "1.31.12",
+    "@percy/logger": "1.31.12",
     "cross-spawn": "^7.0.3",
     "which": "^2.0.2"
   }

--- a/packages/cli-snapshot/package.json
+++ b/packages/cli-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-snapshot",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -33,7 +33,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12-beta.0",
+    "@percy/cli-command": "1.31.12",
     "yaml": "^2.0.0"
   }
 }

--- a/packages/cli-upload/package.json
+++ b/packages/cli-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-upload",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -33,7 +33,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12-beta.0",
+    "@percy/cli-command": "1.31.12",
     "fast-glob": "^3.2.11",
     "image-size": "^1.0.0"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "files": [
     "bin",
@@ -31,15 +31,15 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/cli-app": "1.31.12-beta.0",
-    "@percy/cli-build": "1.31.12-beta.0",
-    "@percy/cli-command": "1.31.12-beta.0",
-    "@percy/cli-config": "1.31.12-beta.0",
-    "@percy/cli-doctor": "1.31.12-beta.0",
-    "@percy/cli-exec": "1.31.12-beta.0",
-    "@percy/cli-snapshot": "1.31.12-beta.0",
-    "@percy/cli-upload": "1.31.12-beta.0",
-    "@percy/client": "1.31.12-beta.0",
-    "@percy/logger": "1.31.12-beta.0"
+    "@percy/cli-app": "1.31.12",
+    "@percy/cli-build": "1.31.12",
+    "@percy/cli-command": "1.31.12",
+    "@percy/cli-config": "1.31.12",
+    "@percy/cli-doctor": "1.31.12",
+    "@percy/cli-exec": "1.31.12",
+    "@percy/cli-snapshot": "1.31.12",
+    "@percy/cli-upload": "1.31.12",
+    "@percy/client": "1.31.12",
+    "@percy/logger": "1.31.12"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/client",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -33,9 +33,9 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.31.12-beta.0",
-    "@percy/env": "1.31.12-beta.0",
-    "@percy/logger": "1.31.12-beta.0",
+    "@percy/config": "1.31.12",
+    "@percy/env": "1.31.12",
+    "@percy/logger": "1.31.12",
     "pac-proxy-agent": "^7.0.2",
     "pako": "^2.1.0"
   }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/config",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -38,7 +38,7 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/logger": "1.31.12-beta.0",
+    "@percy/logger": "1.31.12",
     "ajv": "^8.6.2",
     "cosmiconfig": "^8.0.0",
     "yaml": "^2.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/core",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -43,12 +43,12 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/client": "1.31.12-beta.0",
-    "@percy/config": "1.31.12-beta.0",
-    "@percy/dom": "1.31.12-beta.0",
-    "@percy/logger": "1.31.12-beta.0",
-    "@percy/monitoring": "1.31.12-beta.0",
-    "@percy/webdriver-utils": "1.31.12-beta.0",
+    "@percy/client": "1.31.12",
+    "@percy/config": "1.31.12",
+    "@percy/dom": "1.31.12",
+    "@percy/logger": "1.31.12",
+    "@percy/monitoring": "1.31.12",
+    "@percy/webdriver-utils": "1.31.12",
     "content-disposition": "^0.5.4",
     "cross-spawn": "^7.0.3",
     "extract-zip": "^2.0.1",
@@ -62,6 +62,6 @@
     "yaml": "^2.4.1"
   },
   "optionalDependencies": {
-    "@percy/cli-doctor": "1.31.12-beta.0"
+    "@percy/cli-doctor": "1.31.12"
   }
 }

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/dom",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "main": "dist/bundle.js",
   "browser": "dist/bundle.js",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/env",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -32,6 +32,6 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/logger": "1.31.12-beta.0"
+    "@percy/logger": "1.31.12"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/logger",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/monitoring",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -29,9 +29,9 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.31.12-beta.0",
-    "@percy/logger": "1.31.12-beta.0",
-    "@percy/sdk-utils": "1.31.12-beta.0",
+    "@percy/config": "1.31.12",
+    "@percy/logger": "1.31.12",
+    "@percy/sdk-utils": "1.31.12",
     "systeminformation": "^5.25.11"
   }
 }

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/sdk-utils",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"

--- a/packages/webdriver-utils/package.json
+++ b/packages/webdriver-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/webdriver-utils",
-  "version": "1.31.12-beta.0",
+  "version": "1.31.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "engines": {
     "node": ">=14"
@@ -29,7 +29,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.31.12-beta.0",
-    "@percy/sdk-utils": "1.31.12-beta.0"
+    "@percy/config": "1.31.12",
+    "@percy/sdk-utils": "1.31.12"
   }
 }


### PR DESCRIPTION
## Summary
- Update all package versions from `1.31.12-beta.0` to `1.31.12`
- Change `publishConfig.tag` from `beta` to `latest` across all packages
- Stable release for 1.31.12

## Changes since 1.31.11
- PPLT-5148: Add dialog serialization for showModal() support
- fix: eliminate 5 flaky tests on Windows and Firefox CI
- chore: remove temporary KMS signing test workflow
- chore: migrate Windows binary signing to Google Cloud KMS (HSM)

## Test plan
- [ ] CI passes on all platforms
- [ ] Packages publish to npm with `latest` tag
- [ ] Verify CLI version reports `1.31.12`

🤖 Generated with [Claude Code](https://claude.com/claude-code)