### PR TITLE
chore: update package versions to 1.31.13-beta.0 across all packages

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "packages": [
     "packages/*"
   ],

--- a/packages/cli-app/package.json
+++ b/packages/cli-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-app",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -33,7 +33,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12",
-    "@percy/cli-exec": "1.31.12"
+    "@percy/cli-command": "1.31.13-beta.0",
+    "@percy/cli-exec": "1.31.13-beta.0"
   }
 }

--- a/packages/cli-build/package.json
+++ b/packages/cli-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-build",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -36,6 +36,6 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12"
+    "@percy/cli-command": "1.31.13-beta.0"
   }
 }

--- a/packages/cli-command/package.json
+++ b/packages/cli-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-command",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "files": [
     "dist",
@@ -36,8 +36,8 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.31.12",
-    "@percy/core": "1.31.12",
-    "@percy/logger": "1.31.12"
+    "@percy/config": "1.31.13-beta.0",
+    "@percy/core": "1.31.13-beta.0",
+    "@percy/logger": "1.31.13-beta.0"
   }
 }

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-config",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -33,6 +33,6 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12"
+    "@percy/cli-command": "1.31.13-beta.0"
   }
 }

--- a/packages/cli-doctor/package.json
+++ b/packages/cli-doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-doctor",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -35,13 +35,13 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12",
-    "@percy/client": "1.31.12",
-    "@percy/config": "1.31.12",
-    "@percy/core": "1.31.12",
-    "@percy/env": "1.31.12",
-    "@percy/logger": "1.31.12",
-    "@percy/monitoring": "1.31.12",
+    "@percy/cli-command": "1.31.13-beta.0",
+    "@percy/client": "1.31.13-beta.0",
+    "@percy/config": "1.31.13-beta.0",
+    "@percy/core": "1.31.13-beta.0",
+    "@percy/env": "1.31.13-beta.0",
+    "@percy/logger": "1.31.13-beta.0",
+    "@percy/monitoring": "1.31.13-beta.0",
     "minimatch": "^9.0.0",
     "ws": "^8.17.1"
   }

--- a/packages/cli-exec/package.json
+++ b/packages/cli-exec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-exec",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -33,8 +33,8 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12",
-    "@percy/logger": "1.31.12",
+    "@percy/cli-command": "1.31.13-beta.0",
+    "@percy/logger": "1.31.13-beta.0",
     "cross-spawn": "^7.0.3",
     "which": "^2.0.2"
   }

--- a/packages/cli-snapshot/package.json
+++ b/packages/cli-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-snapshot",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -33,7 +33,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12",
+    "@percy/cli-command": "1.31.13-beta.0",
     "yaml": "^2.0.0"
   }
 }

--- a/packages/cli-upload/package.json
+++ b/packages/cli-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-upload",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -33,7 +33,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.31.12",
+    "@percy/cli-command": "1.31.13-beta.0",
     "fast-glob": "^3.2.11",
     "image-size": "^1.0.0"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "files": [
     "bin",
@@ -31,15 +31,15 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/cli-app": "1.31.12",
-    "@percy/cli-build": "1.31.12",
-    "@percy/cli-command": "1.31.12",
-    "@percy/cli-config": "1.31.12",
-    "@percy/cli-doctor": "1.31.12",
-    "@percy/cli-exec": "1.31.12",
-    "@percy/cli-snapshot": "1.31.12",
-    "@percy/cli-upload": "1.31.12",
-    "@percy/client": "1.31.12",
-    "@percy/logger": "1.31.12"
+    "@percy/cli-app": "1.31.13-beta.0",
+    "@percy/cli-build": "1.31.13-beta.0",
+    "@percy/cli-command": "1.31.13-beta.0",
+    "@percy/cli-config": "1.31.13-beta.0",
+    "@percy/cli-doctor": "1.31.13-beta.0",
+    "@percy/cli-exec": "1.31.13-beta.0",
+    "@percy/cli-snapshot": "1.31.13-beta.0",
+    "@percy/cli-upload": "1.31.13-beta.0",
+    "@percy/client": "1.31.13-beta.0",
+    "@percy/logger": "1.31.13-beta.0"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/client",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -33,9 +33,9 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.31.12",
-    "@percy/env": "1.31.12",
-    "@percy/logger": "1.31.12",
+    "@percy/config": "1.31.13-beta.0",
+    "@percy/env": "1.31.13-beta.0",
+    "@percy/logger": "1.31.13-beta.0",
     "pac-proxy-agent": "^7.0.2",
     "pako": "^2.1.0"
   }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/config",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -38,7 +38,7 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/logger": "1.31.12",
+    "@percy/logger": "1.31.13-beta.0",
     "ajv": "^8.6.2",
     "cosmiconfig": "^8.0.0",
     "yaml": "^2.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/core",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -43,12 +43,12 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/client": "1.31.12",
-    "@percy/config": "1.31.12",
-    "@percy/dom": "1.31.12",
-    "@percy/logger": "1.31.12",
-    "@percy/monitoring": "1.31.12",
-    "@percy/webdriver-utils": "1.31.12",
+    "@percy/client": "1.31.13-beta.0",
+    "@percy/config": "1.31.13-beta.0",
+    "@percy/dom": "1.31.13-beta.0",
+    "@percy/logger": "1.31.13-beta.0",
+    "@percy/monitoring": "1.31.13-beta.0",
+    "@percy/webdriver-utils": "1.31.13-beta.0",
     "content-disposition": "^0.5.4",
     "cross-spawn": "^7.0.3",
     "extract-zip": "^2.0.1",
@@ -62,6 +62,6 @@
     "yaml": "^2.4.1"
   },
   "optionalDependencies": {
-    "@percy/cli-doctor": "1.31.12"
+    "@percy/cli-doctor": "1.31.13-beta.0"
   }
 }

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/dom",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "main": "dist/bundle.js",
   "browser": "dist/bundle.js",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/env",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -32,6 +32,6 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/logger": "1.31.12"
+    "@percy/logger": "1.31.13-beta.0"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/logger",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/monitoring",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -29,9 +29,9 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.31.12",
-    "@percy/logger": "1.31.12",
-    "@percy/sdk-utils": "1.31.12",
+    "@percy/config": "1.31.13-beta.0",
+    "@percy/logger": "1.31.13-beta.0",
+    "@percy/sdk-utils": "1.31.13-beta.0",
     "systeminformation": "^5.25.11"
   }
 }

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/sdk-utils",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"

--- a/packages/webdriver-utils/package.json
+++ b/packages/webdriver-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/webdriver-utils",
-  "version": "1.31.12",
+  "version": "1.31.13-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -29,7 +29,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.31.12",
-    "@percy/sdk-utils": "1.31.12"
+    "@percy/config": "1.31.13-beta.0",
+    "@percy/sdk-utils": "1.31.13-beta.0"
   }
 }


### PR DESCRIPTION
## Summary

Beta release bump. Cuts `1.31.13-beta.0` so the `feat(client): add visual-config support for create-build` change ([#2139](https://github.com/percy/cli/pull/2139), commit `a0bce181`) ships in a pre-release tag.

The visual-config feature was merged to master after `v1.31.12` was tagged ([#2191](https://github.com/percy/cli/pull/2191)), so it currently has no release. This PR is the standard beta-bump pattern (mirroring [#2189](https://github.com/percy/cli/pull/2189) for `1.31.12-beta.0`) so an installable build can be cut.

## What changed

- `lerna.json` — root version `1.31.12` → `1.31.13-beta.0`
- All 18 `packages/*/package.json` — `version` and internal `@percy/*` deps bumped `1.31.12` → `1.31.13-beta.0`
- `publishConfig.tag` flipped `latest` → `beta` (matches the pattern from #2189)

19 files, 82 ± 82 lines — identical shape to the previous beta-bump PR.

## Why this is needed

The `feat(client): add visual-config support` change powers a downstream BrowserStack Central Scanner feature (CN-2616). Without a release tag containing `a0bce181`, the bundled CLI in `browserstack-node-sdk` cannot pick it up, and the new `PERCY_VISUAL_CONFIG` env var that CS workers now emit is silently dropped.

## Test plan

- [x] `lerna.json` and all package versions match `1.31.13-beta.0`
- [x] All `publishConfig.tag` are `beta`
- [x] No leftover `1.31.12` strings in modified files
- [x] Diff stat matches the previous beta-bump (#2189) shape — 19 files, 82 ± 82
- [ ] CI green
- [ ] Beta `npm publish` succeeds and `npm dist-tag ls @percy/cli` shows `beta: 1.31.13-beta.0`

## Refs

- Visual-config feature merge: #2139
- Previous release: #2191 (`1.31.12`)
- Previous beta bump pattern: #2189 (`1.31.12-beta.0`)
- Downstream: BrowserStack CS CN-2616