### PR TITLE
feat(PER-9724): send priority on build create via PERCY_PRIORITY (internal)

### DIFF
--- a/packages/client/src/client.js
+++ b/packages/client/src/client.js
@@ -326,6 +326,12 @@ export class PercyClient {
 
     let tagsArr = tagsList(this.labels);
 
+    // PER-9724: internal-only priority request. Set by internal product
+    // orchestration (e.g. Scanner / LCA) via PERCY_PRIORITY; mirrors the
+    // PERCY_ORIGINATED_SOURCE internal signal above. percy-api only honors this
+    // for eligible internal build types, so it is a no-op for customer builds.
+    let priority = process.env.PERCY_PRIORITY === 'true';
+
     return this.post('builds', {
       data: {
         type: 'builds',
@@ -351,7 +357,8 @@ export class PercyClient {
           'skip-base-build': this.config.percy?.skipBaseBuild,
           'testhub-build-uuid': this.env.testhubBuildUuid,
           'testhub-build-run-id': this.env.testhubBuildRunId,
-          ...(visualConfig ? { 'visual-config': visualConfig } : {})
+          ...(visualConfig ? { 'visual-config': visualConfig } : {}),
+          ...(priority ? { priority: true } : {})
         },
         relationships: {
           resources: {

--- a/packages/client/test/client.test.js
+++ b/packages/client/test/client.test.js
@@ -199,6 +199,7 @@ describe('PercyClient', () => {
       delete process.env.PERCY_AUTO_ENABLED_GROUP_BUILD;
       delete process.env.PERCY_ORIGINATED_SOURCE;
       delete process.env.PERCY_VISUAL_CONFIG;
+      delete process.env.PERCY_PRIORITY;
     });
 
     it('creates a new build', async () => {
@@ -236,6 +237,21 @@ describe('PercyClient', () => {
             tags: []
           }
         }));
+    });
+
+    it('sends priority: true when PERCY_PRIORITY is set (internal signal)', async () => {
+      process.env.PERCY_PRIORITY = 'true';
+
+      await client.createBuild();
+
+      expect(api.requests['/builds'][0].body.data.attributes)
+        .toEqual(jasmine.objectContaining({ priority: true }));
+    });
+
+    it('does not send a priority attribute when PERCY_PRIORITY is unset', async () => {
+      await client.createBuild();
+
+      expect(api.requests['/builds'][0].body.data.attributes.priority).toBeUndefined();
     });
 
     it('creates a new build with projectType passed as null', async () => {


### PR DESCRIPTION
## What & why

[PER-9724](https://browserstack.atlassian.net/browse/PER-9724) — client side of the priority-queue feature. Lets internal product orchestration (e.g. Scanner / LCA) request the priority lane for a build.

`@percy/client` `createBuild()` now forwards an internal env signal as the build-create `priority` attribute:

```js
let priority = process.env.PERCY_PRIORITY === 'true';
// data.attributes:
...(priority ? { priority: true } : {})
```

This mirrors the existing `PERCY_ORIGINATED_SOURCE` internal signal right beside it in `createBuild`.

## Why an env var (internal, decoupled, safe)
- **Internal-only:** the Scanner/LCA orchestration sets `PERCY_PRIORITY=true`; the client just relays it. Not a customer-facing config.
- **Not customer-controllable / no duplicated logic:** percy-api is the authoritative gate — it only honors `priority` for eligible internal build types (`visual_scanner`, `responsive_scanner`, `lca`). A customer setting the env var on a normal build has **no effect**, and the CLI doesn't duplicate the eligibility allowlist.
- **Zero impact when unset:** the `priority` attribute is omitted entirely unless `PERCY_PRIORITY=true`, so existing build payloads are unchanged.

## Companion PRs
- percy-api: percy/percy-api#6337 (accepts `priority`, gates by `param && internal build type`, routes jobs)
- infrastructure: percy/infrastructure#1288 (renderer priority queues + KEDA)
- percy-renderer: percy/percy-renderer#1903 (forward priority on the AfterRenderJob hop)

End-to-end: internal product sets `PERCY_PRIORITY=true` → client sends `priority: true` → percy-api honors it for eligible scanner/lca builds → jobs route to `priority_*` queues across api / renderer / image-processor.

## Tests
Added to `packages/client/test/client.test.js`: priority sent when `PERCY_PRIORITY` set, and omitted when unset. Both pass; all existing `createBuild` tests pass. (Two unrelated `proxy.test.js` failures are pre-existing — a Node URL error-string difference, not part of this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-9724]: https://browserstack.atlassian.net/browse/PER-9724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ