### PR TITLE
fix(core): add pseudoClassEnabledElements to TypeScript types (PPLT-5013)

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -28,6 +28,13 @@ interface ScopeOptions {
   scroll?: boolean;
 }
 
+interface PseudoClassEnabledElements {
+  id?: string[];
+  className?: string[];
+  xpath?: string[];
+  selectors?: string[];
+}
+
 interface DiscoveryLaunchOptions {
   executable?: string;
   args?: string[];
@@ -59,6 +66,7 @@ interface CommonSnapshotOptions {
   devicePixelRatio?: number;
   scopeOptions?: ScopeOptions;
   browsers?: string[];
+  pseudoClassEnabledElements?: PseudoClassEnabledElements;
 }
 // Region support for TypeScript
 interface BoundingBox {

--- a/packages/core/types/index.test-d.ts
+++ b/packages/core/types/index.test-d.ts
@@ -368,3 +368,27 @@ expectType<Promise<void>>(percy.snapshot({
   name: 'Snapshot',
   regions: [region, regionWithPadding, regionFull]
 }));
+
+// pseudoClassEnabledElements
+expectType<Promise<void>>(percy.snapshot({
+  url: 'http://localhost:3000',
+  name: 'pseudo-class snapshot',
+  pseudoClassEnabledElements: {
+    selectors: [':popover-open'],
+    id: ['my-id'],
+    className: ['my-class'],
+    xpath: ['//div[@id="x"]']
+  }
+}));
+
+expectType<PercyConfigOptions>(percy.setConfig({
+  snapshot: {
+    pseudoClassEnabledElements: { selectors: [':popover-open'] }
+  }
+}));
+
+expectError(percy.snapshot({
+  url: 'http://localhost:3000',
+  name: 'invalid pseudo-class snapshot',
+  pseudoClassEnabledElements: { unknown: ['x'] }
+}));


### PR DESCRIPTION
## Summary
- Add `pseudoClassEnabledElements` to `CommonSnapshotOptions` in `@percy/core`'s type definition (`packages/core/types/index.d.ts`), mirroring the runtime config schema in `packages/core/src/config.js`.
- Add positive (`expectType`) and negative (`expectError`) tsd assertions in `packages/core/types/index.test-d.ts`.

## Why
The runtime config schema has accepted `pseudoClassEnabledElements` since the original PPLT-5013 fix, but the TypeScript definition in `@percy/core` did not include it. As a result, TypeScript users have to suppress type errors (`// @ts-ignore` or `as any`) when passing the option to `percySnapshot()`. This was reported in customer ticket PER-6872 (Salsify):

> "the TypeScript type for `percySnapshot` does not include the `pseudoClassEnabledElements` field, which means in a TS codebase I have to suppress a type error in order to set that option when passing it directly."

Since every Percy SDK (`@percy/ember`, `@percy/puppeteer`, `@percy/playwright`, `@percy/selenium`, `@percy/webdriverio`, etc.) imports `SnapshotOptions` from `@percy/core`, this single change fixes the type for all of them.

## Test plan
- [x] `yarn test:types` passes inside `packages/core`
- [x] Verified in a standalone TS scratch project with `file:` link to local `@percy/core`:
  - Positive: valid `{ selectors, id, className, xpath }` compiles cleanly.
  - Negative: an unknown sub-property (`unknown: ['x']`) is rejected by tsc with `TS2353`, confirming the type is not loosened to `any`.

## Related
- Customer ticket: PER-6872
- Original feature: PPLT-5013
