### PR TITLE
security: harden sdk-regression issue_comment workflow — pin actions, scope permissions + token (PER-8610)

### DIFF
--- a/.github/workflows/sdk-regression.yml
+++ b/.github/workflows/sdk-regression.yml
@@ -8,13 +8,16 @@ jobs:
   regression:
     name: regression
     runs-on: ubuntu-latest
-    # Least-privilege: read code/PR data and write commit statuses only. Note an
-    # author-permission guard below (check-access) already restricts triggering
-    # to write/admin collaborators (CWE-284 / PER-8610).
+    # Least-privilege GITHUB_TOKEN: read code/PR data, write commit statuses, and
+    # read this run's Actions job metadata (for the job log URL) only. Triggering
+    # is further gated by the author-permission check (check-access) below, which
+    # restricts it to write/admin collaborators. The powerful cross-repo dispatch
+    # PAT is NOT granted here; it is injected only into the single trigger step.
     permissions:
       contents: read
       pull-requests: read
       statuses: write
+      actions: read
     if: ${{ github.event.issue.pull_request && github.event.comment.body == 'RUN_REGRESSION' }}
     strategy:
       matrix:
@@ -69,13 +72,18 @@ jobs:
         uses: Tiryoh/gha-jobid-action@be260d8673c9211a84cdcf37794ebd654ba81eef # v1.4.0
         id: job-url
         with:
-          github_token: ${{ secrets.WORKFLOW_DISPATCH_ACTIONS_TOKEN }}
-          job_name: "regression (${{ matrix.repo }})" 
+          # Third-party action: only reads this run's job metadata on percy/cli,
+          # so the built-in GITHUB_TOKEN (actions: read) is sufficient. The
+          # cross-repo dispatch PAT is deliberately not exposed to it.
+          github_token: ${{ github.token }}
+          job_name: "regression (${{ matrix.repo }})"
       - name: Output Current Job Log URL
         run: echo ${{ steps.jobs.outputs.html_url }}
       - uses: actions/github-script@f891eff65186019cbb3f7190c4590bc0a1b76fbc # v4.1.0
         with:
-          github-token: ${{ secrets.WORKFLOW_DISPATCH_ACTIONS_TOKEN }}
+          # Writes a commit status on percy/cli itself (job-level statuses: write),
+          # so the built-in GITHUB_TOKEN is used instead of the cross-repo PAT.
+          github-token: ${{ github.token }}
           script: |
             const { owner, repo } = context.repo;
             const sha = '${{ steps.comment-branch.outputs.head_sha }}'
@@ -102,6 +110,9 @@ jobs:
         with:
           owner: percy
           repo: ${{ steps.split.outputs._0 }}
+          # Only step that strictly needs the cross-repo dispatch PAT: it triggers
+          # test.yml in a *different* percy repo, which the built-in GITHUB_TOKEN
+          # cannot do. Injection is scoped to this step alone.
           github_token: ${{ secrets.WORKFLOW_DISPATCH_ACTIONS_TOKEN }}
           workflow_file_name: test.yml
           ref: ${{ steps.split.outputs._1 || 'master' }}
@@ -110,7 +121,9 @@ jobs:
       - name: Update Status
         uses: actions/github-script@f891eff65186019cbb3f7190c4590bc0a1b76fbc # v4.1.0
         with:
-          github-token: ${{ secrets.WORKFLOW_DISPATCH_ACTIONS_TOKEN }}
+          # Writes a commit status on percy/cli itself (job-level statuses: write),
+          # so the built-in GITHUB_TOKEN is used instead of the cross-repo PAT.
+          github-token: ${{ github.token }}
           script: |
             const { owner, repo } = context.repo;
             const sha = '${{ steps.comment-branch.outputs.head_sha }}'

--- a/.github/workflows/sdk-regression.yml
+++ b/.github/workflows/sdk-regression.yml
@@ -153,7 +153,7 @@ jobs:
           # whole matrix (GitHub jobs API max page size is 100).
           per_page: 100
       - name: Output Current Job Log URL
-        run: echo ${{ steps.jobs.outputs.html_url }}
+        run: echo ${{ steps.job-url.outputs.html_url }}
       - uses: actions/github-script@f891eff65186019cbb3f7190c4590bc0a1b76fbc # v4.1.0
         with:
           # Writes a commit status on percy/cli itself (job-level statuses: write),


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/sdk-regression.yml` (F-012, CWE-284/CWE-269). This `issue_comment`-triggered workflow injects the cross-repo dispatch PAT `WORKFLOW_DISPATCH_ACTIONS_TOKEN` into more steps than strictly need it — including a third-party action — so a step compromise could exfiltrate a token that can dispatch workflows across other `percy/*` repos.

The `issue_comment` trigger intent, the author-permission guard (write/admin collaborators only), and the regression-trigger flow are all unchanged.

## Actions SHA-pinned (verified)

All third-party action `uses:` are pinned to full 40-char commit SHAs with a trailing `# vX.Y.Z` comment. Each tag was re-resolved live against the GitHub API for this PR and confirmed correct (already pinned by an earlier hardening pass; no SHA changed):

| Action | Version | Commit SHA |
| --- | --- | --- |
| `actions/github-script` | v4.1.0 | `f891eff65186019cbb3f7190c4590bc0a1b76fbc` |
| `xt0rted/pull-request-comment-branch` | v3.0.0 | `e8b8daa837e8ea7331c0003c9c316a64c6d8b0b1` |
| `actions-ecosystem/action-regex-match` | v2.0.2 | `9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b` |
| `Tiryoh/gha-jobid-action` | v1.4.0 | `be260d8673c9211a84cdcf37794ebd654ba81eef` |
| `winterjung/split` | v2.1.0 | `7f51d99e7cc1f147f6f99be75acf5e641930af88` |
| `convictional/trigger-workflow-and-wait` | v1.6.5 | `f69fa9eedd3c62a599220f4d5745230e237904be` |

## Permissions block

Top-level `permissions: contents: read` (already present). The `regression` job keeps its least-privilege grant and adds `actions: read` so the built-in `GITHUB_TOKEN` can read this run's job metadata:

```yaml
permissions:
  contents: read
  pull-requests: read
  statuses: write
  actions: read   # added
```

## How the token injection was narrowed

`WORKFLOW_DISPATCH_ACTIONS_TOKEN` is now injected into exactly one step — the only one that strictly requires it:

- **`convictional/trigger-workflow-and-wait`** — keeps the PAT. It dispatches `test.yml` in a *different* `percy/*` repo, which the built-in `GITHUB_TOKEN` cannot do.
- **`Tiryoh/gha-jobid-action`** (third-party) — switched to `${{ github.token }}`. It only reads this run's job metadata on `percy/cli`; the new `actions: read` grant covers it. The cross-repo PAT is no longer handed to a third-party action.
- **Both `actions/github-script` commit-status steps** — switched to `${{ github.token }}`. They only write commit statuses on `percy/cli`, covered by the existing job-level `statuses: write`.

No workflow/job-level `env` exposed the token; the over-exposure was per-step `with:` inputs, which is what this PR narrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)