### PR TITLE
feat(client+core): CLI side of direct bucket upload for Percy resources (PPLT-5303)

### DIFF
--- a/packages/cli-upload/test/upload.test.js
+++ b/packages/cli-upload/test/upload.test.js
@@ -108,7 +108,9 @@ describe('percy upload', () => {
                 'resource-url': 'http://local/test-1',
                 mimetype: 'text/html',
                 'for-widths': null,
-                'is-root': true
+                'is-root': true,
+                'content-md5': jasmine.any(String),
+                'content-length': jasmine.any(Number)
               }
             }, {
               type: 'resources',
@@ -117,7 +119,9 @@ describe('percy upload', () => {
                 'resource-url': 'http://local/test-1.png',
                 mimetype: 'image/png',
                 'for-widths': null,
-                'is-root': null
+                'is-root': null,
+                'content-md5': jasmine.any(String),
+                'content-length': jasmine.any(Number)
               }
             }])
           }

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -22,6 +22,15 @@ import {
 // Default client API URL can be set with an env var for API development
 const { PERCY_CLIENT_API_URL = 'https://percy.io/api/v1' } = process.env;
 let pkg = getPackageJSON(import.meta.url);
+
+// Strict boolean env var parser. Only "1" or "true" (case-insensitive) count as
+// enabled. Avoids the JS-truthy trap where "0" or "false" would silently enable
+// a flag because both are non-empty strings.
+function envBool(value) {
+  if (value == null) return false;
+  let v = String(value).toLowerCase();
+  return v === '1' || v === 'true';
+}
 // minimum polling interval milliseconds
 const MIN_POLLING_INTERVAL = 1_000;
 const INVALID_TOKEN_ERROR_MESSAGE = 'Unable to retrieve snapshot details with write access token. Kindly use a full access token for retrieving snapshot details with Synchronous CLI.';
@@ -316,7 +325,7 @@ export class PercyClient {
   // the missing-resources response. PERCY_DISABLE_DIRECT_UPLOAD is the
   // customer-side escape hatch that forces fallback to POST /resources.
   directUploadCapabilityHeaders() {
-    if (process.env.PERCY_DISABLE_DIRECT_UPLOAD) return {};
+    if (envBool(process.env.PERCY_DISABLE_DIRECT_UPLOAD)) return {};
     return { 'X-Percy-Capabilities': 'direct-upload-v1' };
   }
 
@@ -729,7 +738,29 @@ export class PercyClient {
     this.log.debug(`${missing?.length || 0} Missing resources: ${options.name}...`, meta);
     if (missing?.length) {
       let resources = options.resources.reduce((acc, r) => Object.assign(acc, { [r.sha]: r }), {});
-      await this.uploadResources(buildId, missing.map(({ id }) => resources[id]), meta);
+      let disabled = envBool(process.env.PERCY_DISABLE_DIRECT_UPLOAD);
+      let direct = [];
+      let legacy = [];
+
+      for (let entry of missing) {
+        let resource = resources[entry.id];
+        if (!resource) continue;
+        let signedUploadUrl = entry.attributes?.['signed-upload-url'];
+        if (!disabled && signedUploadUrl) {
+          direct.push({ ...resource, signedUploadUrl });
+        } else {
+          legacy.push(resource);
+        }
+      }
+
+      if (direct.length) {
+        let failed = await this.uploadResourcesDirect(direct, meta);
+        legacy.push(...failed);
+      }
+
+      if (legacy.length) {
+        await this.uploadResources(buildId, legacy, meta);
+      }
     }
     this.log.debug(`Resources uploaded: ${options.name}...`, meta);
 

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -572,6 +572,66 @@ export class PercyClient {
     }, this, uploadConcurrency);
   }
 
+  // PUTs a single resource directly to its percy-api-issued GCS signed URL.
+  // Returns the resource when the upload hits a transport-class failure
+  // (caller falls back to legacy POST /resources). Throws on correctness-class
+  // failures (400 BadDigest, 412 if-generation-match) — those signal a real
+  // bug in the declared md5/length or a leaked URL replay, and must not be
+  // silently masked by the fallback path.
+  async uploadResourceDirect(resource, meta = {}) {
+    let { signedUploadUrl, content, md5, contentLength, url, mimetype } = resource;
+    this.log.debug(`Direct-uploading ${formatBytes(contentLength)} resource: ${url}`, meta);
+    this.mayBeLogUploadSize(contentLength, meta);
+
+    let headers = {
+      'Content-MD5': md5,
+      'Content-Length': contentLength
+    };
+    if (mimetype) headers['Content-Type'] = mimetype;
+
+    try {
+      await request(signedUploadUrl, {
+        method: 'PUT',
+        rawBody: true,
+        body: content,
+        headers,
+        meta
+      });
+      return null;
+    } catch (err) {
+      let status = err.response?.statusCode;
+      if (status === 400 || status === 412) throw err;
+      this.log.debug(`Direct upload failed for ${url}, falling back to legacy: ${err.message}`, meta);
+      return resource;
+    }
+  }
+
+  // Uploads resources directly to GCS signed URLs concurrently. Returns the
+  // list of resources that hit transport-class failures so the caller can
+  // route them through the legacy upload path. Concurrency is shared with
+  // the legacy uploader via PERCY_RESOURCE_UPLOAD_CONCURRENCY.
+  async uploadResourcesDirect(resources, meta = {}) {
+    this.log.debug(`Direct-uploading ${resources.length} resource(s)...`, meta);
+
+    const uploadConcurrency = parseInt(process.env.PERCY_RESOURCE_UPLOAD_CONCURRENCY) || 2;
+    let fallback = [];
+
+    await pool(function*() {
+      for (let resource of resources) {
+        let resourceMeta = {
+          url: resource.url,
+          sha: resource.sha,
+          ...meta
+        };
+        yield this.uploadResourceDirect(resource, resourceMeta).then(failed => {
+          if (failed) fallback.push(failed);
+        });
+      }
+    }, this, uploadConcurrency);
+
+    return fallback;
+  }
+
   // Creates a snapshot for the active build using the provided attributes.
   async createSnapshot(buildId, {
     name,

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -9,6 +9,7 @@ import {
   request,
   formatBytes,
   sha256hash,
+  md5base64,
   base64encode,
   getPackageJSON,
   waitForTimeout,
@@ -308,6 +309,15 @@ export class PercyClient {
         meta
       });
     });
+  }
+
+  // Returns capability headers advertised on snapshot creation. `direct-upload-v1`
+  // tells percy-api to mint Content-MD5/Content-Length-bound GCS signed URLs in
+  // the missing-resources response. PERCY_DISABLE_DIRECT_UPLOAD is the
+  // customer-side escape hatch that forces fallback to POST /resources.
+  directUploadCapabilityHeaders() {
+    if (process.env.PERCY_DISABLE_DIRECT_UPLOAD) return {};
+    return { 'X-Percy-Capabilities': 'direct-upload-v1' };
   }
 
   // Creates a build with optional build resources. Only one build can be
@@ -630,13 +640,15 @@ export class PercyClient {
                 'resource-url': r.url || null,
                 'is-root': r.root || null,
                 'for-widths': r.widths || null,
-                mimetype: r.mimetype || null
+                mimetype: r.mimetype || null,
+                'content-md5': r.md5 ?? (r.content != null ? md5base64(r.content) : null),
+                'content-length': r.contentLength ?? (r.content != null ? Buffer.byteLength(r.content, 'utf-8') : null)
               }
             }))
           }
         }
       }
-    }, { identifier: 'snapshot.post', ...meta });
+    }, { identifier: 'snapshot.post', ...meta }, this.directUploadCapabilityHeaders());
   }
 
   // Finalizes a snapshot.

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -25,6 +25,15 @@ export function sha256hash(content) {
     .digest('hex');
 }
 
+// Returns a base64-encoded MD5 of a string or buffer. Used as Content-MD5 for
+// GCS direct-bucket-upload integrity (RFC 1864), declared alongside the SHA-256.
+export function md5base64(content) {
+  return crypto
+    .createHash('md5')
+    .update(content, 'utf-8')
+    .digest('base64');
+}
+
 // Returns a base64 encoding of a string or buffer.
 export function base64encode(content) {
   return Buffer

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -141,7 +141,7 @@ export async function request(url, options = {}, callback) {
   // gather request options
   let {
     body, headers, retries, retryNotFound,
-    interval, noProxy, buffer, meta = {}, ...requestOptions
+    interval, noProxy, buffer, rawBody, meta = {}, ...requestOptions
   } = options;
   let { protocol, hostname, port, pathname, search, hash } = new URL(url);
 
@@ -151,8 +151,9 @@ export async function request(url, options = {}, callback) {
   let { default: http } = protocol === 'https:' ? await import('https') : await import('http');
   let { proxyAgentFor } = await import('./proxy.js');
 
-  // automatically stringify body content
-  if (body !== undefined && typeof body !== 'string') {
+  // rawBody: send body and headers verbatim (e.g. binary PUT to a GCS signed URL).
+  // Otherwise stringify non-string bodies as JSON.
+  if (!rawBody && body !== undefined && typeof body !== 'string') {
     headers = { 'Content-Type': 'application/json', ...headers };
     body = JSON.stringify(body);
   }

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import logger from '@percy/logger/test/helpers';
 import { mockgit } from '@percy/env/test/helpers';
-import { sha256hash, base64encode } from '@percy/client/utils';
+import { md5base64, sha256hash, base64encode } from '@percy/client/utils';
 import PercyClient from '@percy/client';
 import api, { mockRequests } from './helpers.js';
 import * as CoreConfig from '@percy/core/config';
@@ -1222,7 +1222,9 @@ describe('PercyClient', () => {
                   'resource-url': '/foo',
                   mimetype: 'text/html',
                   'for-widths': [1000],
-                  'is-root': true
+                  'is-root': true,
+                  'content-md5': md5base64('foo'),
+                  'content-length': Buffer.byteLength('foo', 'utf-8')
                 }
               }, {
                 type: 'resources',
@@ -1231,7 +1233,9 @@ describe('PercyClient', () => {
                   'resource-url': '/bar',
                   mimetype: 'image/png',
                   'for-widths': null,
-                  'is-root': null
+                  'is-root': null,
+                  'content-md5': md5base64('bar'),
+                  'content-length': Buffer.byteLength('bar', 'utf-8')
                 }
               }]
             }
@@ -1314,7 +1318,9 @@ describe('PercyClient', () => {
                     'resource-url': '/foo',
                     mimetype: 'text/html',
                     'for-widths': [1000],
-                    'is-root': true
+                    'is-root': true,
+                    'content-md5': md5base64('foo'),
+                    'content-length': Buffer.byteLength('foo', 'utf-8')
                   }
                 }, {
                   type: 'resources',
@@ -1323,7 +1329,9 @@ describe('PercyClient', () => {
                     'resource-url': '/bar',
                     mimetype: 'image/png',
                     'for-widths': null,
-                    'is-root': null
+                    'is-root': null,
+                    'content-md5': md5base64('bar'),
+                    'content-length': Buffer.byteLength('bar', 'utf-8')
                   }
                 }]
               }
@@ -1365,13 +1373,57 @@ describe('PercyClient', () => {
                   'resource-url': null,
                   'for-widths': null,
                   'is-root': null,
-                  mimetype: null
+                  mimetype: null,
+                  'content-md5': null,
+                  'content-length': null
                 }
               }]
             }
           }
         }
       });
+    });
+
+    it('advertises direct-upload-v1 capability header by default', async () => {
+      await expectAsync(
+        client.createSnapshot(123, { name: 'cap-test', resources: [{ sha: 'sha' }] })
+      ).toBeResolved();
+
+      expect(api.requests['/builds/123/snapshots'][0].headers).toEqual(
+        jasmine.objectContaining({ 'X-Percy-Capabilities': 'direct-upload-v1' })
+      );
+    });
+
+    it('suppresses capability header when PERCY_DISABLE_DIRECT_UPLOAD is set', async () => {
+      process.env.PERCY_DISABLE_DIRECT_UPLOAD = '1';
+      try {
+        await expectAsync(
+          client.createSnapshot(123, { name: 'cap-test', resources: [{ sha: 'sha' }] })
+        ).toBeResolved();
+
+        expect(api.requests['/builds/123/snapshots'][0].headers['X-Percy-Capabilities']).toBeUndefined();
+      } finally {
+        delete process.env.PERCY_DISABLE_DIRECT_UPLOAD;
+      }
+    });
+
+    it('prefers caller-supplied md5/contentLength over recomputing from content', async () => {
+      await expectAsync(
+        client.createSnapshot(123, {
+          name: 'precomputed',
+          resources: [{
+            url: '/x',
+            sha: 'precomputed-sha',
+            content: 'foo',
+            md5: 'caller-md5-base64',
+            contentLength: 999
+          }]
+        })
+      ).toBeResolved();
+
+      const attrs = api.requests['/builds/123/snapshots'][0].body.data.relationships.resources.data[0].attributes;
+      expect(attrs['content-md5']).toBe('caller-md5-base64');
+      expect(attrs['content-length']).toBe(999);
     });
   });
 
@@ -1438,7 +1490,9 @@ describe('PercyClient', () => {
                   mimetype: 'text/html',
                   'resource-url': null,
                   'for-widths': [1000],
-                  'is-root': true
+                  'is-root': true,
+                  'content-md5': md5base64(testDOM),
+                  'content-length': Buffer.byteLength(testDOM, 'utf-8')
                 }
               }]
             }

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -1142,6 +1142,129 @@ describe('PercyClient', () => {
     });
   });
 
+  describe('#uploadResourceDirect() / #uploadResourcesDirect()', () => {
+    const GCS_BASE = 'https://storage.googleapis.com';
+    let gcsReply;
+
+    function makeResource(overrides = {}) {
+      const content = overrides.content ?? 'foo';
+      return {
+        url: '/foo.css',
+        sha: sha256hash(content),
+        mimetype: 'text/css',
+        content,
+        md5: md5base64(content),
+        contentLength: Buffer.byteLength(content, 'utf-8'),
+        signedUploadUrl: `${GCS_BASE}/percy-resources/ns_gid_${sha256hash(content)}?sig=fake`,
+        ...overrides
+      };
+    }
+
+    beforeEach(async () => {
+      gcsReply = await mockRequests(GCS_BASE);
+    });
+
+    it('PUTs raw bytes with Content-MD5, Content-Length, Content-Type headers and resolves to null on 200', async () => {
+      gcsReply.and.callFake(() => [200]);
+
+      const resource = makeResource({ content: 'p { color: purple; }' });
+      await expectAsync(client.uploadResourceDirect(resource)).toBeResolvedTo(null);
+
+      const req = gcsReply.calls.mostRecent().args[0];
+      expect(req.method).toBe('PUT');
+      expect(req.headers['Content-MD5']).toBe(resource.md5);
+      expect(req.headers['Content-Length']).toBe(resource.contentLength);
+      expect(req.headers['Content-Type']).toBe('text/css');
+    });
+
+    it('returns the resource for fallback on 403 (signed URL expired)', async () => {
+      gcsReply.and.callFake(() => [403, 'expired']);
+
+      const resource = makeResource();
+      await expectAsync(client.uploadResourceDirect(resource)).toBeResolvedTo(resource);
+    });
+
+    it('returns the resource for fallback on 429 (rate limited)', async () => {
+      gcsReply.and.callFake(() => [429]);
+
+      const resource = makeResource();
+      await expectAsync(client.uploadResourceDirect(resource)).toBeResolvedTo(resource);
+    });
+
+    it('returns the resource for fallback on 5xx after retries', async () => {
+      gcsReply.and.callFake(() => [503]);
+
+      const resource = makeResource();
+      await expectAsync(client.uploadResourceDirect(resource)).toBeResolvedTo(resource);
+    });
+
+    it('throws on 400 BadDigest (correctness failure must surface, not be masked)', async () => {
+      gcsReply.and.callFake(() => [400, '<Error><Code>BadDigest</Code></Error>']);
+
+      const resource = makeResource();
+      await expectAsync(client.uploadResourceDirect(resource)).toBeRejected();
+    });
+
+    it('throws on 412 Precondition Failed (object already exists — replay or bug)', async () => {
+      gcsReply.and.callFake(() => [412, '<Error><Code>PreconditionFailed</Code></Error>']);
+
+      const resource = makeResource();
+      await expectAsync(client.uploadResourceDirect(resource)).toBeRejected();
+    });
+
+    it('omits Content-Type when resource has no mimetype', async () => {
+      gcsReply.and.callFake(() => [200]);
+
+      const resource = makeResource();
+      delete resource.mimetype;
+      await client.uploadResourceDirect(resource);
+
+      const req = gcsReply.calls.mostRecent().args[0];
+      expect(req.headers['Content-Type']).toBeUndefined();
+    });
+
+    describe('#uploadResourcesDirect()', () => {
+      it('resolves to empty fallback list when every resource succeeds', async () => {
+        gcsReply.and.callFake(() => [200]);
+
+        await expectAsync(client.uploadResourcesDirect([
+          makeResource({ content: 'a' }),
+          makeResource({ content: 'b' })
+        ])).toBeResolvedTo([]);
+      });
+
+      it('collects transport-failed resources for fallback while letting successes pass', async () => {
+        const resources = [
+          makeResource({ content: 'a' }),
+          makeResource({ content: 'b' }),
+          makeResource({ content: 'c' })
+        ];
+
+        // succeed for 'a' and 'c', 5xx for 'b'
+        gcsReply.and.callFake(({ path }) => {
+          if (path.includes(resources[1].sha)) return [503];
+          return [200];
+        });
+
+        const fallback = await client.uploadResourcesDirect(resources);
+        expect(fallback.length).toBe(1);
+        expect(fallback[0].sha).toBe(resources[1].sha);
+      });
+
+      it('propagates correctness failures from any resource', async () => {
+        gcsReply.and.callFake(() => [400, '<Error><Code>BadDigest</Code></Error>']);
+
+        await expectAsync(client.uploadResourcesDirect([
+          makeResource()
+        ])).toBeRejected();
+      });
+
+      it('does nothing for an empty resource list', async () => {
+        await expectAsync(client.uploadResourcesDirect([])).toBeResolvedTo([]);
+      });
+    });
+  });
+
   describe('#createSnapshot()', () => {
     it('throws when missing a build id', async () => {
       await expectAsync(client.createSnapshot())

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -1772,8 +1772,12 @@ describe('PercyClient', () => {
             client.sendSnapshot(123, {
               name: 'forced-legacy',
               resources: [{
-                url: '/x', sha: sha256hash(content), content, mimetype: 'text/plain',
-                md5: md5base64(content), contentLength: Buffer.byteLength(content, 'utf-8')
+                url: '/x',
+                sha: sha256hash(content),
+                content,
+                mimetype: 'text/plain',
+                md5: md5base64(content),
+                contentLength: Buffer.byteLength(content, 'utf-8')
               }]
             })
           ).toBeResolved();
@@ -1794,8 +1798,13 @@ describe('PercyClient', () => {
           client.sendSnapshot(123, {
             name: 'fallback',
             resources: [{
-              url: '/x', sha: sha256hash(content), content, mimetype: 'text/plain',
-              md5: md5base64(content), contentLength: Buffer.byteLength(content, 'utf-8'), root: true
+              url: '/x',
+              sha: sha256hash(content),
+              content,
+              mimetype: 'text/plain',
+              md5: md5base64(content),
+              contentLength: Buffer.byteLength(content, 'utf-8'),
+              root: true
             }]
           })
         ).toBeResolved();
@@ -1815,8 +1824,12 @@ describe('PercyClient', () => {
           client.sendSnapshot(123, {
             name: 'fail-loud',
             resources: [{
-              url: '/x', sha: sha256hash(content), content, mimetype: 'text/plain',
-              md5: md5base64(content), contentLength: Buffer.byteLength(content, 'utf-8')
+              url: '/x',
+              sha: sha256hash(content),
+              content,
+              mimetype: 'text/plain',
+              md5: md5base64(content),
+              contentLength: Buffer.byteLength(content, 'utf-8')
             }]
           })
         ).toBeRejected();

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -1836,6 +1836,37 @@ describe('PercyClient', () => {
 
         expect(api.requests['/builds/123/resources']).toBeUndefined();
       });
+
+      it('skips missing-resource entries whose SHA was not sent in the request', async () => {
+        api.reply('/builds/123/snapshots', () => [201, {
+          data: {
+            id: '4567',
+            relationships: {
+              'missing-resources': {
+                data: [{ id: 'orphan-sha-not-in-request' }]
+              }
+            }
+          }
+        }]);
+
+        let content = 'orphan';
+        await expectAsync(
+          client.sendSnapshot(123, {
+            name: 'orphan',
+            resources: [{
+              url: '/x',
+              sha: sha256hash(content),
+              content,
+              mimetype: 'text/plain',
+              md5: md5base64(content),
+              contentLength: Buffer.byteLength(content, 'utf-8')
+            }]
+          })
+        ).toBeResolved();
+
+        expect(gcsReply).not.toHaveBeenCalled();
+        expect(api.requests['/builds/123/resources']).toBeUndefined();
+      });
     });
   });
 

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -1530,6 +1530,35 @@ describe('PercyClient', () => {
       }
     });
 
+    it('PERCY_DISABLE_DIRECT_UPLOAD uses strict parsing — "0" / "false" / "anything-else" do NOT disable', async () => {
+      // regression guard: an earlier !!process.env.X would treat any non-empty
+      // string as truthy, so PERCY_DISABLE_DIRECT_UPLOAD=0 would silently
+      // disable direct upload despite reading like "off"
+      for (const v of ['0', 'false', 'no', 'off', 'garbage']) {
+        process.env.PERCY_DISABLE_DIRECT_UPLOAD = v;
+        try {
+          await client.createSnapshot(123, { name: `cap-${v}`, resources: [{ sha: 'sha' }] });
+          const last = api.requests['/builds/123/snapshots'].slice(-1)[0];
+          expect(last.headers['X-Percy-Capabilities']).toBe('direct-upload-v1');
+        } finally {
+          delete process.env.PERCY_DISABLE_DIRECT_UPLOAD;
+        }
+      }
+    });
+
+    it('PERCY_DISABLE_DIRECT_UPLOAD strict-true values (1/true, case-insensitive) all disable', async () => {
+      for (const v of ['1', 'true', 'True', 'TRUE']) {
+        process.env.PERCY_DISABLE_DIRECT_UPLOAD = v;
+        try {
+          await client.createSnapshot(123, { name: `cap-${v}`, resources: [{ sha: 'sha' }] });
+          const last = api.requests['/builds/123/snapshots'].slice(-1)[0];
+          expect(last.headers['X-Percy-Capabilities']).toBeUndefined();
+        } finally {
+          delete process.env.PERCY_DISABLE_DIRECT_UPLOAD;
+        }
+      }
+    });
+
     it('prefers caller-supplied md5/contentLength over recomputing from content', async () => {
       await expectAsync(
         client.createSnapshot(123, {
@@ -1651,6 +1680,149 @@ describe('PercyClient', () => {
     it('finalizes a snapshot', async () => {
       await expectAsync(client.sendSnapshot(123, { name: 'test snapshot name' })).toBeResolved();
       expect(api.requests['/snapshots/4567/finalize']).toBeDefined();
+    });
+
+    describe('direct bucket upload', () => {
+      const GCS_BASE = 'https://storage.googleapis.com';
+      let gcsReply;
+
+      function withSignedUrls(reqBody, includeFor = () => true) {
+        return {
+          data: {
+            id: '4567',
+            attributes: reqBody.attributes,
+            relationships: {
+              'missing-resources': {
+                data: reqBody.data.relationships.resources.data.map(({ id }) => (
+                  includeFor(id)
+                    ? { id, attributes: { 'signed-upload-url': `${GCS_BASE}/percy-resources/ns_gid_${id}?sig=fake` } }
+                    : { id }
+                ))
+              }
+            }
+          }
+        };
+      }
+
+      beforeEach(async () => {
+        gcsReply = await mockRequests(GCS_BASE);
+      });
+
+      it('PUTs directly to GCS when the server returns signed-upload-url', async () => {
+        gcsReply.and.callFake(() => [200]);
+        api.reply('/builds/123/snapshots', ({ body }) => [201, withSignedUrls(body)]);
+
+        let content = 'foo-content';
+        await expectAsync(
+          client.sendSnapshot(123, {
+            name: 'direct-test',
+            resources: [{
+              url: '/foo.css',
+              sha: sha256hash(content),
+              mimetype: 'text/css',
+              content,
+              md5: md5base64(content),
+              contentLength: Buffer.byteLength(content, 'utf-8'),
+              root: true
+            }]
+          })
+        ).toBeResolved();
+
+        expect(gcsReply).toHaveBeenCalledTimes(1);
+        expect(gcsReply.calls.mostRecent().args[0].method).toBe('PUT');
+        expect(gcsReply.calls.mostRecent().args[0].headers['Content-MD5']).toBe(md5base64(content));
+        // legacy upload path NOT used when direct succeeds
+        expect(api.requests['/builds/123/resources']).toBeUndefined();
+        expect(api.requests['/snapshots/4567/finalize']).toBeDefined();
+      });
+
+      it('partitions per-resource: signed URL → direct, no URL → legacy', async () => {
+        gcsReply.and.callFake(() => [200]);
+        let directContent = 'direct-bytes';
+        let legacyContent = 'legacy-bytes';
+        let directSha = sha256hash(directContent);
+        let legacySha = sha256hash(legacyContent);
+
+        api.reply('/builds/123/snapshots', ({ body }) => [201, withSignedUrls(body, id => id === directSha)]);
+
+        await expectAsync(
+          client.sendSnapshot(123, {
+            name: 'mixed',
+            resources: [
+              { url: '/d', sha: directSha, content: directContent, mimetype: 'text/plain', md5: md5base64(directContent), contentLength: Buffer.byteLength(directContent, 'utf-8') },
+              { url: '/l', sha: legacySha, content: legacyContent, mimetype: 'text/plain', md5: md5base64(legacyContent), contentLength: Buffer.byteLength(legacyContent, 'utf-8') }
+            ]
+          })
+        ).toBeResolved();
+
+        expect(gcsReply).toHaveBeenCalledTimes(1);
+        expect(api.requests['/builds/123/resources']).toBeDefined();
+        expect(api.requests['/builds/123/resources'].length).toBe(1);
+        expect(api.requests['/builds/123/resources'][0].body.data.id).toBe(legacySha);
+      });
+
+      it('PERCY_DISABLE_DIRECT_UPLOAD forces every resource through legacy even when URLs are returned', async () => {
+        gcsReply.and.callFake(() => [200]);
+        api.reply('/builds/123/snapshots', ({ body }) => [201, withSignedUrls(body)]);
+
+        let content = 'forced-legacy';
+        process.env.PERCY_DISABLE_DIRECT_UPLOAD = '1';
+        try {
+          await expectAsync(
+            client.sendSnapshot(123, {
+              name: 'forced-legacy',
+              resources: [{
+                url: '/x', sha: sha256hash(content), content, mimetype: 'text/plain',
+                md5: md5base64(content), contentLength: Buffer.byteLength(content, 'utf-8')
+              }]
+            })
+          ).toBeResolved();
+
+          expect(gcsReply).not.toHaveBeenCalled();
+          expect(api.requests['/builds/123/resources'].length).toBe(1);
+        } finally {
+          delete process.env.PERCY_DISABLE_DIRECT_UPLOAD;
+        }
+      });
+
+      it('falls back to legacy when the direct PUT hits a transport error (e.g., 403)', async () => {
+        gcsReply.and.callFake(() => [403, 'expired']);
+        api.reply('/builds/123/snapshots', ({ body }) => [201, withSignedUrls(body)]);
+
+        let content = 'falls-back';
+        await expectAsync(
+          client.sendSnapshot(123, {
+            name: 'fallback',
+            resources: [{
+              url: '/x', sha: sha256hash(content), content, mimetype: 'text/plain',
+              md5: md5base64(content), contentLength: Buffer.byteLength(content, 'utf-8'), root: true
+            }]
+          })
+        ).toBeResolved();
+
+        expect(gcsReply).toHaveBeenCalled();
+        expect(api.requests['/builds/123/resources']).toBeDefined();
+        expect(api.requests['/builds/123/resources'][0].body.data.id).toBe(sha256hash(content));
+        expect(api.requests['/snapshots/4567/finalize']).toBeDefined();
+      });
+
+      it('propagates correctness failures (400 BadDigest) and does not fall back to legacy', async () => {
+        gcsReply.and.callFake(() => [400, '<Error><Code>BadDigest</Code></Error>']);
+        api.reply('/builds/123/snapshots', ({ body }) => [201, withSignedUrls(body)]);
+
+        let content = 'bad-digest';
+        await expectAsync(
+          client.sendSnapshot(123, {
+            name: 'fail-loud',
+            resources: [{
+              url: '/x', sha: sha256hash(content), content, mimetype: 'text/plain',
+              md5: md5base64(content), contentLength: Buffer.byteLength(content, 'utf-8')
+            }]
+          })
+        ).toBeRejected();
+
+        expect(api.requests['/builds/123/resources']).toBeUndefined();
+      });
     });
   });
 

--- a/packages/client/test/unit/request.test.js
+++ b/packages/client/test/unit/request.test.js
@@ -210,6 +210,51 @@ describe('Unit / Request', () => {
       .toBeRejectedWithError('403 \nSTOP');
   });
 
+  describe('rawBody', () => {
+    it('JSON-stringifies non-string bodies and forces application/json by default', async () => {
+      await server.request('/', {
+        method: 'POST',
+        body: { hello: 'world' }
+      });
+
+      const req = server.received[0];
+      expect(req.headers['content-type']).toBe('application/json');
+      expect(req.body).toBe('{"hello":"world"}');
+    });
+
+    it('sends Buffer body verbatim with caller-supplied headers when rawBody is true', async () => {
+      const payload = Buffer.from('raw-bytes-here', 'utf-8');
+
+      await server.request('/', {
+        method: 'PUT',
+        rawBody: true,
+        body: payload,
+        headers: {
+          'Content-Type': 'image/png',
+          'Content-MD5': 'fakebase64md5==',
+          'Content-Length': payload.length
+        }
+      });
+
+      const req = server.received[0];
+      expect(req.headers['content-type']).toBe('image/png');
+      expect(req.headers['content-md5']).toBe('fakebase64md5==');
+      expect(req.headers['content-length']).toBe(String(payload.length));
+      expect(Buffer.from(req.body).toString('utf-8')).toBe('raw-bytes-here');
+    });
+
+    it('does not inject Content-Type when rawBody is true and caller omits one', async () => {
+      await server.request('/', {
+        method: 'PUT',
+        rawBody: true,
+        body: Buffer.from('x')
+      });
+
+      const req = server.received[0];
+      expect(req.headers['content-type']).toBeUndefined();
+    });
+  });
+
   describe('retries', () => {
     it('automatically retries server 500 errors', async () => {
       let responses = [[502], [503], [520], [200]];

--- a/packages/client/test/unit/utils.test.js
+++ b/packages/client/test/unit/utils.test.js
@@ -1,6 +1,28 @@
-import { normalizeBrowsers } from '@percy/client/utils';
+import { md5base64, normalizeBrowsers, sha256hash } from '@percy/client/utils';
+import crypto from 'crypto';
 
 describe('utils', () => {
+  describe('md5base64', () => {
+    it('returns the base64-encoded MD5 of a string', () => {
+      // RFC 1864 test vector: empty string MD5 base64
+      expect(md5base64('')).toEqual('1B2M2Y8AsgTpgAmY7PhCfg==');
+    });
+
+    it('returns the base64-encoded MD5 of a buffer', () => {
+      const buf = Buffer.from('hello world', 'utf-8');
+      const expected = crypto.createHash('md5').update(buf).digest('base64');
+      expect(md5base64(buf)).toEqual(expected);
+    });
+
+    it('treats strings as UTF-8 (same encoding as sha256hash)', () => {
+      const utf8 = 'café — résumé';
+      const expectedMd5 = crypto.createHash('md5').update(utf8, 'utf-8').digest('base64');
+      const expectedSha = crypto.createHash('sha256').update(utf8, 'utf-8').digest('hex');
+      expect(md5base64(utf8)).toEqual(expectedMd5);
+      expect(sha256hash(utf8)).toEqual(expectedSha);
+    });
+  });
+
   describe('normalizeBrowsers', () => {
     describe('when browser values are in kebabcase', () => {
       it('returns snakecase values', () => {

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -18,7 +18,8 @@ import {
 } from './utils.js';
 import { ByteLRU, entrySize, DiskSpillStore, createSpillDir } from './cache/byte-lru.js';
 import {
-  sha256hash
+  sha256hash,
+  md5base64
 } from '@percy/client/utils';
 import Pako from 'pako';
 
@@ -228,6 +229,8 @@ function processSnapshotResources({ domSnapshot, resources, ...snapshot }) {
       if (!alreadyZipped) {
         resources[index].content = Pako.gzip(resources[index].content);
         resources[index].sha = sha256hash(resources[index].content);
+        resources[index].md5 = md5base64(resources[index].content);
+        resources[index].contentLength = Buffer.byteLength(resources[index].content, 'utf-8');
       }
     }
   }

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1,5 +1,5 @@
 import EventEmitter from 'events';
-import { sha256hash, request } from '@percy/client/utils';
+import { sha256hash, md5base64, request } from '@percy/client/utils';
 import { camelcase, merge } from '@percy/config/utils';
 import YAML from 'yaml';
 import path from 'path';
@@ -301,9 +301,19 @@ function processSendEventData(input, cliVersion) {
 }
 
 // Creates a local resource object containing the resource URL, mimetype, content, sha, and any
-// other additional resources attributes.
+// other additional resources attributes. md5 + contentLength are declared on snapshot creation
+// so percy-api can mint Content-MD5/Content-Length-bound signed URLs for direct bucket upload;
+// they must stay in lockstep with the bytes in `content` (see discovery.js PERCY_GZIP path).
 export function createResource(url, content, mimetype, attrs) {
-  return { ...attrs, sha: sha256hash(content), mimetype, content, url };
+  return {
+    ...attrs,
+    sha: sha256hash(content),
+    md5: md5base64(content),
+    contentLength: Buffer.byteLength(content, 'utf-8'),
+    mimetype,
+    content,
+    url
+  };
 }
 
 // Creates a root resource object with an additional `root: true` property. The URL is normalized

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -1,5 +1,5 @@
 import { sha256hash, base64encode } from '@percy/client/utils';
-import { logger, api, setupTest, createTestServer, dedent } from './helpers/index.js';
+import { logger, api, mockRequests, setupTest, createTestServer, dedent } from './helpers/index.js';
 import { waitFor } from '@percy/core/utils';
 import Percy from '@percy/core';
 import { handleSyncJob } from '../src/snapshot.js';
@@ -2067,6 +2067,139 @@ describe('Snapshot', () => {
           ]));
         });
       });
+    });
+  });
+
+  describe('direct bucket upload (end-to-end)', () => {
+    const GCS_BASE = 'https://storage.googleapis.com';
+    let gcsReply;
+
+    function withSignedUrls(reqBody) {
+      return [201, {
+        data: {
+          id: '4567',
+          attributes: reqBody.attributes,
+          relationships: {
+            'missing-resources': {
+              data: reqBody.data.relationships.resources.data.map(({ id }) => ({
+                id,
+                attributes: {
+                  'signed-upload-url': `${GCS_BASE}/percy-resources/ns_gid_${id}?sig=fake`
+                }
+              }))
+            }
+          }
+        }
+      }];
+    }
+
+    beforeEach(async () => {
+      gcsReply = await mockRequests(GCS_BASE);
+    });
+
+    it('PUTs DOM + asset bytes direct to GCS when the API hands back signed URLs, and finalizes the snapshot', async () => {
+      gcsReply.and.callFake(() => [200]);
+      api.reply('/builds/123/snapshots', ({ body }) => withSignedUrls(body));
+
+      await percy.snapshot({
+        name: 'direct-upload-e2e',
+        url: 'http://localhost:8000',
+        domSnapshot: testDOM
+      });
+      await percy.idle();
+
+      // capability header reached percy-api on snapshot creation
+      expect(api.requests['/builds/123/snapshots'][0].headers['X-Percy-Capabilities'])
+        .toBe('direct-upload-v1');
+
+      // every declared resource carried content-md5 + content-length
+      const declared = api.requests['/builds/123/snapshots'][0].body.data.relationships.resources.data;
+      for (const entry of declared) {
+        expect(entry.attributes['content-md5']).toEqual(jasmine.any(String));
+        expect(entry.attributes['content-length']).toEqual(jasmine.any(Number));
+      }
+
+      // every missing resource PUT to GCS (one call per resource)
+      expect(gcsReply).toHaveBeenCalledTimes(declared.length);
+
+      // each PUT carried Content-MD5 and Content-Length
+      const puts = gcsReply.calls.allArgs().map(([req]) => req);
+      for (const put of puts) {
+        expect(put.method).toBe('PUT');
+        expect(put.headers['Content-MD5']).toEqual(jasmine.any(String));
+        expect(put.headers['Content-Length']).toEqual(jasmine.any(Number));
+      }
+
+      // when direct succeeds, legacy POST /resources path is NOT used
+      expect(api.requests['/builds/123/resources']).toBeUndefined();
+
+      // snapshot still finalizes
+      expect(api.requests['/snapshots/4567/finalize']).toBeDefined();
+    });
+
+    it('falls back to legacy POST /resources for any resource that fails the direct PUT (transport-class)', async () => {
+      api.reply('/builds/123/snapshots', ({ body }) => withSignedUrls(body));
+      gcsReply.and.callFake(() => [403, 'expired']);
+
+      await percy.snapshot({
+        name: 'fallback-e2e',
+        url: 'http://localhost:8000',
+        domSnapshot: testDOM
+      });
+      await percy.idle();
+
+      expect(gcsReply).toHaveBeenCalled();
+
+      const declared = api.requests['/builds/123/snapshots'][0].body.data.relationships.resources.data;
+      expect(api.requests['/builds/123/resources']).toBeDefined();
+      expect(api.requests['/builds/123/resources'].length).toBe(declared.length);
+
+      expect(api.requests['/snapshots/4567/finalize']).toBeDefined();
+    });
+
+    it('PERCY_DISABLE_DIRECT_UPLOAD forces every resource through legacy end-to-end', async () => {
+      process.env.PERCY_DISABLE_DIRECT_UPLOAD = '1';
+      api.reply('/builds/123/snapshots', ({ body }) => withSignedUrls(body));
+
+      try {
+        await percy.snapshot({
+          name: 'forced-legacy-e2e',
+          url: 'http://localhost:8000',
+          domSnapshot: testDOM
+        });
+        await percy.idle();
+
+        expect(api.requests['/builds/123/snapshots'][0].headers['X-Percy-Capabilities']).toBeUndefined();
+        expect(gcsReply).not.toHaveBeenCalled();
+
+        const declared = api.requests['/builds/123/snapshots'][0].body.data.relationships.resources.data;
+        expect(api.requests['/builds/123/resources'].length).toBe(declared.length);
+      } finally {
+        delete process.env.PERCY_DISABLE_DIRECT_UPLOAD;
+      }
+    });
+
+    it('Content-MD5 sent to GCS matches the declared md5 from snapshot creation (integrity end-to-end)', async () => {
+      gcsReply.and.callFake(() => [200]);
+      api.reply('/builds/123/snapshots', ({ body }) => withSignedUrls(body));
+
+      await percy.snapshot({
+        name: 'integrity-e2e',
+        url: 'http://localhost:8000',
+        domSnapshot: testDOM
+      });
+      await percy.idle();
+
+      // declared md5 keyed by sha (which is the resource id and also embedded
+      // in the signed-upload URL path)
+      const declared = api.requests['/builds/123/snapshots'][0].body.data.relationships.resources.data;
+      const md5BySha = Object.fromEntries(declared.map(e => [e.id, e.attributes['content-md5']]));
+
+      for (const [req] of gcsReply.calls.allArgs()) {
+        const m = req.path.match(/_(?<sha>[a-f0-9]{64})/);
+        expect(m).withContext(`PUT path missing sha: ${req.path}`).not.toBeNull();
+        expect(req.headers['Content-MD5']).toBe(md5BySha[m.groups.sha]);
+      }
     });
   });
 });

--- a/packages/core/test/utils.test.js
+++ b/packages/core/test/utils.test.js
@@ -1,4 +1,5 @@
-import { decodeAndEncodeURLWithLogging, waitForSelectorInsideBrowser, compareObjectTypes, isGzipped, checkSDKVersion, percyAutomateRequestHandler, detectFontMimeType, handleIncorrectFontMimeType, computeResponsiveWidths, appendUrlSearchParam, processCorsIframesInDomSnapshot, processCorsIframes } from '../src/utils.js';
+import { createLogResource, createPercyCSSResource, createResource, createRootResource, decodeAndEncodeURLWithLogging, waitForSelectorInsideBrowser, compareObjectTypes, isGzipped, checkSDKVersion, percyAutomateRequestHandler, detectFontMimeType, handleIncorrectFontMimeType, computeResponsiveWidths, appendUrlSearchParam, processCorsIframesInDomSnapshot, processCorsIframes } from '../src/utils.js';
+import { md5base64, sha256hash } from '@percy/client/utils';
 import { logger, setupTest, mockRequests } from './helpers/index.js';
 import percyLogger from '@percy/logger';
 import Percy from '@percy/core';
@@ -12,6 +13,59 @@ describe('utils', () => {
     process.env.PERCY_FORCE_PKG_VALUE = JSON.stringify({ name: '@percy/client', version: '1.0.0' });
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 150000;
     await logger.mock({ level: 'debug' });
+  });
+
+  describe('createResource', () => {
+    it('returns sha, md5, contentLength, mimetype, content, and url', () => {
+      const content = 'p { color: purple; }';
+      const r = createResource('https://example.com/a.css', content, 'text/css');
+      expect(r).toEqual({
+        url: 'https://example.com/a.css',
+        mimetype: 'text/css',
+        content,
+        sha: sha256hash(content),
+        md5: md5base64(content),
+        contentLength: Buffer.byteLength(content, 'utf-8')
+      });
+    });
+
+    it('preserves extra attrs and computes byte length over UTF-8', () => {
+      const content = 'café — résumé';
+      const r = createResource('https://example.com/x', content, 'text/plain', { root: true });
+      expect(r.root).toBeTrue();
+      expect(r.contentLength).toEqual(Buffer.byteLength(content, 'utf-8'));
+      expect(r.contentLength).not.toEqual(content.length); // sanity: multi-byte chars
+    });
+
+    it('handles Buffer content', () => {
+      const buf = Buffer.from([0x00, 0x01, 0x02, 0xff]);
+      const r = createResource('https://example.com/blob', buf, 'application/octet-stream');
+      expect(r.contentLength).toEqual(buf.length);
+      expect(r.md5).toEqual(md5base64(buf));
+      expect(r.sha).toEqual(sha256hash(buf));
+    });
+
+    it('propagates new fields through createRootResource', () => {
+      const html = '<html><body>hi</body></html>';
+      const r = createRootResource('https://example.com/', html);
+      expect(r.root).toBeTrue();
+      expect(r.md5).toEqual(md5base64(html));
+      expect(r.contentLength).toEqual(Buffer.byteLength(html, 'utf-8'));
+    });
+
+    it('propagates new fields through createPercyCSSResource', () => {
+      const css = 'body { color: red; }';
+      const r = createPercyCSSResource('https://example.com/page', css);
+      expect(r.md5).toEqual(md5base64(css));
+      expect(r.contentLength).toEqual(Buffer.byteLength(css, 'utf-8'));
+    });
+
+    it('propagates new fields through createLogResource', () => {
+      const r = createLogResource([{ level: 'info', message: 'hi' }]);
+      expect(r.log).toBeTrue();
+      expect(r.md5).toEqual(md5base64(r.content));
+      expect(r.contentLength).toEqual(Buffer.byteLength(r.content, 'utf-8'));
+    });
   });
 
   describe('percyAutomateRequestHandler', () => {


### PR DESCRIPTION
## What this changes

CLI side of [PPLT-5303 — GCS network cost reduction](https://browserstack.atlassian.net/browse/PPLT-5303). Implements the client end of the [Direct Bucket Upload tech spec](https://browserstack.atlassian.net/wiki/spaces/ENG/pages/6165168477/Tech+Spec+Direct+Bucket+Upload+for+Percy+Resources).

Today every Percy resource (HTML / CSS / JS / fonts / inline images) goes `CLI → base64 JSON → percy-api → GCS`. `percy-api` decodes, re-hashes, streams to GCS — pure byte brokerage on the hot path. This PR teaches the CLI to upload resources **directly** to GCS via a per-resource V4 signed URL minted by percy-api in the `missing-resources` response. Integrity is preserved at the GCS layer via `Content-MD5` + `Content-Length` baked into the signed URL.

**Rollout is Strategy A** (locked by review comment on the tech spec): per-org LD flag, legacy `POST /resources` path stays live indefinitely as the per-resource fallback. Nothing in this PR breaks any existing customer — old API ignores the new header and the CLI uses the legacy path; new API + new CLI start using the direct path once the LD flag is on for the org.

## Wire contract added

**CLI → API** on `POST /builds/:id/snapshots`:
- Request header: `X-Percy-Capabilities: direct-upload-v1`
- Each entry in `relationships.resources.data[].attributes` gains:
  - `content-md5` — base64-encoded MD5 of the resource bytes (RFC 1864)
  - `content-length` — byte count

**API → CLI** in the `missing-resources` response, each entry may now carry:
- `signed-upload-url` — V4-signed PUT URL
- `signed-upload-expires` — ISO 8601 expiry timestamp

**CLI → GCS** when a signed URL is returned:
```
PUT <signed-upload-url>
Content-MD5:    <same base64 we declared>
Content-Length: <same length we declared>
Content-Type:   <resource mimetype>
Body:           <raw bytes — not base64, not JSON>
```

## Failure handling

Per-resource decision, not per-build:
- **Transport-class** (network errors, 5xx after retries, 403 expired, 429) → resource falls back to the legacy `POST /resources` path silently. Build still succeeds.
- **Correctness-class** (`400 BadDigest`, `412 Precondition Failed`) → thrown. These indicate a real bug (wrong md5/length declared, or single-use URL replayed). Falling back here would mask the regression; fail-loud surfaces it.

## Customer escape hatch

`PERCY_DISABLE_DIRECT_UPLOAD=1` suppresses the capability header and forces every resource through the legacy path. Lets a latency-sensitive customer self-serve back to the old behavior without waiting on an LD flag flip. **Strict parsing** — only `"1"` or `"true"` (case-insensitive) count as enabled; `"0"`/`"false"` do NOT silently enable like a naive `!!process.env.X` would.

## Commits (6, in a clean bottom-up order)

| # | SHA | What |
|---|---|---|
| 1 | b09794ad | `createResource` attaches `md5` + `contentLength` to every resource (incl. PERCY_GZIP lockstep) |
| 2 | ebaeeb7a | `request()` accepts `rawBody: true` to send raw `Buffer` bodies |
| 3 | c36c5383 | `createSnapshot` sends capability header + new attrs |
| 4 | 3fc46086 | `uploadResourceDirect` / `uploadResourcesDirect` primitives + failure classification |
| 5 | 821c402b | `sendSnapshot` partitions missing-resources between direct + legacy + strict env parsing |
| 6 | 861047ba | End-to-end integration test in `@percy/core` |

## Compatibility

| Scenario | Result |
|---|---|
| New CLI + new API, LD flag on | Direct upload happens |
| New CLI + new API, LD flag off | API returns no signed URLs → CLI uses legacy. Transparent. |
| New CLI + old API | API ignores header, returns no signed URLs → CLI uses legacy. Transparent. |
| Old CLI + new API | No capability header → API doesn't mint URLs → legacy. Transparent. |
| New CLI + `PERCY_DISABLE_DIRECT_UPLOAD=1` | Capability header suppressed → API treats as old CLI → legacy. |
| New CLI + GCS unreachable for customer | Each PUT fails transport-class → falls back per-resource. Build succeeds. |

## What's intentionally NOT in this PR

- **`createBuild` parity** for declared resources. The static-image `upload` command uses `createBuild` declared resources, and symmetry suggests it should also carry `content-md5`/`content-length`. Held back until the percy-api side confirms it accepts those attrs on `POST /builds` — gated on **O1** in the plan. Easy follow-up commit once confirmed.
- **Docs.** `PERCY_DISABLE_DIRECT_UPLOAD` doesn't appear in any README yet. Punted to a follow-up PR so the doc can describe the end-to-end behavior with the API side landed.

## Open items (need API-side confirmation, not coding-blockers)

- **O1** — `POST /builds` accepts `content-md5` + `content-length` on declared resources (re-enables `createBuild` parity).
- **O2** — Wire-attr naming: kebab-case (`content-md5`, `content-length`) as used here, or camelCase? Will mirror whatever the API side ships.
- **O3** — Capability string: `direct-upload-v1` is the working name. Confirm with API.

## Test plan

- [x] Unit tests: `md5base64` (3), `createResource` & factories (6), `request() rawBody` (3), `createSnapshot` header + attrs (3 + 2 strict-parsing), `uploadResourceDirect` / `uploadResourcesDirect` (11), `sendSnapshot` partition + fallback (5)
- [x] End-to-end in `@percy/core` with mocked GCS endpoint: happy path, transport failure → fallback, `PERCY_DISABLE_DIRECT_UPLOAD` forces legacy, Content-MD5 integrity matches declared md5 (4 tests)
- [x] Existing regressions: full `@percy/client` suite (283/283 minus 1 pre-existing PAC proxy flake); existing `createSnapshot` / `sendSnapshot` tests updated to assert the new attrs; legacy `POST /resources` path still exercised by every test that doesn't return signed URLs.
- [ ] Staging end-to-end against real percy-api once the matching API PR lands (cross-repo, tracked separately).
- [ ] Manual smoke on a real production build with `PERCY_DISABLE_DIRECT_UPLOAD=1` to confirm legacy still works for customers on the escape hatch.

## Plan doc

Full implementation plan (both CLI and API sides, plus rollout/observability/rollback) is at `docs/plans/2026-05-11-003-pplt5303-direct-bucket-upload-cli.md`. That doc is gitignored — local reference only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)