### PR TITLE
Revert PER-9560 CI changes — restore original test/windows workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    paths-ignore:
-      - 'lerna.json'
-      - 'packages/*/package.json'
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    paths-ignore:
-      - 'lerna.json'
-      - 'packages/*/package.json'
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
## Summary

Reverts the PER-9560 CI changes made this session — restores `.github/workflows/test.yml` and `windows.yml` to their pre-PER-9560 state.

Net diff is just **removing the `paths-ignore` block** from both workflows (added in #2293):

```diff
   pull_request:
-    paths-ignore:
-      - 'lerna.json'
-      - 'packages/*/package.json'
   workflow_dispatch:
```

#2293 had already reverted #2284's machinery (the `changes` job, the `version_only` / `github-actions[bot]` gate, and the `permissions` block), so removing the path filter restores the original workflows exactly.

**Effect:** version-bump PRs will once again run the full Linux + Windows test suites — i.e., PER-9560 is fully backed out. No other behavior change.

## Reverts
- #2284 — `ci: skip heavy test suites on bot version-bump PRs`
- #2293 — `ci: skip heavy suites on version-bump PRs via paths-ignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
