### PR TITLE
ci: set ignore-scripts=false to fix executable build

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-ignore-scripts=true
+ignore-scripts=false
 strict-ssl=true
 save-exact=true
 audit-level=high


### PR DESCRIPTION
## Problem

The **Build Executables** workflow has failed for the last 3 releases (since `v1.32.0-beta.8`), most recently on [v1.32.0](https://github.com/percy/cli/actions/runs/27682535456/job/81873257738). The job dies in `scripts/executable.sh` at:

```
cp: ./build/*: No such file or directory
```

## Root cause

The release-automation PR added a root `.npmrc` with `ignore-scripts=true`. The Build Executables runner uses **Node 14 → npm 6**, and **npm 6 honors `ignore-scripts` even for explicit `npm run <script>`** (npm 7+ later relaxed this). So `npm run build_cjs` (`BABEL_ENV=dev babel packages -d build`) became a silent no-op — `build/` was never created — and the following `cp -R ./build/* packages/` failed.

`yarn build` two lines earlier is unaffected because it runs via `lerna` + Nx, whose task runner executes package scripts directly rather than through `npm run`.

Verified by elimination: same runner image, same Node version, and the exact `v1.32.0` source tree all build `build_cjs` fine; the only delta at the first failing tag was this `.npmrc`.

## Fix

Set `ignore-scripts=false` so `npm run build_cjs` executes on the npm-6 runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)