### PR TITLE
ci: skip heavy suites on version-bump PRs via paths-ignore (PER-9560)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,47 +2,19 @@ name: Test
 on:
   push:
     branches: [master]
+  # Version-bump PRs change only lerna.json + packages/*/package.json and have no
+  # code to test, so the heavy suite is skipped entirely — the workflow doesn't run,
+  # so no Build/Test/Regression checks appear. Any PR touching source (or yarn.lock)
+  # still runs the full suite. These checks aren't required, so skipped PRs aren't
+  # left pending. (PER-9560)
   pull_request:
+    paths-ignore:
+      - 'lerna.json'
+      - 'packages/*/package.json'
   workflow_dispatch:
-
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
-  changes:
-    name: Detect version-only changes
-    runs-on: ubuntu-latest
-    outputs:
-      version_only: ${{ steps.filter.outputs.version_only }}
-    steps:
-      - name: Check the PR changes only version files
-        id: filter
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          if ! files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename'); then
-            echo "Could not list PR files — running full CI to be safe."
-            echo "version_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          printf 'Changed files:\n%s\n' "$files"
-          # version_only=true only if EVERY changed file is lerna.json or a top-level
-          # packages/<pkg>/package.json (exactly what version-bump.yml commits).
-          others=$(printf '%s\n' "$files" | grep -vE '^(lerna\.json|packages/[^/]+/package\.json)$' || true)
-          if [ -n "$files" ] && [ -z "$others" ]; then
-            echo "version_only=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "version_only=false" >> "$GITHUB_OUTPUT"
-          fi
-
   build:
     name: Build
-    needs: [changes]
-    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' && needs.changes.outputs.version_only == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -71,8 +43,7 @@ jobs:
 
   test:
     name: Test ${{ matrix.package }}
-    needs: [build, changes]
-    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' && needs.changes.outputs.version_only == 'true') }}
+    needs: [build]
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -174,8 +145,7 @@ jobs:
 
   regression:
     name: Regression
-    needs: [build, changes]
-    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' && needs.changes.outputs.version_only == 'true') }}
+    needs: [build]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,6 @@ name: Test
 on:
   push:
     branches: [master]
-  # Version-bump PRs change only lerna.json + packages/*/package.json and have no
-  # code to test, so the heavy suite is skipped entirely — the workflow doesn't run,
-  # so no Build/Test/Regression checks appear. Any PR touching source (or yarn.lock)
-  # still runs the full suite. These checks aren't required, so skipped PRs aren't
-  # left pending. (PER-9560)
   pull_request:
     paths-ignore:
       - 'lerna.json'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,9 +2,6 @@ name: Windows
 on:
   push:
     branches: [master]
-  # See test.yml — skip the heavy Windows suite on version-only PRs (lerna.json +
-  # packages/*/package.json). The workflow doesn't run, so no checks appear; any PR
-  # touching source (or yarn.lock) still runs the full suite. (PER-9560)
   pull_request:
     paths-ignore:
       - 'lerna.json'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,47 +2,17 @@ name: Windows
 on:
   push:
     branches: [master]
+  # See test.yml — skip the heavy Windows suite on version-only PRs (lerna.json +
+  # packages/*/package.json). The workflow doesn't run, so no checks appear; any PR
+  # touching source (or yarn.lock) still runs the full suite. (PER-9560)
   pull_request:
+    paths-ignore:
+      - 'lerna.json'
+      - 'packages/*/package.json'
   workflow_dispatch:
-
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
-  changes:
-    name: Detect version-only changes
-    runs-on: ubuntu-latest
-    outputs:
-      version_only: ${{ steps.filter.outputs.version_only }}
-    steps:
-      - name: Check the PR changes only version files
-        id: filter
-        if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          if ! files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename'); then
-            echo "Could not list PR files — running full CI to be safe."
-            echo "version_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          printf 'Changed files:\n%s\n' "$files"
-          # version_only=true only if EVERY changed file is lerna.json or a top-level
-          # packages/<pkg>/package.json (exactly what version-bump.yml commits).
-          others=$(printf '%s\n' "$files" | grep -vE '^(lerna\.json|packages/[^/]+/package\.json)$' || true)
-          if [ -n "$files" ] && [ -z "$others" ]; then
-            echo "version_only=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "version_only=false" >> "$GITHUB_OUTPUT"
-          fi
-
   build:
     name: Build
-    needs: [changes]
-    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' && needs.changes.outputs.version_only == 'true') }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
@@ -71,8 +41,7 @@ jobs:
 
   test:
     name: Test ${{ matrix.package }}
-    needs: [build, changes]
-    if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]' && needs.changes.outputs.version_only == 'true') }}
+    needs: [build]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Automated version-bump PRs (opened by `version-bump.yml`) change only `lerna.json` + `packages/*/package.json` and have no code to test, yet they otherwise wait ~1h on the full Linux/Windows test matrices ([PER-9560](https://browserstack.atlassian.net/browse/PER-9560)).

This skips the heavy suites on those PRs with a simple **path filter** — and crucially, the heavy jobs **don't appear on the PR at all** (the workflow doesn't run), keeping version-bump PRs clean:

```yaml
on:
  pull_request:
    paths-ignore:
      - 'lerna.json'
      - 'packages/*/package.json'
```

A PR whose diff is confined to those files won't trigger `test.yml` / `windows.yml`. **Any PR touching source (or `yarn.lock`) still runs the full suite**, so this doubles as a correct "only skip when there's nothing to test" filter. These checks aren't required by branch protection, so skipped PRs aren't left pending. `lint`, `typecheck`, `Semgrep`, and `CodeQL` are untouched and keep running on every PR.

### Replaces the earlier approach
This **reverts the job-level skip + `version_only` gate from #2284** (removes the `changes` job, the `version_only` / `github-actions[bot]` conditions, and the `permissions` block) in favour of the path filter — far less machinery, and it hides the jobs instead of showing them as skipped/green.

## Verified end-to-end (on a fork of percy/cli)
| PR | Changed files | Result |
|----|---------------|--------|
| version-only | `lerna.json` + `packages/cli/package.json` | only `Lint` + `Typecheck` ran — **`Test` and `Windows` did not run** ✅ |
| source | a file under `packages/core/src/` | `Lint`, `Typecheck`, **`Test`, `Windows`** all ran ✅ |

## Test plan
- [ ] A version-bump PR (only `lerna.json` + `packages/*/package.json`) shows **no** Build/Test/Regression checks; lint/typecheck/Semgrep/CodeQL still run; PR is mergeable.
- [ ] A PR touching any source file (or `yarn.lock`) runs the full Linux + Windows matrices.
- [ ] Push to `master` / `workflow_dispatch` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PER-9560]: https://browserstack.atlassian.net/browse/PER-9560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ