### PR TITLE
feat(core): explicit runtime field gates maestro-screenshot self-hosted detection (R2)

### DIFF
--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -422,13 +422,34 @@ export function createPercyServer(percy, port) {
   // post a comparison by reading a Maestro screenshot from disk
     .route('post', '/percy/maestro-screenshot', async (req, res) => {
       /* istanbul ignore next — req.body falsy guard; tests always pass a body. */
-      let { name, sessionId } = req.body || {};
+      let { name, sessionId, runtime } = req.body || {};
 
       if (!name) throw new ServerError(400, 'Missing required field: name');
-      // `sessionId` is host-injected on BrowserStack; its absence signals
-      // self-hosted mode (gated separately on PERCY_MAESTRO_SCREENSHOT_DIR
-      // below). When present, the BS path runs byte-identical.
-      let selfHosted = !sessionId;
+
+      // Validate `runtime` if present: must be a string, but unknown values
+      // are NOT rejected — we treat anything other than "selfhosted" /
+      // "browserstack" as "fall back to sessionId-absent detection". This
+      // is defensive against future runtime values (maestro-cloud,
+      // saucelabs, etc.) the SDK might introduce ahead of relay support.
+      if (runtime !== undefined && typeof runtime !== 'string') {
+        throw new ServerError(400, 'Invalid runtime: must be a string');
+      }
+
+      // Self-hosted detection — prefer the SDK's explicit declaration when
+      // present, fall back to sessionId absence (the implicit signal used
+      // by SDKs that predate the runtime field). The fallback is what
+      // ships in cli#2261 today; the explicit runtime field arrives with
+      // @percy/maestro-app >= v1.0.0-Beta.1 (cf. percy-maestro-app#7+R2).
+      let selfHosted = (runtime === 'selfhosted') || (!runtime && !sessionId);
+
+      // Diagnostic surface for any inconsistency between the two signals
+      // (debug-only — never breaks the request).
+      if (runtime === 'browserstack' && !sessionId) {
+        percy.log.debug('maestro-screenshot: runtime=browserstack but sessionId missing — trusting runtime field');
+      }
+      if (runtime === 'selfhosted' && sessionId) {
+        percy.log.debug('maestro-screenshot: runtime=selfhosted but sessionId present — trusting runtime field');
+      }
 
       // Strict character-class validation — rejects path separators, shell metacharacters,
       // NUL, newlines, and anything else that could confuse the glob or the filesystem.

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -1255,6 +1255,103 @@ describe('API Server', () => {
         .toBeRejectedWithError(/Invalid platform: must be a string/);
     });
 
+    describe('runtime field gating', () => {
+      // The relay's self-hosted detection prefers an explicit `runtime` field
+      // from the SDK when present, falling back to sessionId-absence for older
+      // SDKs. These tests cover the eight-way matrix of (runtime ∈
+      // {undefined, "selfhosted", "browserstack", "unknown"}) × (sessionId ∈
+      // {present, absent}) — plus the type-validation 400.
+
+      it('rejects non-string runtime type with 400', async () => {
+        await percy.start();
+        await expectAsync(postMaestro({ name: SS_NAME, sessionId: SID, runtime: 123 }))
+          .toBeRejectedWithError(/Invalid runtime: must be a string/);
+      });
+
+      it('runtime=selfhosted + no sessionId → self-hosted branch (400s on missing env)', async () => {
+        let prior = process.env.PERCY_MAESTRO_SCREENSHOT_DIR;
+        delete process.env.PERCY_MAESTRO_SCREENSHOT_DIR;
+        try {
+          await percy.start();
+          await expectAsync(postMaestro({ name: SS_NAME, runtime: 'selfhosted' }))
+            .toBeRejectedWithError(/Missing required env: PERCY_MAESTRO_SCREENSHOT_DIR/);
+        } finally {
+          if (prior === undefined) delete process.env.PERCY_MAESTRO_SCREENSHOT_DIR;
+          else process.env.PERCY_MAESTRO_SCREENSHOT_DIR = prior;
+        }
+      });
+
+      it('runtime=selfhosted + sessionId PRESENT → still self-hosted branch (trust runtime field)', async () => {
+        // Bidirectional-consistency case: SDK explicitly says self-hosted but
+        // a sessionId leaked into the payload. Trust the SDK's declaration.
+        let prior = process.env.PERCY_MAESTRO_SCREENSHOT_DIR;
+        delete process.env.PERCY_MAESTRO_SCREENSHOT_DIR;
+        try {
+          await percy.start();
+          await expectAsync(postMaestro({ name: SS_NAME, sessionId: SID, runtime: 'selfhosted' }))
+            .toBeRejectedWithError(/Missing required env: PERCY_MAESTRO_SCREENSHOT_DIR/);
+        } finally {
+          if (prior === undefined) delete process.env.PERCY_MAESTRO_SCREENSHOT_DIR;
+          else process.env.PERCY_MAESTRO_SCREENSHOT_DIR = prior;
+        }
+      });
+
+      it('runtime=browserstack + sessionId present → BS branch finds file under /tmp/<sid>/...', async () => {
+        await percy.start();
+        const res = await postMaestro({ name: SS_NAME, sessionId: SID, runtime: 'browserstack' });
+        expect(res.status).toBe(200);
+      });
+
+      it('runtime=browserstack + sessionId ABSENT → BS branch (trust runtime), but file-find fails → 404', async () => {
+        // Bidirectional-consistency case: SDK explicitly says browserstack
+        // but sessionId is missing. BS branch runs, can't locate the file
+        // because `/tmp/<undefined>/...` doesn't resolve.
+        await percy.start();
+        await expectAsync(postMaestro({ name: SS_NAME, runtime: 'browserstack' }))
+          .toBeRejectedWithError(/Screenshot not found|sessionId/i);
+      });
+
+      it('runtime=unknown-value + no sessionId → falls back to sessionId-absent → self-hosted branch', async () => {
+        // Defensive: unknown runtime values are NOT rejected. The relay falls
+        // back to sessionId-absence detection, so this lands in self-hosted.
+        let prior = process.env.PERCY_MAESTRO_SCREENSHOT_DIR;
+        delete process.env.PERCY_MAESTRO_SCREENSHOT_DIR;
+        try {
+          await percy.start();
+          await expectAsync(postMaestro({ name: SS_NAME, runtime: 'maestro-cloud' }))
+            .toBeRejectedWithError(/Missing required env: PERCY_MAESTRO_SCREENSHOT_DIR/);
+        } finally {
+          if (prior === undefined) delete process.env.PERCY_MAESTRO_SCREENSHOT_DIR;
+          else process.env.PERCY_MAESTRO_SCREENSHOT_DIR = prior;
+        }
+      });
+
+      it('runtime=unknown-value + sessionId present → falls back to sessionId-present → BS branch', async () => {
+        await percy.start();
+        const res = await postMaestro({ name: SS_NAME, sessionId: SID, runtime: 'maestro-cloud' });
+        expect(res.status).toBe(200);
+      });
+
+      it('no runtime + sessionId present → BS branch (backward-compat with pre-runtime SDKs)', async () => {
+        await percy.start();
+        const res = await postMaestro({ name: SS_NAME, sessionId: SID });
+        expect(res.status).toBe(200);
+      });
+
+      it('no runtime + no sessionId → self-hosted branch (backward-compat with pre-runtime SDKs)', async () => {
+        let prior = process.env.PERCY_MAESTRO_SCREENSHOT_DIR;
+        delete process.env.PERCY_MAESTRO_SCREENSHOT_DIR;
+        try {
+          await percy.start();
+          await expectAsync(postMaestro({ name: SS_NAME }))
+            .toBeRejectedWithError(/Missing required env: PERCY_MAESTRO_SCREENSHOT_DIR/);
+        } finally {
+          if (prior === undefined) delete process.env.PERCY_MAESTRO_SCREENSHOT_DIR;
+          else process.env.PERCY_MAESTRO_SCREENSHOT_DIR = prior;
+        }
+      });
+    });
+
     it('rejects non-object element selector with 400', async () => {
       await percy.start();
       await expectAsync(postMaestro({


### PR DESCRIPTION
## Summary

Stacks on [#2261](https://github.com/percy/cli/pull/2261). Promotes the self-hosted-vs-BrowserStack discriminator in the `/percy/maestro-screenshot` relay handler from an implicit signal (`sessionId` absence, introduced by #2261) to an explicit one — `runtime: "selfhosted" | "browserstack"` in the SDK payload. The `sessionId`-absent fallback stays for backward compatibility with SDKs that predate the runtime field.

Companion SDK change ships the field in a future `@percy/maestro-app` release (tracked under `percy-maestro/docs/plans/2026-06-02-001-feat-explicit-runtime-field-plan.md` Unit 1, blocked behind `percy-maestro-app#7`). The relay works correctly today with older SDKs via the backward-compat fallback.

## Why now

cli#2261's relay handler infers the runtime from a field's *absence*:

```js
let { name, sessionId } = req.body || {};
let selfHosted = !sessionId;
```

This works today (R7 verified on BS canary builds #22 and #23). The brittleness: if BS ever omits `sessionId` in a future code path — a new session type, a retry that doesn't re-inject — the self-hosted branch activates accidentally → wrong file-find scope → 404. Moving the declaration to the SDK (where the knowledge originates — the SDK knows whether `PERCY_SESSION_ID` was injected) eliminates that future-proofing risk.

The field is also semantically clearer for code review: today `sessionId` in this handler means "BS App Automate session" but in sibling Appium SDKs it means "Appium driver session UUID" (which exists in both runtimes). Adding `runtime` makes the wire contract self-documenting.

## What changes

`packages/core/src/api.js`:

```js
let { name, sessionId, runtime } = req.body || {};

// Type validation — but unknown values are NOT rejected (fall back to sessionId).
if (runtime !== undefined && typeof runtime !== 'string') {
  throw new ServerError(400, 'Invalid runtime: must be a string');
}

// Prefer explicit declaration; fall back to sessionId-absent for older SDKs.
let selfHosted = (runtime === 'selfhosted') || (!runtime && !sessionId);

// Diagnostic surface for inconsistencies (debug-only, never breaks the request).
if (runtime === 'browserstack' && !sessionId) {
  percy.log.debug('maestro-screenshot: runtime=browserstack but sessionId missing — trusting runtime field');
}
if (runtime === 'selfhosted' && sessionId) {
  percy.log.debug('maestro-screenshot: runtime=selfhosted but sessionId present — trusting runtime field');
}
```

The `selfHosted` boolean propagates through the existing handler logic unchanged — only its source-of-truth shifts from implicit to explicit.

## Testing

9 new scenarios under a new `describe('runtime field gating')` block. Covers the 8-way matrix of `(runtime ∈ {undefined, "selfhosted", "browserstack", "unknown-value"}) × (sessionId ∈ {present, absent})` plus the type-validation 400. Pre-existing `/percy/maestro-screenshot` tests are unchanged.

| `runtime` | `sessionId` | Expected branch | Verification |
|---|---|---|---|
| `"selfhosted"` | absent | self-hosted | 400 `Missing required env: PERCY_MAESTRO_SCREENSHOT_DIR` |
| `"selfhosted"` | **present** | self-hosted (trust runtime) | 400 same (with debug log) |
| `"browserstack"` | present | BS | 200 success |
| `"browserstack"` | **absent** | BS (trust runtime) | 404 (debug log fires) |
| `"unknown-value"` | absent | falls back to self-hosted | 400 same |
| `"unknown-value"` | present | falls back to BS | 200 success |
| missing | present | BS (back-compat) | 200 success |
| missing | absent | self-hosted (back-compat) | 400 same |
| non-string | — | reject early | 400 `Invalid runtime: must be a string` |

R7 (BS regression) preserved — the explicit `runtime: "browserstack"` + `sessionId` path runs byte-identically to today's `sessionId`-only path.

## Origin

- Brainstorm: `percy-maestro/docs/brainstorms/2026-06-02-selfhosted-followup-bundle-requirements.md` (R2)
- Plan: `percy-maestro/docs/plans/2026-06-02-001-feat-explicit-runtime-field-plan.md` (Unit 2)

## Stacking

- **Base:** `feat/self-hosted-maestro-percy-v1` (cli#2261). Rebase to `master` once #2261 merges.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - The two new `percy.log.debug` lines — they appear when SDK declarations and `sessionId` presence disagree. Non-zero rate in production would indicate a customer misconfiguration or an upstream BS bug.
  - `[BROWSERSTACK_TESTSUITE_PARSE_ERROR]` or `Screenshot not found` rate post-deploy. Should be unchanged.
- **Validation checks**
  - BS canary regression on both Android (`183.177.55.134`) and iOS (`103.234.68.130`) Maestro v2 hosts. Expected: snapshots produce identically pre/post deploy.
  - Self-hosted Pixel + iPhone simulator quickstart from the example repo. Expected: unchanged behavior (SDK ships no `runtime` field yet; relay falls back to `sessionId`-absent path).
- **Expected healthy signals**
  - Zero new `[percy] Screenshot not found` errors on BS or self-hosted builds compared to baseline.
  - Debug log lines remain quiet in production (no SDK is sending the new field yet).
- **Failure signal / rollback trigger**
  - Any BS App Automate Maestro build that previously passed reports `Snapshot command was not called` post-deploy → revert immediately (back-compat path broken).
  - Self-hosted runs that previously worked now 404 → revert (sessionId-absent fallback broken).
- **Validation window & owner**
  - Window: 7 days post-merge. Owner: Arumulla Sri Ram (arumulla@browserstack.com) + the Percy team.

🤖 Generated with Claude Opus 4.7 via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.54.0