### PR TITLE
fix(cli-upload): pin image-size to ~1.0.2 to keep Node 14 support

### DIFF
--- a/packages/cli-upload/package.json
+++ b/packages/cli-upload/package.json
@@ -35,6 +35,6 @@
   "dependencies": {
     "@percy/cli-command": "1.32.0",
     "fast-glob": "^3.2.11",
-    "image-size": "^1.0.0"
+    "image-size": "~1.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5493,7 +5493,7 @@ ignore@^5.0.4, ignore@^5.1.1, ignore@^5.2.0:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
-image-size@^1.0.0:
+image-size@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz"
   integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==


### PR DESCRIPTION
## Problem

`@percy/cli` declares `engines: { node: ">=14" }`, but `@percy/cli-upload` declared its `image-size` dependency as the loose range `"^1.0.0"`.

`image-size` raised its own engine requirement to **`node >=16`** starting at **v1.1.1** (1.0.2 = `>=14`, 1.1.1 / 1.2.0 / 1.2.1 = `>=16`). Because `^1.0.0` resolves to the latest matching version, any consumer that **regenerates its lockfile** against `@percy/cli` now pulls `image-size@1.2.1` (node>=16) — silently violating `@percy/cli`'s own `engines: node>=14`.

This isn't a code change in any recent CLI release — the `^1.0.0` range has been here since `@percy/cli-upload` was first added. It only surfaces now because (a) `image-size` published a node-bumping release and (b) downstream lockfiles get regenerated (e.g. when SDKs bump `@percy/cli`).

### Observed impact

Downstream Percy SDKs that still test Node 14 (`percy-puppeteer`, `percy-selenium-js`, `percy-testcafe`, `percy-nightmare`) fail their **Node 14 CI legs on install**, because the transitive `image-size@1.2.1` requires `node>=16` even though `@percy/cli` claims `>=14`.

## Fix

Constrain the range to `~1.0.2` (`>=1.0.2 <1.1.0`) — the last `image-size` line that supports `node>=14` — so `@percy/cli` honors its own `engines` field again.

- The CLI monorepo's own lockfile already resolved `image-size@1.0.2`; this just keeps every **downstream** consumer pinned to that line too.
- `image-size@1.0.x` is API-compatible with `cli-upload`'s usage (reading image dimensions), so no functional change.

## Alternative considered

Officially dropping Node 14 (bump `engines` to `>=16` across the CLI + SDK matrices). That's a larger, breaking decision; this PR is the minimal fix that restores the *currently declared* support contract. Happy to go the other direction if maintainers prefer to drop Node 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)