### PR TITLE
PER-7129: Fix the cssom serialization bug of not accounting for inherit:all css rule 

### DIFF
--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -24,7 +24,16 @@ function styleSheetsMatch(sheetA, sheetB) {
   const lenA = sheetA.cssRules.length;
   const lenB = sheetB.cssRules.length;
 
-  if (lenA !== lenB) return false;
+  // Only treat as mismatch when the live sheet has MORE rules than the
+  // clone — that signals rules were added via CSSOM (insertRule/adopted)
+  // and must be re-serialized. When lenA <= lenB, the clone already
+  // contains all of the live rules (often duplicated by clone-dom's
+  // <style> textContent handling); trust the clone's source text so that
+  // CSS shorthand semantics (e.g. `all: initial; border-radius: var(...)`)
+  // survive — `cssRule.cssText` expansion appends logical longhands like
+  // `border-end-end-radius: initial` AFTER the shorthand, which silently
+  // overrides it and breaks the cascade.
+  if (lenA > lenB) return false;
 
   for (let i = 0; i < lenA; i++) {
     const ruleA = sheetA.cssRules[i] && sheetA.cssRules[i].cssText;

--- a/packages/dom/test/serialize-css.test.js
+++ b/packages/dom/test/serialize-css.test.js
@@ -460,4 +460,94 @@ describe('serializeCSSOM', () => {
       expect(found).toBe(false);
     });
   });
+
+  describe('regression: cloned <style> text-node duplication', () => {
+    // serializeCSSOM decides whether to re-serialize each in-memory CSSOM
+    // stylesheet via styleSheetsMatch(liveSheet, cloneSheet). Cloned <style>
+    // elements in real snapshots can end up with the original text node
+    // appended twice (clone-dom assigns clone.textContent = ... and the
+    // subsequent generic walkTree re-clones the original text node). The
+    // parsed cloneSheet then has 2x the rules of liveSheet.
+    //
+    // Strict length equality (`lenA !== lenB`) treats that as a mismatch
+    // and forces re-serialization via Array.from(liveSheet.cssRules).map(
+    // r => r.cssText), which is NOT semantically identity-preserving:
+    // Chromium expands `all: initial` into hundreds of longhands and
+    // emits logical-property longhands (border-end-end-radius: initial,
+    // ...) AFTER the shorthand it sat next to in source, silently
+    // overriding `border-radius: var(--x)` with 0.
+    //
+    // styleSheetsMatch must therefore tolerate lenB > lenA when every
+    // live rule still appears in the clone (re-serialization is only
+    // required when the live sheet has rules the clone is missing).
+
+    it('skips re-serialization when clone <style> text duplicates the live rules — preserves `all: initial; border-radius: var(--x)` semantics', () => {
+      withExample('<div class="box"></div>', { withShadow: false });
+      withCSSOM('.box { all: initial; border-radius: var(--x); }', undefined, { withShadow: false });
+
+      const liveStyle = document.getElementById('test-style');
+      liveStyle.setAttribute('data-percy-element-id', 'dup-regression');
+      const liveRuleText = liveStyle.sheet.cssRules[0].cssText;
+
+      const clone = document.createDocumentFragment();
+      const cloneOwner = document.createElement('style');
+      cloneOwner.setAttribute('data-percy-element-id', 'dup-regression');
+      // Duplicate the source rule — what clone-dom currently produces.
+      // styleSheetFromNode will parse this into a sheet with 2 rules,
+      // while the live sheet has 1.
+      cloneOwner.textContent = liveRuleText + '\n' + liveRuleText;
+      clone.appendChild(cloneOwner);
+
+      serializeCSSOM({
+        dom: document,
+        clone,
+        resources: new Set(),
+        cache: new Map(),
+        warnings: new Set()
+      });
+
+      // Re-serialization would have removed cloneOwner and inserted a new
+      // <style data-percy-cssom-serialized="true"> in its place. With the
+      // correct match logic, cloneOwner stays put with its source text
+      // intact, so the cascade-correct shorthand survives the snapshot.
+      expect(cloneOwner.parentNode).toBe(clone);
+      expect(cloneOwner.textContent).toBe(liveRuleText + '\n' + liveRuleText);
+      expect(clone.querySelector('[data-percy-cssom-serialized]')).toBeNull();
+    });
+
+    it('still re-serializes when live sheet has rules the clone is missing (CSSOM insertRule case)', () => {
+      // Sanity-check the other direction: when live has MORE rules than
+      // clone (e.g. a rule was added via sheet.insertRule at runtime),
+      // re-serialization must still run so the snapshot captures it.
+      withExample('<div class="box"></div>', { withShadow: false });
+      withCSSOM(
+        ['.live-only { color: red; }', '.box { width: 10px; }'],
+        undefined,
+        { withShadow: false }
+      );
+
+      const liveStyle = document.getElementById('test-style');
+      liveStyle.setAttribute('data-percy-element-id', 'insert-rule-case');
+
+      const clone = document.createDocumentFragment();
+      const cloneOwner = document.createElement('style');
+      cloneOwner.setAttribute('data-percy-element-id', 'insert-rule-case');
+      // Clone only has one of the two live rules — the second was added
+      // via CSSOM (insertRule) after the <style> was authored.
+      cloneOwner.textContent = '.box { width: 10px; }';
+      clone.appendChild(cloneOwner);
+
+      serializeCSSOM({
+        dom: document,
+        clone,
+        resources: new Set(),
+        cache: new Map(),
+        warnings: new Set()
+      });
+
+      const reserialized = clone.querySelector('[data-percy-cssom-serialized]');
+      expect(reserialized).not.toBeNull();
+      expect(reserialized.textContent).toContain('.live-only');
+    });
+  });
 });


### PR DESCRIPTION
# Summary
Jira: [PER-7129](https://browserstack.atlassian.net/browse/PER-7129)
Restore styleSheetsMatch's tolerance for cloned <style> sheets that contain a superset of the live sheet's rules. Without this, serializeCSSOM over-eagerly rewrites the clone using cssRule.cssText, whose expansion of CSS shorthands (most visibly all: initial) silently breaks the cascade. 

Visible to consumers using shadow-DOM components whose part styles rely on shorthand semantics (e.g. `::part(body) { all: initial; border-radius: var(--token);`.

# The bug

serializeCSSOM decides per-stylesheet whether to keep the cloned <style>'s text verbatim or rewrite it from the live CSSOM:

```
  if (styleSheetsMatch(styleSheet, styleSheetFromNode(cloneOwnerNode))) continue;
  // otherwise: replace clone with Array.from(liveSheet.cssRules)
  //                              .map(r => r.cssText).join('\n')
```

  PR #1975 changed the comparison from "every live rule matches a clone rule at the same index" to strict length equality:

```
  - for (let i = 0; i < sheetA.cssRules.length; i++) { … }
  - return true;
  + if (lenA !== lenB) return false;
  + for (let i = 0; i < lenA; i++) { … }
  + return true;
```

That looks reasonable in isolation, but lenB > lenA is routine in this code path because of a longstanding clone-dom artifact:

  1. clone-dom.js's <style> handler runs clone.textContent = node.textContent, attaching one text-node child with the source CSS.
  2. The generic walkTree(node.firstChild, clone) immediately afterwards iterates the original element's children and re-clones them onto the same clone. For a <style>, the only child is a text node — so
  the same CSS text gets appended a second time.
  3. styleSheetFromNode parses the clone's now-doubled textContent and returns a CSSStyleSheet with 2 × liveSheet.cssRules.length.

  The strict equality check therefore reports a mismatch for every duplicated <style> and forces the rewrite branch. The rewrite uses cssRule.cssText, which is not semantically identity-preserving for
  shorthands. Chromium's serialization of

  .x { all: initial; border-radius: var(--token); }
  
  expands all: initial into hundreds of explicit longhands and emits the four logical-corner radii (border-end-end-radius: initial; border-end-start-radius: initial; border-start-end-radius: initial; 
  border-start-start-radius: initial;) after border-radius: var(--token);. In the cascade, those longhands win, zeroing each corner. The shorthand effectively disappears.

  Snapshot HTML still contains --token, var(--token), and the border-radius declaration — grep for them succeeds — but the rendered border radius is 0.


# Root cause
  
The combination of:

  - a clone-dom artifact that doubles the text content of <style> clones,
  - a styleSheetsMatch predicate that demands strict length equality to skip re-serialization,
  - cssRule.cssText's lossy expansion of all: initial, which interleaves logical-property longhands after the shorthand they sat next to in source.

  Any one of the three on its own is innocuous; the three together produce the regression.

# Steps to reproduce 
Just snapshot this 
```
<!doctype html>
<meta charset="utf-8">
<title>percy cssText regression repro</title>
<style>
  .box {
    all: initial;
    display: block;
    width: 200px;
    height: 200px;
    margin: 40px;
    background: tomato;
    border-radius: 100px;
  }
</style>
<div class="box"></div>
```

# The fix
  
  packages/dom/src/serialize-cssom.js:

  - if (lenA !== lenB) return false;
  + // Only mismatch when the live sheet has MORE rules than the clone —
  + // that signals rules were added via CSSOM (insertRule/adopted) and
  + // must be re-serialized. lenA <= lenB is the common shape after
  + // clone-dom's <style> text duplication; the live rules are still
  + // covered by the clone, so trust the clone's source text and skip
  + // the lossy cssText rewrite.
  + if (lenA > lenB) return false;

  This keeps the genuine improvement from #1975 (detect runtime-inserted rules in the live sheet and re-serialize) while restoring v1.31.2's tolerance for lenB > lenA. No other file changes are required.

  The clone-dom duplication is the deeper structural issue and worth a separate fix, but is out of scope here — the one-line styleSheetsMatch adjustment is sufficient to unblock the regression with no other observable behavior change.


[PER-7129]: https://browserstack.atlassian.net/browse/PER-7129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ