### PR TITLE
PER-8439: Read archiveDir from config.percy.archiveDir in Percy core

### DIFF
--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -99,6 +99,7 @@ export class Percy {
 
     labels ??= config.percy?.labels;
     deferUploads ??= config.percy?.deferUploads;
+    archiveDir ??= config.percy?.archiveDir;
     if (archiveDir) skipUploads = skipUploads != null ? skipUploads : true;
     this.config = config;
     this.cliStartTime = null;

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -2453,6 +2453,19 @@ describe('Percy', () => {
       expect(percy.skipUploads).toBe(false);
     });
 
+    it('pulls archiveDir from percy config when not passed at the top level', () => {
+      // Mirrors how `percy exec --archive-dir` reaches Percy: the flag has
+      // `percyrc: 'percy.archiveDir'`, so the value arrives nested under
+      // `percy.archiveDir` rather than as a top-level constructor option.
+      percy = new Percy({
+        token: 'PERCY_TOKEN',
+        percy: { archiveDir: './percy-archive' }
+      });
+
+      expect(percy.archiveDir).toMatch(/[\\/]percy-archive$/);
+      expect(percy.skipUploads).toBe(true);
+    });
+
     it('logs the archive summary when stopping with snapshots', async () => {
       percy = new Percy({
         token: 'PERCY_TOKEN',


### PR DESCRIPTION
## Summary

- Adds the missing `archiveDir ??= config.percy?.archiveDir` fallback in the `Percy` core constructor so the `--archive-dir` CLI flag (which is declared with `percyrc: 'percy.archiveDir'`) and the equivalent `.percy.yml` entry actually take effect.
- Includes a regression test that constructs `Percy` with the nested `{ percy: { archiveDir } }` shape the CLI flag produces — the exact shape that was silently dropped before this change.

## Root cause

`packages/core/src/percy.js` already pulled `labels` and `deferUploads` from `config.percy?.*`, but `archiveDir` had no such fallback. Because the `--archive-dir` flag in `packages/cli-exec/src/exec.js` is declared with `percyrc: 'percy.archiveDir'`, the value arrives as `config.percy.archiveDir`, never as a top-level constructor option. As a result:

- `this.archiveDir` was always `null` when the value came from the CLI flag or a `.percy.yml` entry.
- `percy exec --archive-dir ./percy-archive -- yarn test` produced **no archive** and **no logs** about archiving.
- `percy replay ./percy-archive` later failed with *"Archive directory not found"*.

Existing unit tests only exercised the top-level constructor path (`new Percy({ archiveDir })`), so they kept passing and masked the bug.

## Change

```diff
 labels ??= config.percy?.labels;
 deferUploads ??= config.percy?.deferUploads;
+archiveDir ??= config.percy?.archiveDir;
 if (archiveDir) skipUploads = skipUploads != null ? skipUploads : true;
```

One line in `packages/core/src/percy.js`, mirroring the `deferUploads` pattern directly above it.

## Test plan

- [x] New unit test in `packages/core/test/percy.test.js` (`archive flow > pulls archiveDir from percy config when not passed at the top level`) — passes with the fix; fails without it.
- [x] Full `archive flow` suite still passes (5/5).
- [x] End-to-end with `percy snapshot snapshots.yml` and `.percy.yml` containing `percy.archiveDir: ./percy-archive` writes a snapshot JSON file to disk and logs `Archiving snapshots to: …` / `Archived 1 snapshot(s) to: …`.
- [x] `percy replay ./percy-archive` can read the archived snapshot back.

## Jira

- [PER-8439](https://browserstack.atlassian.net/browse/PER-8439)
- Previous related ticket: [PER-7714](https://browserstack.atlassian.net/browse/PER-7714)

[PER-8439]: https://browserstack.atlassian.net/browse/PER-8439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ