### PR TITLE
Replace em dash in serialize-dialog.js comment w/ ASCII dash

### DIFF
--- a/packages/dom/src/serialize-dialog.js
+++ b/packages/dom/src/serialize-dialog.js
@@ -23,7 +23,7 @@ export function serializeDialogs(ctx) {
       // :modal pseudo-class matches only dialogs in the top layer (opened via showModal())
       if (!elem.matches(':modal')) continue;
 
-      // Mark for renderer — it will removeAttribute('open') then showModal()
+      // Mark for renderer - it will removeAttribute('open') then showModal()
       cloneEl.setAttribute('data-percy-dialog-modal', 'true');
     } catch (err) {
       handleErrors(err, 'Error serializing dialog element: ', elem);


### PR DESCRIPTION
The em dash (U+2014 EM DASH) that is being replaced in this change with a simple dash (U+002D HYPHEN-MINUS) causes a problem for me (and maybe/probably other people). The em dash ultimately causes Ruby's HTTP library (which I use via the `percy-capybara` gem) to interpret a certain HTTP response from the Percy server as having a binary encoding, rather than a UTF-8 encoding, which then causes a warning from the `json` gem (`/home/runner/work/david_runger/david_runger/vendor/bundle/ruby/4.0.0/gems/json-2.19.4/lib/json/common.rb:445: warning: JSON.generate: UTF-8 string passed as BINARY, this will raise an encoding error in json 3.0`).

Replacing the em dash with a simple ASCII dash avoids this issue.

The non-ASCII dash was introduced in the latest released Percy version (1.31.12) via #2185.