### PR TITLE
fix(core): don't serve in-page POST/unsafe requests from the discovery cache

### DIFF
--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -668,6 +668,15 @@ async function sendResponseResource(network, request, session) {
   let meta = { ...network.meta, url };
   let send = (method, params) => network.send(session, method, params);
 
+  // The resource cache is keyed by URL only, and cached bodies are GET responses.
+  // Serving one for an unsafe method (POST/PUT/PATCH/DELETE) would answer a
+  // state-changing request with stale content and stop it from ever reaching the
+  // origin — e.g. an in-page login POST issued from an execute script would be
+  // fulfilled from the cached login page and never authenticate (PER-9766). Only
+  // safe, cacheable methods may be served from cache; anything else (or an absent
+  // method) safely falls through to a real origin request.
+  let cacheableMethod = request.method === 'GET' || request.method === 'HEAD';
+
   try {
     let resource = network.intercept.getResource(url, network.intercept.currentWidth);
     network.log.debug(`Handling request: ${url}`, meta);
@@ -684,7 +693,7 @@ async function sendResponseResource(network, request, session) {
         requestId: request.interceptId,
         errorReason: 'Aborted'
       });
-    } else if (resource && (resource.root || resource.provided || !disableCache)) {
+    } else if (resource && cacheableMethod && (resource.root || resource.provided || !disableCache)) {
       // Don't rename the below log line as it is used in getting network logs in api
       log.debug(resource.root ? '- Serving root resource' : '- Resource cache hit', meta);
 

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -2560,6 +2560,32 @@ describe('Discovery', () => {
       let nonRootResources = Array.from(percy[RESOURCE_CACHE_KEY].values()).filter(resource => !resource.root);
       expect(nonRootResources.length).toEqual(2);
     });
+
+    it('serves cached resources only for cacheable methods (PER-9766)', async () => {
+      // A resource is cached on the initial GET during discovery. An in-page POST to
+      // that same URL (e.g. a login form submitted from an execute script) must reach
+      // the origin instead of being answered from the URL-keyed cache — otherwise the
+      // request never authenticates and the snapshot captures unauthenticated content.
+      let methods = [];
+      server.reply('/cached.css', req => (methods.push(req.method), [200, 'text/css', '.a{}']));
+      server.reply('/', () => [200, 'text/html', dedent`
+        <html><head><link rel="stylesheet" href="/cached.css"/></head>
+        <body><p>auth</p></body></html>`
+      ]);
+
+      await percy.snapshot({
+        name: 'post bypasses cache',
+        url: 'http://localhost:8000',
+        // execute runs after initial discovery, so /cached.css is already cached here
+        execute: async () => { await fetch('/cached.css', { method: 'POST' }); }
+      });
+      await percy.idle();
+
+      // GET is cached on first load; the POST must NOT be served from cache, so the
+      // origin sees it too. On the buggy path the POST was a cache hit and never arrived.
+      expect(methods).toContain('GET');
+      expect(methods).toContain('POST');
+    });
   });
 
   describe('with --max-cache-ram', () => {


### PR DESCRIPTION
Fixes **PER-9766** — *PSE team can't snapshot pages behind form authentication.*

## Root cause
Asset-discovery's request interception serves cached responses **keyed on URL only, ignoring the HTTP method**:

- `packages/core/src/discovery.js:463` — `lookupCacheResource` keys purely on URL (`snapshotResources.get(url) || cache.get(url)`).
- `packages/core/src/network.js` (`sendResponseResource`) — fulfils any cached resource via `Fetch.fulfillRequest` regardless of `request.method`.

A customer logging in from an `execute` script did:
```js
await fetch(form.action, { method: 'POST', credentials: 'same-origin' }); // login
const html = await (await fetch('/my-account', { credentials: 'same-origin' })).text();
document.open(); document.write(html); document.close();
```
The login **POST** went to the site root, which had already been captured (GET) and cached during navigation. Discovery answered the POST from that cached login-page body, so it **never reached the origin** — no session was established, and the follow-up `/my-account` fetch returned unauthenticated content that `document.write` then captured.

**Debug-log proof:** `Evaluate JavaScript` → `Handling request: https://…/` (the POST) → `- Resource cache hit` → `/my-account` fetched unauthenticated → `Snapshot taken`.

## Fix
Only serve cached resources for **safe, cacheable methods (GET/HEAD)**. POST/PUT/PATCH/DELETE (or an absent method) fall through to `Fetch.continueRequest` → origin. Answering a state-changing request with a cached GET body is incorrect in general; page navigation and asset fetches are GET, so normal snapshotting is unaffected.

```js
let cacheableMethod = request.method === 'GET' || request.method === 'HEAD';
// …
} else if (resource && cacheableMethod && (resource.root || resource.provided || !disableCache)) {
```

## Testing
Added `discovery.test.js` › *resource caching* › "serves cached resources only for cacheable methods (PER-9766)": caches an asset on the initial GET, then issues a POST to the same URL from an `execute` script and asserts the **origin sees the POST** (i.e. it is not served from cache). Verified the spec **fails without the fix** (`Expected ['GET'] to contain 'POST'`) and passes with it.

## Review notes
This touches **core discovery interception** (100%-coverage gate). The new `cacheableMethod` branch is exercised by the GET+POST test. Worth a prod-replay sanity check, though the only behavior change is: an unsafe-method request whose URL happens to be cached now hits the origin instead of replaying a GET body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)