### PR TITLE
feat(webdriver-utils): env-var overrides for staging/percy-dev testing

### DIFF
--- a/packages/webdriver-utils/src/playwrightDriver.js
+++ b/packages/webdriver-utils/src/playwrightDriver.js
@@ -27,7 +27,8 @@ export default class PlaywrightDriver {
       command.script = `/* percy_automate_script */ \n ${command.script}`;
     }
     const options = this.requestPostOptions(command);
-    const baseUrl = `https://cdp.browserstack.com/wd/hub/session/${this.sessionId}/execute`;
+    const cdpDomain = process.env.PERCY_CDP_DOMAIN || 'cdp.browserstack.com';
+    const baseUrl = `https://${cdpDomain}/wd/hub/session/${this.sessionId}/execute`;
     const response = JSON.parse((await request(baseUrl, options)).body);
     return response;
   }

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -106,9 +106,10 @@ export default class AutomateProvider extends GenericProvider {
 
   async setDebugUrl() {
     if (!this.driver) throw new Error('Driver is null, please initialize driver with createDriver().');
+    const automateDomain = process.env.PERCY_AUTOMATE_DOMAIN || 'automate.browserstack.com';
     this.debugUrl = await Cache.withCache(Cache.bstackSessionDetails, this.driver.sessionId,
       async () => {
-        return `https://automate.browserstack.com/builds/${this.automateResults.buildHash}/sessions/${this.automateResults.sessionHash}`;
+        return `https://${automateDomain}/builds/${this.automateResults.buildHash}/sessions/${this.automateResults.sessionHash}`;
       });
   }
 

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -96,10 +96,6 @@ export default class GenericProvider {
 
   async browserstackExecutor(action, args) {
     if (!this.driver) throw new Error('Driver is null, please initialize driver with createDriver().');
-    // Staging/local override: when PERCY_ENABLE_DEV=true, route percyScreenshot
-    // payloads to the percy-dev project. Defaults to no projectId field (prod) so
-    // customer payloads are byte-identical to today. Mirrors the Python SDK's
-    // PERCY_ENABLE_DEV convention (percy-appium-app app_automate.py).
     if (action === 'percyScreenshot' && process.env.PERCY_ENABLE_DEV === 'true') {
       args = { ...args, projectId: 'percy-dev' };
     }

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -96,6 +96,13 @@ export default class GenericProvider {
 
   async browserstackExecutor(action, args) {
     if (!this.driver) throw new Error('Driver is null, please initialize driver with createDriver().');
+    // Staging/local override: when PERCY_ENABLE_DEV=true, route percyScreenshot
+    // payloads to the percy-dev project. Defaults to no projectId field (prod) so
+    // customer payloads are byte-identical to today. Mirrors the Python SDK's
+    // PERCY_ENABLE_DEV convention (percy-appium-app app_automate.py).
+    if (action === 'percyScreenshot' && process.env.PERCY_ENABLE_DEV === 'true') {
+      args = { ...args, projectId: 'percy-dev' };
+    }
     let options = args ? { action, arguments: args } : { action };
     let res = await this.driver.executeScript({ script: `browserstack_executor: ${JSON.stringify(options)}`, args: [] });
     return res;

--- a/packages/webdriver-utils/src/providers/playwrightProvider.js
+++ b/packages/webdriver-utils/src/providers/playwrightProvider.js
@@ -35,7 +35,8 @@ export default class PlaywrightProvider extends GenericProvider {
   }
 
   async setDebugUrl() {
-    this.debugUrl = `https://automate.browserstack.com/builds/${this.automateResults.buildHash}/sessions/${this.automateResults.sessionHash}`;
+    const automateDomain = process.env.PERCY_AUTOMATE_DOMAIN || 'automate.browserstack.com';
+    this.debugUrl = `https://${automateDomain}/builds/${this.automateResults.buildHash}/sessions/${this.automateResults.sessionHash}`;
   }
 
   async screenshot(name, options) {

--- a/packages/webdriver-utils/test/playwrightDriver.test.js
+++ b/packages/webdriver-utils/test/playwrightDriver.test.js
@@ -86,6 +86,18 @@ describe('PlaywrightDriver', () => {
       expect(response).toEqual({ value: 'mockVal' });
     });
 
+    it('should use PERCY_CDP_DOMAIN when set', async () => {
+      process.env.PERCY_CDP_DOMAIN = 'cdp-k8s-devpercyplat.bsstag.com';
+      try {
+        const command = { script: 'console.log("Hello, World!")', args: [] };
+        await driver.executeScript(command);
+        const baseUrl = `https://cdp-k8s-devpercyplat.bsstag.com/wd/hub/session/${sessionId}/execute`;
+        expect(requestSpy).toHaveBeenCalledWith(baseUrl, jasmine.any(Object));
+      } finally {
+        delete process.env.PERCY_CDP_DOMAIN;
+      }
+    });
+
     it('should handle request error and re-throw', async () => {
       requestSpy.and.returnValue(Promise.reject(new Error('Request failed')));
       const command = { script: 'console.log("Hello, World!")', args: [] };

--- a/packages/webdriver-utils/test/providers/automateProvider.test.js
+++ b/packages/webdriver-utils/test/providers/automateProvider.test.js
@@ -50,6 +50,19 @@ describe('AutomateProvider', () => {
       expect(automateProvider.debugUrl).toEqual('https://automate.browserstack.com/builds/12e3/sessions/abc1d');
     });
 
+    it('uses PERCY_AUTOMATE_DOMAIN when set', async () => {
+      Cache.reset();
+      process.env.PERCY_AUTOMATE_DOMAIN = 'automate-k8s-mobile.bsstag.com';
+      try {
+        let automateProvider = new AutomateProvider(args);
+        await automateProvider.createDriver();
+        await automateProvider.screenshot('abc', { });
+        expect(automateProvider.debugUrl).toEqual('https://automate-k8s-mobile.bsstag.com/builds/12e3/sessions/abc1d');
+      } finally {
+        delete process.env.PERCY_AUTOMATE_DOMAIN;
+      }
+    });
+
     it('throws error if driver is not initialized', async () => {
       let automateProvider = new AutomateProvider(args);
       await expectAsync(automateProvider.setDebugUrl())

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -1262,6 +1262,38 @@ describe('GenericProvider', () => {
       expect(executeScriptSpy)
         .toHaveBeenCalledWith({ script: 'browserstack_executor: {"action":"getSessionDetails","arguments":"new"}', args: [] });
     });
+
+    describe('with PERCY_ENABLE_DEV', () => {
+      afterEach(() => {
+        delete process.env.PERCY_ENABLE_DEV;
+      });
+
+      it('injects projectId: percy-dev into percyScreenshot payloads when enabled', async () => {
+        process.env.PERCY_ENABLE_DEV = 'true';
+        let provider = new GenericProvider(args);
+        await provider.createDriver();
+        await provider.browserstackExecutor('percyScreenshot', { state: 'begin' });
+        expect(executeScriptSpy)
+          .toHaveBeenCalledWith({ script: 'browserstack_executor: {"action":"percyScreenshot","arguments":{"state":"begin","projectId":"percy-dev"}}', args: [] });
+      });
+
+      it('does not inject projectId for non-percyScreenshot actions when enabled', async () => {
+        process.env.PERCY_ENABLE_DEV = 'true';
+        let provider = new GenericProvider(args);
+        await provider.createDriver();
+        await provider.browserstackExecutor('getSessionDetails', { foo: 'bar' });
+        expect(executeScriptSpy)
+          .toHaveBeenCalledWith({ script: 'browserstack_executor: {"action":"getSessionDetails","arguments":{"foo":"bar"}}', args: [] });
+      });
+
+      it('does not inject projectId when disabled (byte-identical to prod)', async () => {
+        let provider = new GenericProvider(args);
+        await provider.createDriver();
+        await provider.browserstackExecutor('percyScreenshot', { state: 'begin' });
+        expect(executeScriptSpy)
+          .toHaveBeenCalledWith({ script: 'browserstack_executor: {"action":"percyScreenshot","arguments":{"state":"begin"}}', args: [] });
+      });
+    });
   });
 
   describe('getTag', () => {

--- a/packages/webdriver-utils/test/providers/playwrightProvider.test.js
+++ b/packages/webdriver-utils/test/providers/playwrightProvider.test.js
@@ -49,6 +49,22 @@ describe('PlaywrightProvider', () => {
         'https://automate.browserstack.com/builds/buildHash/sessions/sessionHash'
       );
     });
+
+    it('uses PERCY_AUTOMATE_DOMAIN when set', async () => {
+      process.env.PERCY_AUTOMATE_DOMAIN = 'automate-k8s-mobile.bsstag.com';
+      try {
+        provider.automateResults = {
+          buildHash: 'buildHash',
+          sessionHash: 'sessionHash'
+        };
+        await provider.setDebugUrl();
+        expect(provider.debugUrl).toBe(
+          'https://automate-k8s-mobile.bsstag.com/builds/buildHash/sessions/sessionHash'
+        );
+      } finally {
+        delete process.env.PERCY_AUTOMATE_DOMAIN;
+      }
+    });
   });
 
   describe('screenshot', () => {


### PR DESCRIPTION
## Summary
Makes the screenshot executor's project routing and the CDP / Automate host resolution optionally configurable, all defaulting to current behavior. No change unless explicitly opted in.

## Changes
- `genericProvider.browserstackExecutor`: optionally include a `projectId` in the `percyScreenshot` payload, injected once at this shared chokepoint (covers begin/end and `getTiles` for both the Automate and Playwright providers).
- `playwrightDriver`: CDP execute host is now resolved with a default of `cdp.browserstack.com`.
- `automateProvider` / `playwrightProvider`: Automate debug-URL host resolved with a default of `automate.browserstack.com`.

All three are opt-in and fall back to the existing values, so the default path is unchanged.

## Testing
- Default path: executor payloads and hosts are unchanged; builds finalize (web + automate + playwright).
- Opt-in path: override applied as expected.
- Unit tests pass (238/238).

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: the overrides are opt-in and default to current production behavior; default-path payloads and hosts are byte-identical (covered by unit tests).

---

🤖 Generated with Claude Opus 4.8 (1M context) via [Claude Code](https://claude.com/claude-code)