### PR TITLE
PER-9142: fail snapshot when comparison tile upload fails after retries

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -879,7 +879,22 @@ export class PercyClient {
     }
     let snapshot = await this.createSnapshot(buildId, options);
     let comparison = await this.createComparison(snapshot.data.id, options);
-    await this.uploadComparisonTiles(comparison.data.id, options.tiles);
+    try {
+      await this.uploadComparisonTiles(comparison.data.id, options.tiles);
+    } catch (error) {
+      // A tile failed to upload/verify after all retries (see #verify). Finalize
+      // the comparison anyway so the server resolves it deterministically and
+      // marks this snapshot failed — an unfinalized comparison is otherwise swept
+      // by the build-cleanup retry loop and surfaces as a misleading render_timeout.
+      // Re-throw afterwards so the snapshot is reported as failed to the caller.
+      this.log.error(`Failed to upload tiles for comparison: ${comparison.data.id} ${options.tag?.name}`, meta);
+      try {
+        await this.finalizeComparison(comparison.data.id);
+      } catch (finalizeError) {
+        this.log.debug(`Failed to finalize failed comparison ${comparison.data.id}: ${finalizeError.message}`, meta);
+      }
+      throw error;
+    }
     this.log.debug(`Created comparison: ${comparison.data.id} ${options.tag.name}`, meta);
     await this.finalizeComparison(comparison.data.id);
     this.log.debug(`Finalized comparison: ${comparison.data.id} ${options.tag.name}`, meta);

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -887,13 +887,13 @@ export class PercyClient {
       // marks this snapshot failed — an unfinalized comparison is otherwise swept
       // by the build-cleanup retry loop and surfaces as a misleading render_timeout.
       // Re-throw afterwards so the snapshot is reported as failed to the caller.
-      this.log.error(`Failed to upload tiles for comparison: ${comparison.data.id} ${options.tag?.name}`, meta);
+      this.log.error(`Failed to upload tiles for comparison: ${comparison.data.id} ${options.tag.name}`, meta);
       try {
         await this.finalizeComparison(comparison.data.id);
       } catch (finalizeError) {
-        // Coerce defensively: a non-Error rejection (null/undefined/string) must not
-        // throw here and mask the original tile-upload error we re-throw below.
-        this.log.debug(`Failed to finalize failed comparison ${comparison.data.id}: ${finalizeError?.message || finalizeError}`, meta);
+        // String-coerce the rejection so a non-Error value (null/undefined/string)
+        // can't throw here and mask the original tile-upload error we re-throw below.
+        this.log.debug(`Failed to finalize failed comparison ${comparison.data.id}: ${finalizeError}`, meta);
       }
       throw error;
     }

--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -891,7 +891,9 @@ export class PercyClient {
       try {
         await this.finalizeComparison(comparison.data.id);
       } catch (finalizeError) {
-        this.log.debug(`Failed to finalize failed comparison ${comparison.data.id}: ${finalizeError.message}`, meta);
+        // Coerce defensively: a non-Error rejection (null/undefined/string) must not
+        // throw here and mask the original tile-upload error we re-throw below.
+        this.log.debug(`Failed to finalize failed comparison ${comparison.data.id}: ${finalizeError?.message || finalizeError}`, meta);
       }
       throw error;
     }

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -2441,6 +2441,9 @@ describe('PercyClient', () => {
           tag: { name: 'test tag' },
           tiles: [{ sha: 'abcd' }]
         })).toBeRejectedWithError('Uploading comparison tile failed');
+
+        // the finalize attempt was still made (and its own failure swallowed)
+        expect(client.finalizeComparison).toHaveBeenCalled();
       });
     });
 

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -2413,6 +2413,37 @@ describe('PercyClient', () => {
       });
     });
 
+    describe('when a tile fails to upload after all retries', () => {
+      it('finalizes the comparison and rethrows so the snapshot is marked failed', async () => {
+        spyOn(client, 'uploadComparisonTiles').and.callFake(() =>
+          Promise.reject(new Error('Uploading comparison tile failed')));
+        spyOn(client, 'finalizeComparison').and.callThrough();
+
+        await expectAsync(client.sendComparison(123, {
+          name: 'test snapshot name',
+          tag: { name: 'test tag' },
+          tiles: [{ sha: 'abcd' }]
+        })).toBeRejectedWithError('Uploading comparison tile failed');
+
+        // the comparison is still finalized so the server fails it deterministically
+        expect(client.finalizeComparison).toHaveBeenCalled();
+        expect(api.requests['/comparisons/891011/finalize']).toBeDefined();
+      });
+
+      it('still rethrows the original error when finalizing the failed comparison also fails', async () => {
+        spyOn(client, 'uploadComparisonTiles').and.callFake(() =>
+          Promise.reject(new Error('Uploading comparison tile failed')));
+        spyOn(client, 'finalizeComparison').and.callFake(() =>
+          Promise.reject(new Error('finalize boom')));
+
+        await expectAsync(client.sendComparison(123, {
+          name: 'test snapshot name',
+          tag: { name: 'test tag' },
+          tiles: [{ sha: 'abcd' }]
+        })).toBeRejectedWithError('Uploading comparison tile failed');
+      });
+    });
+
     describe('when labels are provided on a POA comparison', () => {
       beforeEach(async () => {
         await client.sendComparison(123, {


### PR DESCRIPTION
## Problem

For App Percy / Percy-on-Automate comparisons, `client.verify()` retries a tile up to 20× and then `throw`s `Uploading comparison tile failed` (intended: *"the comparison will be failed even if 1 tile gets failed"*).

But that throw happens **inside `uploadComparisonTiles`, before `finalizeComparison`**:

```js
// sendComparison (before)
await this.uploadComparisonTiles(comparison.data.id, options.tiles); // verify throws here
await this.finalizeComparison(comparison.data.id);                   // never reached
```

So the comparison is left **unfinalized**. The server's build-cleanup loop then reinserts the stuck comparison up to 10× and finally marks the build `render_timeout` — a misleading failure reason, and the snapshot is never cleanly reported as failed. (This is the CLI-side counterpart of the App Automate dropped-tile issue investigated in PER-9142 / browserstack/mobile-common#1197.)

## Fix

On tile-upload failure, **finalize the comparison anyway** so the server resolves it deterministically (and marks that snapshot failed) instead of leaving it to be swept as a `render_timeout`, then re-throw so the snapshot is reported failed to the caller:

```js
try {
  await this.uploadComparisonTiles(comparison.data.id, options.tiles);
} catch (error) {
  this.log.error(`Failed to upload tiles for comparison: ${comparison.data.id} ${options.tag?.name}`, meta);
  try { await this.finalizeComparison(comparison.data.id); }
  catch (finalizeError) { this.log.debug(`Failed to finalize failed comparison ${comparison.data.id}: ${finalizeError.message}`, meta); }
  throw error;
}
```

- The re-throw routes to the existing snapshot `error` handler in `core/src/snapshot.js`, which logs the failure and (for sync snapshots) rejects that snapshot's promise — so failure is surfaced per-snapshot.
- The build is **not** failed and other snapshots continue (the throw is not a 422 build error).
- If the finalize-on-failure itself errors, the original tile-upload error is still re-thrown.

## Tests

Added to `#sendComparison()`:
- finalizes the comparison and rethrows so the snapshot is marked failed
- still rethrows the original error when finalizing the failed comparison also fails

`yarn test --node` (client) → all `sendComparison` specs green; existing specs unaffected. ESLint clean on changed files. (The 2 failures in `test/unit/proxy.test.js` on my machine are pre-existing/environmental — a local proxy + a Node-20 `Invalid URL` message-format difference — unrelated to this change.)

## Related
- browserstack/mobile-common#1197 — terminal-side fix (verify the tile actually reached GCS before returning the sha).
- Together: the terminal stops handing back shas for un-uploaded tiles, and the CLI fails the snapshot cleanly if a tile still can't be verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)