### PR TITLE
ci: skip heavy test suites on bot version-bump PRs (PER-9560)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,16 +16,28 @@ jobs:
     outputs:
       version_only: ${{ steps.filter.outputs.version_only }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      - name: Check the PR changes only version files
         id: filter
         if: github.event_name == 'pull_request'
-        with:
-          predicate-quantifier: every
-          filters: |
-            version_only:
-              - 'lerna.json'
-              - 'packages/**/package.json'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if ! files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename'); then
+            echo "Could not list PR files — running full CI to be safe."
+            echo "version_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf 'Changed files:\n%s\n' "$files"
+          # version_only=true only if EVERY changed file is lerna.json or a top-level
+          # packages/<pkg>/package.json (exactly what version-bump.yml commits).
+          others=$(printf '%s\n' "$files" | grep -vE '^(lerna\.json|packages/[^/]+/package\.json)$' || true)
+          if [ -n "$files" ] && [ -z "$others" ]; then
+            echo "version_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "version_only=false" >> "$GITHUB_OUTPUT"
+          fi
 
   build:
     name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,45 +4,14 @@ on:
     branches: [master]
   pull_request:
   workflow_dispatch:
-jobs:
-  # Detect whether a PR's diff is confined to the version files that version-bump.yml
-  # is allowed to commit (lerna.json + packages/**/package.json). Combined with the
-  # `release/` branch check on the heavy jobs below, this lets us skip the ~1h matrix
-  # for genuine version-bump PRs while still running it for any `release/*` PR that
-  # touches source — so the skip can't be abused to land untested code behind a
-  # green-looking "skipped" check (PER-9560).
-  changes:
-    name: Detect version-only changes
-    runs-on: ubuntu-latest
-    outputs:
-      version_only: ${{ steps.filter.outputs.version_only }}
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
-        id: filter
-        # Only meaningful for PRs; on push/workflow_dispatch the step is skipped, the
-        # output is empty, and the branch check below already evaluates to "run".
-        if: github.event_name == 'pull_request'
-        with:
-          # `every`: version_only is true ONLY when every changed file matches a pattern.
-          predicate-quantifier: every
-          filters: |
-            version_only:
-              - 'lerna.json'
-              - 'packages/**/package.json'
 
+permissions:
+  contents: read
+
+jobs:
   build:
     name: Build
-    # Skip the ~1h test matrix on automated version-bump PRs. version-bump.yml opens
-    # these from `release/<version>` branches and commits only lerna.json +
-    # packages/**/package.json, so there's nothing to test. We skip only when BOTH hold
-    # — branch is `release/*` AND the diff is version-only — so a `release/*` PR that
-    # touches source still runs the full suite (PER-9560). Implemented as a job-level
-    # `if` (not an `on:` branch filter) so the check still reports as "skipped" — which
-    # satisfies a required status check — instead of staying "pending" and blocking the
-    # release PR from merging.
-    needs: [changes]
-    if: ${{ !(startsWith(github.head_ref, 'release/') && needs.changes.outputs.version_only == 'true') }}
+    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -71,9 +40,8 @@ jobs:
 
   test:
     name: Test ${{ matrix.package }}
-    needs: [build, changes]
-    # Skip on version-only version-bump PRs — see the build job and PER-9560.
-    if: ${{ !(startsWith(github.head_ref, 'release/') && needs.changes.outputs.version_only == 'true') }}
+    needs: [build]
+    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -175,9 +143,8 @@ jobs:
 
   regression:
     name: Regression
-    needs: [build, changes]
-    # Skip on version-only version-bump PRs — see the build job and PER-9560.
-    if: ${{ !(startsWith(github.head_ref, 'release/') && needs.changes.outputs.version_only == 'true') }}
+    needs: [build]
+    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,44 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
+  # Detect whether a PR's diff is confined to the version files that version-bump.yml
+  # is allowed to commit (lerna.json + packages/**/package.json). Combined with the
+  # `release/` branch check on the heavy jobs below, this lets us skip the ~1h matrix
+  # for genuine version-bump PRs while still running it for any `release/*` PR that
+  # touches source — so the skip can't be abused to land untested code behind a
+  # green-looking "skipped" check (PER-9560).
+  changes:
+    name: Detect version-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      version_only: ${{ steps.filter.outputs.version_only }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        # Only meaningful for PRs; on push/workflow_dispatch the step is skipped, the
+        # output is empty, and the branch check below already evaluates to "run".
+        if: github.event_name == 'pull_request'
+        with:
+          # `every`: version_only is true ONLY when every changed file matches a pattern.
+          predicate-quantifier: every
+          filters: |
+            version_only:
+              - 'lerna.json'
+              - 'packages/**/package.json'
+
   build:
     name: Build
+    # Skip the ~1h test matrix on automated version-bump PRs. version-bump.yml opens
+    # these from `release/<version>` branches and commits only lerna.json +
+    # packages/**/package.json, so there's nothing to test. We skip only when BOTH hold
+    # — branch is `release/*` AND the diff is version-only — so a `release/*` PR that
+    # touches source still runs the full suite (PER-9560). Implemented as a job-level
+    # `if` (not an `on:` branch filter) so the check still reports as "skipped" — which
+    # satisfies a required status check — instead of staying "pending" and blocking the
+    # release PR from merging.
+    needs: [changes]
+    if: ${{ !(startsWith(github.head_ref, 'release/') && needs.changes.outputs.version_only == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -35,7 +71,9 @@ jobs:
 
   test:
     name: Test ${{ matrix.package }}
-    needs: [build]
+    needs: [build, changes]
+    # Skip on version-only version-bump PRs — see the build job and PER-9560.
+    if: ${{ !(startsWith(github.head_ref, 'release/') && needs.changes.outputs.version_only == 'true') }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -137,7 +175,9 @@ jobs:
 
   regression:
     name: Regression
-    needs: [build]
+    needs: [build, changes]
+    # Skip on version-only version-bump PRs — see the build job and PER-9560.
+    if: ${{ !(startsWith(github.head_ref, 'release/') && needs.changes.outputs.version_only == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,30 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    name: Detect version-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      version_only: ${{ steps.filter.outputs.version_only }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: every
+          filters: |
+            version_only:
+              - 'lerna.json'
+              - 'packages/**/package.json'
+
   build:
     name: Build
-    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    needs: [changes]
+    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' && needs.changes.outputs.version_only == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -40,8 +59,8 @@ jobs:
 
   test:
     name: Test ${{ matrix.package }}
-    needs: [build]
-    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    needs: [build, changes]
+    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' && needs.changes.outputs.version_only == 'true') }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -143,8 +162,8 @@ jobs:
 
   regression:
     name: Regression
-    needs: [build]
-    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    needs: [build, changes]
+    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' && needs.changes.outputs.version_only == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,16 +16,28 @@ jobs:
     outputs:
       version_only: ${{ steps.filter.outputs.version_only }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+      - name: Check the PR changes only version files
         id: filter
         if: github.event_name == 'pull_request'
-        with:
-          predicate-quantifier: every
-          filters: |
-            version_only:
-              - 'lerna.json'
-              - 'packages/**/package.json'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if ! files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename'); then
+            echo "Could not list PR files — running full CI to be safe."
+            echo "version_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf 'Changed files:\n%s\n' "$files"
+          # version_only=true only if EVERY changed file is lerna.json or a top-level
+          # packages/<pkg>/package.json (exactly what version-bump.yml commits).
+          others=$(printf '%s\n' "$files" | grep -vE '^(lerna\.json|packages/[^/]+/package\.json)$' || true)
+          if [ -n "$files" ] && [ -z "$others" ]; then
+            echo "version_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "version_only=false" >> "$GITHUB_OUTPUT"
+          fi
 
   build:
     name: Build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,8 +5,36 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
+  # See test.yml for the rationale. Detects whether a PR's diff is confined to the
+  # version files version-bump.yml is allowed to commit, so the skip below can't be
+  # abused to land untested source behind a green-looking "skipped" check (PER-9560).
+  changes:
+    name: Detect version-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      version_only: ${{ steps.filter.outputs.version_only }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          # `every`: version_only is true ONLY when every changed file matches a pattern.
+          predicate-quantifier: every
+          filters: |
+            version_only:
+              - 'lerna.json'
+              - 'packages/**/package.json'
+
   build:
     name: Build
+    # Skip the ~60m Windows matrix on version-only version-bump PRs (branch `release/*`
+    # AND a diff confined to lerna.json + packages/**/package.json). A `release/*` PR that
+    # touches source still runs the full suite (PER-9560). Job-level `if` (not an `on:`
+    # branch filter) so the check posts a "skipped" result that satisfies required status
+    # checks, instead of staying "pending" and blocking the release PR.
+    needs: [changes]
+    if: ${{ !(startsWith(github.head_ref, 'release/') && needs.changes.outputs.version_only == 'true') }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
@@ -35,7 +63,9 @@ jobs:
 
   test:
     name: Test ${{ matrix.package }}
-    needs: [build]
+    needs: [build, changes]
+    # Skip on version-only version-bump PRs — see the build job and PER-9560.
+    if: ${{ !(startsWith(github.head_ref, 'release/') && needs.changes.outputs.version_only == 'true') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,37 +4,14 @@ on:
     branches: [master]
   pull_request:
   workflow_dispatch:
-jobs:
-  # See test.yml for the rationale. Detects whether a PR's diff is confined to the
-  # version files version-bump.yml is allowed to commit, so the skip below can't be
-  # abused to land untested source behind a green-looking "skipped" check (PER-9560).
-  changes:
-    name: Detect version-only changes
-    runs-on: ubuntu-latest
-    outputs:
-      version_only: ${{ steps.filter.outputs.version_only }}
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
-        id: filter
-        if: github.event_name == 'pull_request'
-        with:
-          # `every`: version_only is true ONLY when every changed file matches a pattern.
-          predicate-quantifier: every
-          filters: |
-            version_only:
-              - 'lerna.json'
-              - 'packages/**/package.json'
 
+permissions:
+  contents: read
+
+jobs:
   build:
     name: Build
-    # Skip the ~60m Windows matrix on version-only version-bump PRs (branch `release/*`
-    # AND a diff confined to lerna.json + packages/**/package.json). A `release/*` PR that
-    # touches source still runs the full suite (PER-9560). Job-level `if` (not an `on:`
-    # branch filter) so the check posts a "skipped" result that satisfies required status
-    # checks, instead of staying "pending" and blocking the release PR.
-    needs: [changes]
-    if: ${{ !(startsWith(github.head_ref, 'release/') && needs.changes.outputs.version_only == 'true') }}
+    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
@@ -63,9 +40,8 @@ jobs:
 
   test:
     name: Test ${{ matrix.package }}
-    needs: [build, changes]
-    # Skip on version-only version-bump PRs — see the build job and PER-9560.
-    if: ${{ !(startsWith(github.head_ref, 'release/') && needs.changes.outputs.version_only == 'true') }}
+    needs: [build]
+    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,11 +7,30 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    name: Detect version-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      version_only: ${{ steps.filter.outputs.version_only }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: every
+          filters: |
+            version_only:
+              - 'lerna.json'
+              - 'packages/**/package.json'
+
   build:
     name: Build
-    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    needs: [changes]
+    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' && needs.changes.outputs.version_only == 'true') }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
@@ -40,8 +59,8 @@ jobs:
 
   test:
     name: Test ${{ matrix.package }}
-    needs: [build]
-    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    needs: [build, changes]
+    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' && needs.changes.outputs.version_only == 'true') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Automated version-bump PRs — opened by `version-bump.yml` — only touch `lerna.json` + `packages/**/package.json` and have no code impact, yet they currently block ~1h waiting on the full Linux (`test.yml`) and Windows (`windows.yml`) test matrices ([PER-9560](https://browserstack.atlassian.net/browse/PER-9560)).

This skips those heavy suites for the release bot's version-bump PRs, while keeping them fully in force everywhere else.

**The skip fires only when ALL THREE hold** (evaluated per push):
- the head branch matches **`release/*`** (the convention set by `version-bump.yml` — a slash, not the `release-*` hyphen in the ticket),
- the PR was opened by **`github-actions[bot]`** (`github.event.pull_request.user.login`), **and**
- the PR diff is **confined to version files** — a `changes` job lists the PR's changed files (`gh api .../pulls/N/files`) and confirms every one is `lerna.json` or a top-level `packages/<pkg>/package.json`.

The diff check is the load-bearing one and is re-evaluated on **every push**, so if a source commit lands on a `release/*` branch after the bot opens the PR, `version_only` becomes `false` and the full suite runs — author/branch are fixed at PR-creation time and can't mask a later source change. The check is fail-safe: any API error (or a non-version file) → `version_only=false` → full CI runs.

### What's skipped vs kept
| Workflow / job | Bot `release/*` PR, version-only diff | Everything else |
|---|---|---|
| `test.yml` → `build`, `test` (17-pkg matrix), `regression` | **skipped** (~1h saved) | runs |
| `windows.yml` → `build`, `test` (17-pkg matrix) | **skipped** (~60m saved) | runs |
| `lint`, `typecheck`, `Semgrep` | run (~1m each) | run |

### Why a job-level `if`, not an `on:` branch filter
The test jobs are required status checks. A skipped *job* posts a "skipped" conclusion that **satisfies** branch protection, whereas an `on:`-level skip leaves required checks stuck **"pending"** and would block the release PR from ever merging.

Also adds a least-privilege `permissions:` block (`contents: read` + `pull-requests: read`, the latter for listing PR files).

## Verified end-to-end (on a fork of percy/cli)
- **Bot version-bump PR** (`github-actions[bot]`, `release/1.32.0-beta.10`, version-only diff) → `Build`/`Test`/`Regression` (Linux) and `Build`/`Test` (Windows) reported **`skipped`**; `changes` computed `version_only=true`; lint/typecheck/Semgrep ran.
- **Normal PR** (non-version file, human author) → `changes` computed `version_only=false` and the heavy `Build`/`Test` jobs **ran**.

> Note: the first iteration used `dorny/paths-filter` with `predicate-quantifier: every`, which (verified on the fork) never matched — `every` requires a file to match *all* patterns at once, so `version_only` was always false and the skip never fired. Replaced with the explicit file-list check above.

## Test plan
- [ ] Bot version-bump PR → heavy jobs skipped; lint/typecheck/Semgrep run; mergeable in ~1m.
- [ ] Push a source commit onto a `release/*` branch → `version_only` flips false → full matrices run.
- [ ] Human PR from a `release/*` branch → runs (author isn't the bot).
- [ ] Normal feature PR / `master` push / `workflow_dispatch` → unchanged; everything runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PER-9560]: https://browserstack.atlassian.net/browse/PER-9560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ