### PR TITLE
fix(sdk-utils): readiness gate no-ops on page.evaluate SDKs — illegal top-level return (PER-7348)

### DIFF
--- a/packages/sdk-utils/src/serialize-dom.js
+++ b/packages/sdk-utils/src/serialize-dom.js
@@ -66,11 +66,14 @@ export function waitForReadyScript(readinessConfig = {}, { callback = false } = 
     `;
   }
 
-  // For page.evaluate (auto-await Promises)
+  // For page.evaluate (auto-awaits the returned Promise). This MUST be a single
+  // expression: page.evaluate(string) evaluates the string as a script, where a
+  // top-level `return` is a SyntaxError ("Illegal return statement"). A ternary
+  // expression yields the waitForReady Promise (auto-awaited) or undefined.
   return `
-    if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
-      return PercyDOM.waitForReady(${config});
-    }
+    (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function')
+      ? PercyDOM.waitForReady(${config})
+      : undefined
   `;
 }
 

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -739,10 +739,14 @@ describe('SDK Utils', () => {
       expect(script).toContain('} catch(e) { done(); }');
     });
 
-    it('default variant returns the waitForReady result', () => {
+    it('default variant returns the waitForReady result as a bare expression', () => {
       let script = waitForReadyScript({ preset: 'strict' });
-      expect(script).toContain('return PercyDOM.waitForReady');
+      expect(script).toContain('? PercyDOM.waitForReady');
       expect(script).not.toContain('arguments[arguments.length - 1]');
+      // Regression (PER-7348): a top-level `return` is an "Illegal return
+      // statement" when run via page.evaluate(string). The non-callback variant
+      // must be an expression, never a statement with a leading `return`.
+      expect(script).not.toContain('return PercyDOM.waitForReady');
     });
 
     it('escapes U+2028 and U+2029 in interpolated config so older engines can parse the source', () => {
@@ -892,7 +896,8 @@ describe('SDK Utils', () => {
         (script) => { captured = script; return null; },
         {}
       );
-      expect(captured).toContain('return PercyDOM.waitForReady');
+      expect(captured).toContain('? PercyDOM.waitForReady');
+      expect(captured).not.toContain('return PercyDOM.waitForReady');
       expect(captured).not.toContain('arguments[arguments.length - 1]');
     });
 


### PR DESCRIPTION
## Bug

The non-callback branch of `waitForReadyScript` (`packages/sdk-utils/src/serialize-dom.js`) emitted a **top-level `return`**:

```js
return `
  if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
    return PercyDOM.waitForReady(${config});   // ← illegal at top level
  }`;
```

SDKs that inject this via **`page.evaluate(string)`** (Puppeteer, Playwright) run the string as a *script*, where a top-level `return` is a `SyntaxError: Illegal return statement`. `runReadinessGate` catches it and returns `null`, so **the readiness gate silently no-ops** — no waiting, no `readiness_diagnostics`.

The `executeAsyncScript`/callback branch (Selenium-js, WebdriverIO, Nightwatch, Capybara) uses `var done = arguments[...]` with no top-level return and is **unaffected**.

## Impact

- `@percy/puppeteer` **(published `2.0.3-beta.0`)** — readiness gate broken
- `@percy/playwright` (PER-7348 just merged) — same path, would ship broken

## Fix

Emit a bare **ternary expression** (no leading `return`); `page.evaluate` auto-awaits the returned Promise.

```js
return `
  (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function')
    ? PercyDOM.waitForReady(${config})
    : undefined`;
```

## Verification

Patched the installed `@percy/sdk-utils` and re-ran the puppeteer validation harness:
- `Illegal return statement` — **gone**
- Gate now waits: `disabled` 435ms vs `default` 3264ms / `strict` 2539ms
- Full diagnostics returned: `passed:true`, all checks present (`dom_stability` 1400ms/22 mutations, `image_ready` 808ms, `network_idle` 208ms, `js_idle` 366ms, `font_ready` 0ms)

Tests updated to assert the expression form and guard against the top-level-return regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)