### PR TITLE
feat(core): tip about VRA when a build uses Layout review mode (PER-9502)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,12 +12,13 @@ packages/sdk-utils/test/client.js
 packs
 docs/
 
+# spec-level retry bookkeeping (CI only, see PER-9011)
+.cli-test-failures.json
+
 # bstack-ai-harness:begin (managed — do not edit between markers)
 bstack-ai-harness.yml
 .harness-docs.json
+.harness-manifest.json
 CLAUDE.md
 .claude/
 # bstack-ai-harness:end
-
-# spec-level retry bookkeeping (CI only, see PER-9011)
-.cli-test-failures.json

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -886,10 +886,13 @@ export class PercyClient {
     return comparison;
   }
 
-  async sendBuildEvents(buildId, body, meta = {}) {
+  async sendBuildEvents(buildId, body, meta = {}, { eventName, category } = {}) {
     validateId('build', buildId);
     this.log.debug('Sending Build Events');
     return this.post(`builds/${buildId}/send-events`, {
+      // newer params are optional; when omitted the API applies its defaults
+      ...(eventName && { event_name: eventName }),
+      ...(category && { category }),
       data: body
     }, { identifier: 'build.send_events', ...meta });
   }

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -2510,6 +2510,21 @@ describe('PercyClient', () => {
         }
       });
     });
+
+    it('includes event_name and category when provided', async () => {
+      await expectAsync(client.sendBuildEvents(123, [
+        { message: 'some event' }
+      ], {}, {
+        eventName: 'percy_cli_vra_recommendation_emitted',
+        category: 'percy:cli'
+      })).toBeResolved();
+
+      expect(api.requests['/builds/123/send-events'][0].body).toEqual({
+        event_name: 'percy_cli_vra_recommendation_emitted',
+        category: 'percy:cli',
+        data: [{ message: 'some event' }]
+      });
+    });
   });
 
   describe('#sendBuildLogs', () => {

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -428,6 +428,9 @@ export function createSnapshotsQueue(percy) {
         await runDoctorOnFailure(percy);
       } else if (build?.id) {
         await percy.client.finalizeBuild(build.id);
+        if (build.layoutUsed) {
+          percy.log.warn('Tip: VRA is Percy\'s recommended visual review mode — more accurate and adaptable than Layout. Learn more: https://www.browserstack.com/docs/percy/ai-agents/visual-review-agent/overview.');
+        }
         percy.log.info(`Finalized build #${build.number}: ${build.url}`, { build });
       } else {
         percy.log.warn('Build not created', { build });
@@ -443,6 +446,9 @@ export function createSnapshotsQueue(percy) {
     // when pushed, maybe flush old snapshots or possibly merge with existing snapshots
     .handle('push', (snapshot, existing) => {
       let { name, meta } = snapshot;
+
+      // track layout usage to tip about VRA when the build is finalized
+      if (snapshot.enableLayout) build.layoutUsed = true;
 
       // log immediately when not deferred or dry-running
       if (!percy.deferUploads) percy.log.info(`Snapshot taken: ${snapshotLogName(name, meta)}`, meta);

--- a/packages/core/src/snapshot.js
+++ b/packages/core/src/snapshot.js
@@ -427,10 +427,22 @@ export function createSnapshotsQueue(percy) {
         percy.log.warn(`Build #${build.number} failed: ${build.url}`, { build });
         await runDoctorOnFailure(percy);
       } else if (build?.id) {
-        await percy.client.finalizeBuild(build.id);
         if (build.layoutUsed) {
           percy.log.warn('Tip: VRA is Percy\'s recommended visual review mode — more accurate and adaptable than Layout. Learn more: https://www.browserstack.com/docs/percy/ai-agents/visual-review-agent/overview.');
+
+          // instrument the recommendation; telemetry must never fail a build
+          try {
+            await percy.client.sendBuildEvents(build.id, {
+              message: 'VRA recommendation shown for a build using Layout review mode'
+            }, {}, {
+              eventName: 'percy_cli_vra_recommendation_emitted',
+              category: 'percy:cli'
+            });
+          } catch (err) {
+            percy.log.debug('VRA recommendation telemetry failed', err);
+          }
         }
+        await percy.client.finalizeBuild(build.id);
         percy.log.info(`Finalized build #${build.number}: ${build.url}`, { build });
       } else {
         percy.log.warn('Build not created', { build });

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -2259,6 +2259,26 @@ describe('Snapshot', () => {
       expect(logger.stderr.filter(l => l === tip).length).toEqual(1);
     });
 
+    it('still finalizes the build when recommendation telemetry fails', async () => {
+      percy.loglevel('debug');
+      spyOn(percy.client, 'sendBuildEvents').and.rejectWith(new Error('network down'));
+
+      await percy.snapshot({
+        name: 'test snapshot',
+        url: 'http://localhost:8000',
+        domSnapshot: '<html></html>',
+        enableLayout: true
+      });
+
+      await percy.stop();
+
+      // telemetry failure is swallowed and logged at debug; build still finalizes
+      expect(logger.stderr).toContain('[percy:core] VRA recommendation telemetry failed');
+      expect(logger.stdout).toContain(
+        '[percy:core] Finalized build #1: https://percy.io/test/test/123'
+      );
+    });
+
     it('does not log the VRA tip when no snapshot has layout enabled', async () => {
       await percy.snapshot({
         name: 'test snapshot',

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -2212,6 +2212,18 @@ describe('Snapshot', () => {
       expect(logger.stdout).toContain(
         '[percy] Finalized build #1: https://percy.io/test/test/123'
       );
+
+      // the recommendation is instrumented with the newer send-events params
+      let vraEvents = (api.requests['/builds/123/send-events'] || [])
+        .filter(r => r.body.event_name === 'percy_cli_vra_recommendation_emitted');
+      expect(vraEvents.length).toEqual(1);
+      expect(vraEvents[0].body).toEqual({
+        event_name: 'percy_cli_vra_recommendation_emitted',
+        category: 'percy:cli',
+        data: {
+          message: 'VRA recommendation shown for a build using Layout review mode'
+        }
+      });
     });
 
     it('logs the VRA tip when enableLayout is set globally in config', async () => {
@@ -2260,6 +2272,10 @@ describe('Snapshot', () => {
       expect(logger.stdout).toContain(
         '[percy] Finalized build #1: https://percy.io/test/test/123'
       );
+      // no recommendation event is sent when Layout is not used
+      let vraEvents = (api.requests['/builds/123/send-events'] || [])
+        .filter(r => r.body.event_name === 'percy_cli_vra_recommendation_emitted');
+      expect(vraEvents.length).toEqual(0);
     });
   });
 });

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -2194,6 +2194,74 @@ describe('Snapshot', () => {
       });
     });
   });
+
+  describe('VRA layout tip', () => {
+    let tip = '[percy] Tip: VRA is Percy\'s recommended visual review mode — more accurate and adaptable than Layout. Learn more: https://www.browserstack.com/docs/percy/ai-agents/visual-review-agent/overview.';
+
+    it('logs a VRA tip before finalizing when a snapshot has layout enabled', async () => {
+      await percy.snapshot({
+        name: 'test snapshot',
+        url: 'http://localhost:8000',
+        domSnapshot: '<html></html>',
+        enableLayout: true
+      });
+
+      await percy.stop();
+
+      expect(logger.stderr).toContain(tip);
+      expect(logger.stdout).toContain(
+        '[percy] Finalized build #1: https://percy.io/test/test/123'
+      );
+    });
+
+    it('logs the VRA tip when enableLayout is set globally in config', async () => {
+      percy.config.snapshot.enableLayout = true;
+
+      await percy.snapshot({
+        name: 'test snapshot',
+        url: 'http://localhost:8000',
+        domSnapshot: '<html></html>'
+      });
+
+      await percy.stop();
+
+      expect(logger.stderr).toContain(tip);
+    });
+
+    it('logs the VRA tip only once when multiple snapshots have layout enabled', async () => {
+      await percy.snapshot({
+        name: 'snapshot one',
+        url: 'http://localhost:8000',
+        domSnapshot: '<html></html>',
+        enableLayout: true
+      });
+      await percy.snapshot({
+        name: 'snapshot two',
+        url: 'http://localhost:8000',
+        domSnapshot: '<html></html>',
+        enableLayout: true
+      });
+
+      await percy.stop();
+
+      expect(logger.stderr.filter(l => l === tip).length).toEqual(1);
+    });
+
+    it('does not log the VRA tip when no snapshot has layout enabled', async () => {
+      await percy.snapshot({
+        name: 'test snapshot',
+        url: 'http://localhost:8000',
+        domSnapshot: '<html></html>'
+      });
+
+      await percy.stop();
+
+      expect(logger.stderr).not.toContain(tip);
+      expect(logger.stdout).toContain(
+        '[percy] Finalized build #1: https://percy.io/test/test/123'
+      );
+    });
+  });
 });
 
 // ── runDoctorOnFailure ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Emits a single `warn`-level tip immediately before the `Finalized build` log whenever any snapshot in a build had **Layout** review mode enabled (`enableLayout`, set via global config or per-snapshot).
- **Why:** Layout is a legacy review mode; VRA (Visual Review Agent) is the recommended replacement. This surfaces a contextual nudge at build finalization — where users already look — with minimal noise (one line, only when Layout is actually used).
- **Key decisions:**
  - Detection flips a per-build flag (`build.layoutUsed`) in the queue `push` handler; emission is gated in the `end` handler, so it logs **at most once per process**.
  - Covers both standard and parallel builds: each parallel shard runs core's `end` handler, so `cli-build` finalize needs no change.
  - Tip copy (renders with the `[percy]` prefix at normal log level):
    > `Tip: VRA is Percy's recommended visual review mode — more accurate and adaptable than Layout. Learn more: https://www.browserstack.com/docs/percy/ai-agents/visual-review-agent/overview.`

## Changes
- `packages/core/src/snapshot.js` — detection in `push` handler + guarded `warn` in `end` handler.
- `packages/core/test/snapshot.test.js` — 4 new specs.

## Testing
- 4 new specs in `snapshot.test.js`, all passing:
  - logs the tip before finalizing when a snapshot has layout enabled
  - logs the tip when `enableLayout` is set globally in config
  - logs the tip only once when multiple snapshots have layout enabled
  - does not log the tip when no snapshot has layout enabled
- Lint clean (`eslint` from repo root).
- Note: the full local core suite shows pre-existing, environment-only failures unrelated to this change — `install.test.js` (`global.__MOCK_IMPORTS__` undefined; ESM loader hook) and one `api.test.js` server-disabled spec (`AggregateError` vs `ECONNREFUSED`, a Node networking quirk). No snapshot/finalize/layout specs fail.

## Post-Deploy Monitoring & Validation
- **What to monitor/search**
  - Logs: CLI build output for the new line `Tip: VRA is Percy's recommended visual review mode`.
- **Validation checks (queries/commands)**
  - `npx percy snapshot` with `enableLayout: true` (global or per-snapshot) → tip appears once just before `Finalized build`.
  - Same run without any Layout snapshot → tip does NOT appear.
- **Expected healthy behavior**
  - Exactly one tip line per build process when Layout is used; none otherwise. Build finalization behavior unchanged.
- **Failure signal(s) / rollback trigger**
  - Tip appearing on builds with no Layout usage, duplicate tips within a single process, or any change to `Finalized build` ordering → revert this commit (log-only change, safe to revert).
- **Validation window & owner**
  - Window: first few CLI releases / dogfood builds after merge. Owner: PR author.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: instrumentation of the recommendation

The VRA tip is now also instrumented via a build event so we can measure how often the recommendation is shown:

- Extended `PercyClient#sendBuildEvents` to optionally accept the newer top-level params `event_name` and `category` (backward compatible — existing callers unchanged; when omitted the API applies its defaults).
- When the tip is shown, core sends a build event **before** finalizing the build (so the build is still open), wrapped in try/catch so telemetry can never fail a build:
  - `event_name`: `percy_cli_vra_recommendation_emitted`
  - `category`: `percy:cli`
  - `data`: `{ message: "VRA recommendation shown for a build using Layout review mode" }`

**Note:** `category` was set to `percy:cli` (the CLI-side sibling of the `percy:app` example) since it wasn't specified — easy to change if a different taxonomy is preferred.

Added tests: client `sendBuildEvents` with `event_name`/`category`, and core specs asserting the event is sent (filtered by `event_name`) only when Layout is used.
