### PR TITLE
ci(release): skip CI and the approval gate on version-bump PRs

### DIFF
--- a/.github/workflows/Semgrep.yml
+++ b/.github/workflows/Semgrep.yml
@@ -33,10 +33,16 @@ jobs:
       # suppressions were ignored. See https://semgrep.dev/docs CHANGELOG v1.164.0.
       image: semgrep/semgrep:1.164.0
 
-    # Skip any PR created by dependabot to avoid permission issues, and skip
-    # release ("Release X.Y.Z") version-bump PRs (the Create Release PR workflow
-    # posts the required checks as passing for those).
-    if: ${{ github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'release/') }}
+    # Skip any PR created by dependabot to avoid permission issues, and skip the
+    # automated release PR (opened by github-actions[bot], same repo, release/*
+    # branch — the Create Release PR workflow posts the required checks for it).
+    # The release gate is keyed on the PR author, not the branch name (which any
+    # contributor controls), so a "release/…" branch can't bypass required checks.
+    if: >-
+      ${{ github.actor != 'dependabot[bot]'
+      && !(github.event.pull_request.user.login == 'github-actions[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.head_ref, 'release/')) }}
 
     steps:
       # Fetch project source with GitHub Actions Checkout.

--- a/.github/workflows/Semgrep.yml
+++ b/.github/workflows/Semgrep.yml
@@ -33,8 +33,10 @@ jobs:
       # suppressions were ignored. See https://semgrep.dev/docs CHANGELOG v1.164.0.
       image: semgrep/semgrep:1.164.0
 
-    # Skip any PR created by dependabot to avoid permission issues:
-    if: (github.actor != 'dependabot[bot]')
+    # Skip any PR created by dependabot to avoid permission issues, and skip
+    # release ("Release X.Y.Z") version-bump PRs (the Create Release PR workflow
+    # posts the required checks as passing for those).
+    if: ${{ github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'release/') }}
 
     steps:
       # Fetch project source with GitHub Actions Checkout.

--- a/.github/workflows/executable-check.yml
+++ b/.github/workflows/executable-check.yml
@@ -23,6 +23,9 @@ concurrency:
 jobs:
   verify:
     name: Build & verify executable
+    # Skip for release ("Release X.Y.Z") version-bump PRs; the Create Release PR
+    # workflow posts the required checks as passing for those.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/executable-check.yml
+++ b/.github/workflows/executable-check.yml
@@ -23,9 +23,15 @@ concurrency:
 jobs:
   verify:
     name: Build & verify executable
-    # Skip for release ("Release X.Y.Z") version-bump PRs; the Create Release PR
-    # workflow posts the required checks as passing for those.
-    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    # Skip CI only for the automated release PR: opened by github-actions[bot],
+    # from this same repo, on a release/* branch (the Create Release PR workflow
+    # posts the required checks as passing for it). Keyed on the PR author, not the
+    # branch name, so a "release/…" branch can't be used to bypass required checks.
+    if: >-
+      ${{ !(github.event_name == 'pull_request'
+      && github.event.pull_request.user.login == 'github-actions[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.head_ref, 'release/')) }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,15 @@ permissions:
 jobs:
   lint:
     name: Lint
-    # Skip for release ("Release X.Y.Z") version-bump PRs; the Create Release PR
-    # workflow posts the required checks as passing for those.
-    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    # Skip CI only for the automated release PR: opened by github-actions[bot],
+    # from this same repo, on a release/* branch (the Create Release PR workflow
+    # posts the required checks as passing for it). Keyed on the PR author, not the
+    # branch name, so a "release/…" branch can't be used to bypass required checks.
+    if: >-
+      ${{ !(github.event_name == 'pull_request'
+      && github.event.pull_request.user.login == 'github-actions[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.head_ref, 'release/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   lint:
     name: Lint
+    # Skip for release ("Release X.Y.Z") version-bump PRs; the Create Release PR
+    # workflow posts the required checks as passing for those.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     name: Build
+    # Release ("Release X.Y.Z") PRs only bump version files; CI is skipped and the
+    # required checks are posted as passing by the Create Release PR workflow.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -35,6 +38,7 @@ jobs:
 
   test:
     name: Test ${{ matrix.package }}
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     needs: [build]
     strategy:
       matrix:
@@ -137,6 +141,7 @@ jobs:
 
   regression:
     name: Regression
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     needs: [build]
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,16 @@ on:
 jobs:
   build:
     name: Build
-    # Release ("Release X.Y.Z") PRs only bump version files; CI is skipped and the
-    # required checks are posted as passing by the Create Release PR workflow.
-    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    # Skip CI only for the automated release PR: opened by github-actions[bot],
+    # from this same repo, on a release/* branch (the Create Release PR workflow
+    # posts the required checks as passing for it). The gate is keyed on the PR
+    # author — NOT the branch name, which any contributor controls — so a PR from
+    # a "release/…" branch can't be used to bypass required checks.
+    if: >-
+      ${{ !(github.event_name == 'pull_request'
+      && github.event.pull_request.user.login == 'github-actions[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.head_ref, 'release/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -38,7 +45,12 @@ jobs:
 
   test:
     name: Test ${{ matrix.package }}
-    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    # Skip only for the automated release PR (see the build job for rationale).
+    if: >-
+      ${{ !(github.event_name == 'pull_request'
+      && github.event.pull_request.user.login == 'github-actions[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.head_ref, 'release/')) }}
     needs: [build]
     strategy:
       matrix:
@@ -141,7 +153,12 @@ jobs:
 
   regression:
     name: Regression
-    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    # Skip only for the automated release PR (see the build job for rationale).
+    if: >-
+      ${{ !(github.event_name == 'pull_request'
+      && github.event.pull_request.user.login == 'github-actions[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.head_ref, 'release/')) }}
     needs: [build]
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -10,9 +10,15 @@ permissions:
 jobs:
   typecheck:
     name: Typecheck
-    # Skip for release ("Release X.Y.Z") version-bump PRs; the Create Release PR
-    # workflow posts the required checks as passing for those.
-    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    # Skip CI only for the automated release PR: opened by github-actions[bot],
+    # from this same repo, on a release/* branch (the Create Release PR workflow
+    # posts the required checks as passing for it). Keyed on the PR author, not the
+    # branch name, so a "release/…" branch can't be used to bypass required checks.
+    if: >-
+      ${{ !(github.event_name == 'pull_request'
+      && github.event.pull_request.user.login == 'github-actions[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.head_ref, 'release/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   typecheck:
     name: Typecheck
+    # Skip for release ("Release X.Y.Z") version-bump PRs; the Create Release PR
+    # workflow posts the required checks as passing for those.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -97,6 +97,14 @@ jobs:
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Fully attribute the commit to the GitHub Actions bot (not the human
+          # who clicked "Run workflow", which is create-pull-request's default
+          # author). A bot-authored, GITHUB_TOKEN-pushed commit lets GitHub's
+          # recursion guard suppress the on:pull_request CI runs entirely, so the
+          # release PR never sits in the "Approve and run workflows" gate — the
+          # synthetic check runs posted below satisfy branch protection on their own.
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           base: master
           branch: release/${{ steps.bump.outputs.version }}
           # Only commit version files — never workflow files (GITHUB_TOKEN may

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,9 +7,15 @@ on:
 jobs:
   build:
     name: Build
-    # Skip CI for release ("Release X.Y.Z") version-bump PRs; the Create Release
-    # PR workflow posts the required checks as passing for those.
-    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    # Skip CI only for the automated release PR: opened by github-actions[bot],
+    # from this same repo, on a release/* branch (the Create Release PR workflow
+    # posts the required checks as passing for it). Keyed on the PR author, not the
+    # branch name, so a "release/…" branch can't be used to bypass required checks.
+    if: >-
+      ${{ !(github.event_name == 'pull_request'
+      && github.event.pull_request.user.login == 'github-actions[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.head_ref, 'release/')) }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -38,7 +44,12 @@ jobs:
 
   test:
     name: Test ${{ matrix.package }}
-    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    # Skip only for the automated release PR (see the build job for rationale).
+    if: >-
+      ${{ !(github.event_name == 'pull_request'
+      && github.event.pull_request.user.login == 'github-actions[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.head_ref, 'release/')) }}
     needs: [build]
     strategy:
       fail-fast: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     name: Build
+    # Skip CI for release ("Release X.Y.Z") version-bump PRs; the Create Release
+    # PR workflow posts the required checks as passing for those.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -35,6 +38,7 @@ jobs:
 
   test:
     name: Test ${{ matrix.package }}
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     needs: [build]
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Problem

The **Create Release PR** workflow opens a `release/X.Y.Z` PR that only bumps version files and already posts passing check runs for every required context. But on the last real release PR (#2317) the full CI suite still got involved:

- `peter-evans/create-pull-request` defaults the commit **author** to `${{ github.actor }}` — the human who clicked *Run workflow* — so the commit looked user-authored (committer was still `github-actions[bot]`).
- That defeated GitHub's `GITHUB_TOKEN` recursion guard, so the `on: pull_request` CI workflows were queued and parked in **`action_required`** → the unwanted **"Approve and run workflows"** prompt.
- Once approved, the full ~20-min suite ran *redundantly* and left the PR `BLOCKED` until it finished.

Confirmed on #2317: attempt 1 `conclusion = action_required` (triggered by `github-actions[bot]`), attempt 2 triggered by a human clicking approve.

## Fix

1. **Fully attribute the release commit to `github-actions[bot]`** (both `author` and `committer`) in `version-bump.yml`, so GitHub's recursion guard suppresses the `pull_request` runs entirely. No approval gate; the synthetic check runs satisfy branch protection on their own.
2. **Defense-in-depth:** add a `!startsWith(github.head_ref, 'release/')` guard to every PR-triggered CI job (`test`, `windows`, `typecheck`, `lint`, `semgrep`, `executable-check`). If a run is ever triggered/approved on a release PR anyway, the heavy jobs skip instead of running.

## Resulting release flow (3 manual clicks)

1. Run **Create Release PR** (pick bump type).
2. Review + **merge** the version-only PR (now mergeable immediately, no approval prompt).
3. **Publish** the auto-created draft GitHub Release → npm publish + executable builds run automatically.

## Notes

- `draft-release.yml` is intentionally untouched (it's part of the release flow, runs only on merged "Release …" PRs).
- "Claude Code Review" / CodeQL have no in-repo workflow to guard (the review check is posted synthetically already).

🤖 Generated with [Claude Code](https://claude.com/claude-code)