### PR TITLE
security: scope CORS to loopback + block cross-origin config/stop (PER-8600/8601/8602/8603)

### DIFF
--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -996,8 +996,10 @@ export function createPercyServer(percy, port) {
 
       res.json(200, { success: true });
     })
-  // stops percy at the end of the current event loop
-    .route('/percy/stop', (req, res) => {
+  // stops percy at the end of the current event loop; POST-only so a browser
+  // cannot trigger it via a no-Origin GET (e.g. an <img> tag), which would
+  // otherwise slip past the cross-origin gate below
+    .route('post', '/percy/stop', (req, res) => {
       assertNotCrossOrigin(req);
       setImmediate(() => percy.stop());
       return res.json(200, { success: true });

--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -284,8 +284,13 @@ export function createPercyServer(percy, port) {
         try { req.body = JSON.parse(req.body); } catch {}
       }
 
-      // add version header
-      res.setHeader('Access-Control-Expose-Headers', '*, X-Percy-Core-Version');
+      // Expose headers only to loopback origins, consistent with the CORS
+      // handler in server.js. Access-Control-Expose-Headers is inert without a
+      // matching Access-Control-Allow-Origin, so gating it here keeps the two
+      // layers aligned rather than emitting it unconditionally.
+      if (isLoopbackOrigin(req.headers.origin)) {
+        res.setHeader('Access-Control-Expose-Headers', '*, X-Percy-Core-Version');
+      }
 
       // skip or change api version header in testing mode
       if (percy.testing?.version !== false) {
@@ -308,12 +313,23 @@ export function createPercyServer(percy, port) {
         next = () => req.connection.destroy();
       }
 
+      // Block cross-origin browser requests to every state-changing route at a
+      // single choke point. CORS-safelisted content types (text/plain, form
+      // data) reach handlers with no preflight, but a cross-origin request
+      // always carries an Origin header, so gating every non-safe method here
+      // covers all present and future mutating routes. Read-only methods and
+      // same-host / no-Origin SDK callers are unaffected.
       // return json errors
-      return next().catch(e => res.json(e.status ?? 500, {
-        build: percy.testing?.build || percy.build,
-        error: e.message,
-        success: false
-      }));
+      return Promise.resolve()
+        .then(() => {
+          if (!['GET', 'HEAD', 'OPTIONS'].includes(req.method)) assertNotCrossOrigin(req);
+          return next();
+        })
+        .catch(e => res.json(e.status ?? 500, {
+          build: percy.testing?.build || percy.build,
+          error: e.message,
+          success: false
+        }));
     })
   // healthcheck returns basic information
     .route('get', '/percy/healthcheck', (req, res) => res.json(200, {
@@ -357,8 +373,7 @@ export function createPercyServer(percy, port) {
     })
   // get or set config options
     .route(['get', 'post'], '/percy/config', async (req, res) => {
-      // mutating the live config is only allowed from same-host callers
-      if (req.body) assertNotCrossOrigin(req);
+      // POST mutation is blocked cross-origin by the general middleware above.
       let body = req.body && stripBlockedConfigFields(req.body, logger('core:server'));
       return res.json(200, {
         config: body ? percy.set(body) : percy.config,
@@ -997,10 +1012,9 @@ export function createPercyServer(percy, port) {
       res.json(200, { success: true });
     })
   // stops percy at the end of the current event loop; POST-only so a browser
-  // cannot trigger it via a no-Origin GET (e.g. an <img> tag), which would
-  // otherwise slip past the cross-origin gate below
+  // cannot trigger it via a no-Origin GET (e.g. an <img> tag). Cross-origin
+  // POSTs are blocked by the general middleware's single choke point above.
     .route('post', '/percy/stop', (req, res) => {
-      assertNotCrossOrigin(req);
       setImmediate(() => percy.stop());
       return res.json(200, { success: true });
     });

--- a/packages/core/src/api.js
+++ b/packages/core/src/api.js
@@ -3,7 +3,7 @@ import path, { dirname, resolve } from 'path';
 import logger from '@percy/logger';
 import { normalize } from '@percy/config/utils';
 import { getPackageJSON, Server, percyAutomateRequestHandler, percyBuildEventHandler, computeResponsiveWidths } from './utils.js';
-import { ServerError } from './server.js';
+import { ServerError, isLoopbackOrigin } from './server.js';
 import WebdriverUtils from '@percy/webdriver-utils';
 import { handleSyncJob } from './snapshot.js';
 import { dump as maestroDump, firstMatch as maestroFirstMatch, SELECTOR_KEYS_WHITELIST, getMaestroHierarchyDrift } from './maestro-hierarchy.js';
@@ -89,6 +89,19 @@ export function _applyHttpReadOnlyStripping(body, paths, log) {
 // Returns a body with `httpReadOnly` fields removed. Caller guarantees `body` is truthy.
 function stripBlockedConfigFields(body, log) {
   return _applyHttpReadOnlyStripping(body, findHttpReadOnlyPaths(body, ROOT_CONFIG_SCHEMA), log);
+}
+
+// Reject state-changing requests that carry a cross-origin (non-loopback) Origin
+// header. The local server is unauthenticated by design (SDKs post to it), so
+// this blocks a malicious website the user is visiting from driving sensitive
+// endpoints — live config mutation or stopping the build — via the browser
+// (CWE-352 / CWE-306, PER-8600/8601). Node SDK clients send no Origin header and
+// are unaffected; loopback browser tooling (any localhost port) is allowed.
+function assertNotCrossOrigin(req) {
+  let origin = req.headers.origin;
+  if (origin && !isLoopbackOrigin(origin)) {
+    throw new ServerError(403, 'Cross-origin requests are not allowed on this endpoint');
+  }
 }
 
 // Parse PNG IHDR chunk for the screenshot's actual rendered dimensions.
@@ -344,6 +357,8 @@ export function createPercyServer(percy, port) {
     })
   // get or set config options
     .route(['get', 'post'], '/percy/config', async (req, res) => {
+      // mutating the live config is only allowed from same-host callers
+      if (req.body) assertNotCrossOrigin(req);
       let body = req.body && stripBlockedConfigFields(req.body, logger('core:server'));
       return res.json(200, {
         config: body ? percy.set(body) : percy.config,
@@ -983,6 +998,7 @@ export function createPercyServer(percy, port) {
     })
   // stops percy at the end of the current event loop
     .route('/percy/stop', (req, res) => {
+      assertNotCrossOrigin(req);
       setImmediate(() => percy.stop());
       return res.json(200, { success: true });
     });

--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -17,9 +17,11 @@ import {
 export function isLoopbackOrigin(origin) {
   if (!origin || typeof origin !== 'string') return false;
   try {
+    // URL.hostname strips the brackets from an IPv6 literal, so `[::1]`
+    // normalises to `::1` here — no need to match the bracketed form.
     let host = new URL(origin).hostname.toLowerCase();
     return host === 'localhost' || host === '127.0.0.1' ||
-      host === '::1' || host === '[::1]' || host.endsWith('.localhost');
+      host === '::1' || host.endsWith('.localhost');
   } catch {
     return false;
   }

--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -17,9 +17,10 @@ import {
 export function isLoopbackOrigin(origin) {
   if (!origin || typeof origin !== 'string') return false;
   try {
-    // URL.hostname strips the brackets from an IPv6 literal, so `[::1]`
-    // normalises to `::1` here — no need to match the bracketed form.
+    // URL.hostname KEEPS the brackets around an IPv6 literal, so `[::1]`
+    // stays `[::1]` here and must be unwrapped before matching `::1`.
     let host = new URL(origin).hostname.toLowerCase();
+    if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1);
     return host === 'localhost' || host === '127.0.0.1' ||
       host === '::1' || host.endsWith('.localhost');
   } catch {

--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -242,12 +242,16 @@ export class Server extends http.Server {
       // from the local Percy server (build data, config) cross-origin (CWE-942).
       let origin = req.headers.origin;
       let originAllowed = isLoopbackOrigin(origin);
+      // The response branches on Origin on every path (ACAO is emitted only for
+      // loopback origins), so Vary: Origin must be set unconditionally —
+      // otherwise a cache/intermediary could serve a no-ACAO body to a loopback
+      // origin, or a loopback body to another origin.
+      res.setHeader('Vary', 'Origin');
       if (originAllowed) {
         // `origin` is validated against a loopback-only allowlist above, so it
         // is not attacker-controlled here.
         // nosemgrep: javascript.express.security.cors-misconfiguration.cors-misconfiguration
         res.setHeader('Access-Control-Allow-Origin', origin);
-        res.setHeader('Vary', 'Origin');
       }
 
       if (req.method === 'OPTIONS') {

--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -9,6 +9,22 @@ import {
   compile as makeToPath
 } from 'path-to-regexp';
 
+// Returns true when an Origin header value resolves to a loopback host. The
+// local Percy server is only ever legitimately reached by Node SDK clients
+// (which send no Origin) or by loopback browser tooling (e.g. the Storybook
+// manager on localhost:<port>). Treating non-loopback origins as untrusted lets
+// us scope CORS and reject cross-origin state changes (CWE-942 / CWE-352).
+export function isLoopbackOrigin(origin) {
+  if (!origin || typeof origin !== 'string') return false;
+  try {
+    let host = new URL(origin).hostname.toLowerCase();
+    return host === 'localhost' || host === '127.0.0.1' ||
+      host === '::1' || host === '[::1]' || host.endsWith('.localhost');
+  } catch {
+    return false;
+  }
+}
+
 // custom incoming message adds a `url` and `body` properties containing the parsed URL and message
 // buffer respectively; both available after the 'end' event is emitted
 export class IncomingMessage extends http.IncomingMessage {
@@ -218,19 +234,29 @@ export class Server extends http.Server {
   #routes = [{
     priority: -1,
     handle: (req, res, next) => {
-      res.setHeader('Access-Control-Allow-Origin', '*');
+      // Only echo a loopback Origin back as Access-Control-Allow-Origin. The
+      // previous wildcard `*` let any website the user visited read responses
+      // from the local Percy server (build data, config) cross-origin (CWE-942).
+      let origin = req.headers.origin;
+      let originAllowed = isLoopbackOrigin(origin);
+      if (originAllowed) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        res.setHeader('Vary', 'Origin');
+      }
 
       if (req.method === 'OPTIONS') {
-        let allowHeaders = req.headers['access-control-request-headers'] || '*';
-        let allowMethods = [...new Set(this.#routes.flatMap(route => (
-          (!route.match || route.match(req.url.pathname)) && route.methods
-        ) || []))].join(', ');
+        if (originAllowed) {
+          let allowHeaders = req.headers['access-control-request-headers'] || '*';
+          let allowMethods = [...new Set(this.#routes.flatMap(route => (
+            (!route.match || route.match(req.url.pathname)) && route.methods
+          ) || []))].join(', ');
 
-        res.setHeader('Access-Control-Allow-Headers', allowHeaders);
-        res.setHeader('Access-Control-Allow-Methods', allowMethods);
+          res.setHeader('Access-Control-Allow-Headers', allowHeaders);
+          res.setHeader('Access-Control-Allow-Methods', allowMethods);
+        }
         res.writeHead(204).end();
       } else {
-        res.setHeader('Access-Control-Expose-Headers', '*');
+        if (originAllowed) res.setHeader('Access-Control-Expose-Headers', '*');
         return next();
       }
     }

--- a/packages/core/src/server.js
+++ b/packages/core/src/server.js
@@ -243,6 +243,9 @@ export class Server extends http.Server {
       let origin = req.headers.origin;
       let originAllowed = isLoopbackOrigin(origin);
       if (originAllowed) {
+        // `origin` is validated against a loopback-only allowlist above, so it
+        // is not attacker-controlled here.
+        // nosemgrep: javascript.express.security.cors-misconfiguration.cors-misconfiguration
         res.setHeader('Access-Control-Allow-Origin', origin);
         res.setHeader('Vary', 'Origin');
       }

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -169,6 +169,44 @@ describe('API Server', () => {
     ]));
   });
 
+  it('rejects /config POST carrying a cross-origin Origin header (PER-8601)', async () => {
+    await percy.start();
+    let before = percy.config;
+
+    await expectAsync(request('/percy/config', {
+      method: 'POST',
+      body: { snapshot: { widths: [1234] } },
+      headers: { Origin: 'https://evil.example' }
+    })).toBeRejected();
+
+    // live config was not mutated by the cross-origin request
+    expect(percy.config).toEqual(before);
+  });
+
+  it('allows /config POST from a loopback origin', async () => {
+    await percy.start();
+
+    await expectAsync(request('/percy/config', {
+      method: 'POST',
+      body: { snapshot: { widths: [1000] } },
+      headers: { Origin: 'http://localhost:6006' }
+    })).toBeResolved();
+
+    expect(percy.config.snapshot.widths).toEqual([1000]);
+  });
+
+  it('rejects /stop carrying a cross-origin Origin header (PER-8600)', async () => {
+    await percy.start();
+    let stopSpy = spyOn(percy, 'stop').and.resolveTo();
+
+    await expectAsync(request('/percy/stop', {
+      method: 'POST',
+      headers: { Origin: 'https://evil.example' }
+    })).toBeRejected();
+
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
   it('has an /idle endpoint that calls #idle()', async () => {
     spyOn(percy, 'idle').and.resolveTo();
     await percy.start();

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -218,6 +218,27 @@ describe('API Server', () => {
     expect(stopSpy).not.toHaveBeenCalled();
   });
 
+  it('blocks cross-origin POSTs to every state-changing endpoint at the middleware choke point (PER-8600/8601)', async () => {
+    await percy.start();
+
+    // CORS-safelisted content types reach these handlers with no preflight, but
+    // a cross-origin request always carries an Origin, so the general-middleware
+    // choke point must reject all of them before any side effect runs.
+    let endpoints = [
+      '/percy/snapshot', '/percy/comparison', '/percy/comparison/upload',
+      '/percy/maestro-screenshot', '/percy/flush', '/percy/automateScreenshot',
+      '/percy/events', '/percy/log'
+    ];
+
+    for (let path of endpoints) {
+      await expectAsync(request(path, {
+        method: 'POST',
+        body: { name: 'x' },
+        headers: { Origin: 'https://evil.example' }
+      })).toBeRejectedWithError(/Cross-origin requests are not allowed/);
+    }
+  });
+
   it('has an /idle endpoint that calls #idle()', async () => {
     spyOn(percy, 'idle').and.resolveTo();
     await percy.start();

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -207,6 +207,17 @@ describe('API Server', () => {
     expect(stopSpy).not.toHaveBeenCalled();
   });
 
+  it('does not stop Percy on a GET to /stop (no-Origin CSRF vector, PER-8600)', async () => {
+    await percy.start();
+    let stopSpy = spyOn(percy, 'stop').and.resolveTo();
+
+    // A browser can issue a cross-origin GET (e.g. via <img>) with no Origin
+    // header; the endpoint is POST-only so this must not reach the handler.
+    await expectAsync(request('/percy/stop', 'GET')).toBeRejected();
+
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
   it('has an /idle endpoint that calls #idle()', async () => {
     spyOn(percy, 'idle').and.resolveTo();
     await percy.start();

--- a/packages/core/test/unit/server.test.js
+++ b/packages/core/test/unit/server.test.js
@@ -323,6 +323,11 @@ describe('Unit / Server', () => {
       expect(isLoopbackOrigin('http://app.localhost')).toBe(true);
     });
 
+    it('returns true for the bracketed IPv6 loopback literal', () => {
+      expect(isLoopbackOrigin('http://[::1]:5338')).toBe(true);
+      expect(isLoopbackOrigin('http://[::1]')).toBe(true);
+    });
+
     it('returns false for non-loopback and missing origins', () => {
       expect(isLoopbackOrigin('https://evil.example.com')).toBe(false);
       expect(isLoopbackOrigin('')).toBe(false);

--- a/packages/core/test/unit/server.test.js
+++ b/packages/core/test/unit/server.test.js
@@ -1,5 +1,5 @@
 import { fs, mockfs } from '../helpers/index.js';
-import Server from '../../src/server.js';
+import Server, { isLoopbackOrigin } from '../../src/server.js';
 
 describe('Unit / Server', () => {
   let server;
@@ -313,6 +313,25 @@ describe('Unit / Server', () => {
       expect(res.statusCode).toBe(404);
       expect(res.headers).toHaveProperty('content-type', 'application/json');
       expect(res.body).toEqual({ error: 'Not Found' });
+    });
+  });
+
+  describe('isLoopbackOrigin', () => {
+    it('returns true for loopback origins', () => {
+      expect(isLoopbackOrigin('http://localhost:8000')).toBe(true);
+      expect(isLoopbackOrigin('http://127.0.0.1')).toBe(true);
+      expect(isLoopbackOrigin('http://app.localhost')).toBe(true);
+    });
+
+    it('returns false for non-loopback and missing origins', () => {
+      expect(isLoopbackOrigin('https://evil.example.com')).toBe(false);
+      expect(isLoopbackOrigin('')).toBe(false);
+      expect(isLoopbackOrigin(undefined)).toBe(false);
+      expect(isLoopbackOrigin(42)).toBe(false);
+    });
+
+    it('returns false for a malformed origin that cannot be parsed as a URL', () => {
+      expect(isLoopbackOrigin('not a valid origin')).toBe(false);
     });
   });
 

--- a/packages/core/test/unit/server.test.js
+++ b/packages/core/test/unit/server.test.js
@@ -241,26 +241,52 @@ describe('Unit / Server', () => {
       });
     });
 
-    it('handles CORS preflight requests', async () => {
+    it('handles CORS preflight requests for loopback origins', async () => {
       server.route(['get', 'post'], '/1', (req, res) => res.send(200));
       server.route(['put', 'delete'], '/2', (req, res) => res.text(200));
 
-      let res1 = await request('/1', 'OPTIONS', false);
+      // CORS is scoped to loopback origins (CWE-942): Access-Control-Allow-Origin
+      // is the echoed loopback origin, not a wildcard `*`.
+      let origin = server.address(); // http://localhost:8000
+
+      let res1 = await request('/1', {
+        method: 'OPTIONS',
+        headers: { Origin: origin }
+      }, false);
 
       expect(res1.statusCode).toBe(204);
-      expect(res1.headers).toHaveProperty('access-control-allow-origin', '*');
+      expect(res1.headers).toHaveProperty('access-control-allow-origin', origin);
       expect(res1.headers).toHaveProperty('access-control-allow-headers', '*');
       expect(res1.headers).toHaveProperty('access-control-allow-methods', 'GET, POST');
 
       let res2 = await request('/2', {
         method: 'OPTIONS',
-        headers: { 'Access-Control-Request-Headers': 'Content-Type' }
+        headers: { Origin: origin, 'Access-Control-Request-Headers': 'Content-Type' }
       }, false);
 
       expect(res2.statusCode).toBe(204);
-      expect(res2.headers).toHaveProperty('access-control-allow-origin', '*');
+      expect(res2.headers).toHaveProperty('access-control-allow-origin', origin);
       expect(res2.headers).toHaveProperty('access-control-allow-headers', 'Content-Type');
       expect(res2.headers).toHaveProperty('access-control-allow-methods', 'PUT, DELETE');
+    });
+
+    it('omits CORS headers for missing or non-loopback origins', async () => {
+      server.route(['get', 'post'], '/1', (req, res) => res.send(200));
+
+      // No Origin header (e.g. a Node SDK client) — still a valid 204 preflight,
+      // but no CORS headers are emitted.
+      let res1 = await request('/1', 'OPTIONS', false);
+      expect(res1.statusCode).toBe(204);
+      expect(res1.headers).not.toHaveProperty('access-control-allow-origin');
+      expect(res1.headers).not.toHaveProperty('access-control-allow-methods');
+
+      // Cross-origin website must not receive permissive CORS headers.
+      let res2 = await request('/1', {
+        method: 'OPTIONS',
+        headers: { Origin: 'https://evil.example.com' }
+      }, false);
+      expect(res2.statusCode).toBe(204);
+      expect(res2.headers).not.toHaveProperty('access-control-allow-origin');
     });
 
     it('handles server errors', async () => {


### PR DESCRIPTION
## Summary
Fifth (final contained) percy-cli security PR — the local-server origin findings (deadline 2026-06-16) + chain [PER-8626](https://browserstack.atlassian.net/browse/PER-8626).

| Ticket | CWE | Finding |
|--------|-----|---------|
| [PER-8602](https://browserstack.atlassian.net/browse/PER-8602) | CWE-942 | CORS wildcard enables cross-origin state mutation |
| [PER-8600](https://browserstack.atlassian.net/browse/PER-8600) | CWE-306 | Missing auth on the process-terminating endpoint |
| [PER-8601](https://browserstack.atlassian.net/browse/PER-8601) | CWE-306 | Unauthenticated live config mutation via `POST /percy/config` |
| [PER-8603](https://browserstack.atlassian.net/browse/PER-8603) | CWE-915 | Live config mass assignment |

## The constraint
The local API is unauthenticated **by design** — every SDK posts to it without credentials. The real exploit path in these findings is a **malicious website** the user is visiting reaching `http://localhost:5338` from the browser. The fix defends that vector without breaking the SDK contract.

## Changes
**`server.js` (PER-8602):** the CORS middleware no longer returns `Access-Control-Allow-Origin: *`. It reflects the request `Origin` **only when it's loopback** (`isLoopbackOrigin` — `localhost`/`127.0.0.1`/`::1`/`*.localhost`, any port). Arbitrary sites get no ACAO and can't read local-server responses (build data, config). Node SDK clients don't use CORS; loopback browser tooling (e.g. the Storybook manager on `localhost:6006`) still works.

**`api.js` (PER-8600 / PER-8601):** `assertNotCrossOrigin()` rejects (403) any `POST /percy/config` or `/percy/stop` request carrying a **non-loopback `Origin`** header. Node SDK clients send no `Origin` → unaffected; a malicious site's cross-origin `fetch` → blocked.

**PER-8603:** already mitigated by the existing `stripBlockedConfigFields` (`httpReadOnly`) control; the cross-origin guard adds defense against browser-driven mutation.

## Why not Host-validation
The server binds to all interfaces by default (`PERCY_SERVER_HOST`, default `::`), so Dockerized SDKs legitimately reach it via a non-loopback `Host`. Origin-based checks defend the browser vector **without breaking** those setups.

## Verification
- `isLoopbackOrigin` verified (localhost/127.0.0.1/`*.localhost` allowed; `evil.com`/empty/undefined rejected); both files `node --check` clean.
- Added unit tests: cross-origin `/config` POST rejected + config unmutated; loopback `/config` POST allowed; cross-origin `/stop` rejected + `percy.stop` not called.
- Existing config/stop tests use Node request helpers (no `Origin`) → unaffected.

Closes PER-8602; closes the browser-origin vector for PER-8600/8601/8603 and chain PER-8626.

> **Residual (flagged):** a no-`Origin` top-level navigation/`<img>` GET to `/percy/stop` isn't covered by an Origin check, and full request **authentication** (a token adopted by all SDKs) remains a larger coordinated change. This PR closes the cross-origin (CORS/`fetch`) vector the findings exploit; full auth tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8626]: https://browserstack.atlassian.net/browse/PER-8626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8602]: https://browserstack.atlassian.net/browse/PER-8602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8600]: https://browserstack.atlassian.net/browse/PER-8600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8601]: https://browserstack.atlassian.net/browse/PER-8601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8603]: https://browserstack.atlassian.net/browse/PER-8603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ