### PR TITLE
fix(cli-app): parse app:exec loosely when command separator is missing (PER-9997)

### DIFF
--- a/packages/cli-app/src/exec.js
+++ b/packages/cli-app/src/exec.js
@@ -182,7 +182,7 @@ export function maybeInjectScreenshotDir(ctx, log) {
 
 export const exec = command('exec', {
   description: 'Start and stop Percy around a supplied command for native apps',
-  usage: '[options] -- <command>',
+  usage: '[options] [--] <command>',
   commands: [start, stop, ping],
 
   flags: ExecPlugin.default.definition

--- a/packages/cli-app/src/exec.js
+++ b/packages/cli-app/src/exec.js
@@ -189,6 +189,10 @@ export const exec = command('exec', {
   // grouped flags are built-in flags
     .flags.filter(f => !f.group),
 
+  // some environments (e.g. npx PowerShell shims) strip the `--` separator;
+  // fall back to loose parsing like `percy exec` instead of hard failing
+  loose: ExecPlugin.default.definition.loose,
+
   percy: {
     server: true,
     projectType: 'app',

--- a/packages/cli-app/test/exec.test.js
+++ b/packages/cli-app/test/exec.test.js
@@ -28,10 +28,19 @@ describe('percy app:exec', () => {
   });
 
   it('does not accept asset discovery options', async () => {
+    // with loose parsing, unrecognized exec options are treated as the command
     await expectAsync(exec(['--allowed-hostname', 'percy.io']))
-      .toBeRejectedWithError("Unknown option '--allowed-hostname'");
+      .toBeRejectedWithError('Command not found "--allowed-hostname"');
     await expectAsync(start(['--network-idle-timeout', '500']))
       .toBeRejectedWithError("Unknown option '--network-idle-timeout'");
+  });
+
+  it('parses loosely when the command separator is missing', async () => {
+    // some environments (e.g. npx PowerShell shims) strip the `--` separator;
+    // the command should warn and run instead of throwing a parse error
+    expect(exec.definition.loose).toEqual(ExecPlugin.default.definition.loose);
+    await expectAsync(exec(['dotnet', 'test'])).not.toBeRejectedWithError(
+      "Unexpected argument 'dotnet'");
   });
 
   describe('maybeInjectMaestroServer', () => {

--- a/packages/cli-app/test/exec.test.js
+++ b/packages/cli-app/test/exec.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { setupTest } from '@percy/cli-command/test/helpers';
+import { logger, setupTest } from '@percy/cli-command/test/helpers';
 import * as ExecPlugin from '@percy/cli-exec';
 import {
   exec, start, stop, ping,
@@ -28,19 +28,39 @@ describe('percy app:exec', () => {
   });
 
   it('does not accept asset discovery options', async () => {
-    // with loose parsing, unrecognized exec options are treated as the command
-    await expectAsync(exec(['--allowed-hostname', 'percy.io']))
-      .toBeRejectedWithError('Command not found "--allowed-hostname"');
     await expectAsync(start(['--network-idle-timeout', '500']))
       .toBeRejectedWithError("Unknown option '--network-idle-timeout'");
+  });
+
+  it('degrades unrecognized exec options into the command (loose parsing trade-off)', async () => {
+    // with loose parsing, exec no longer hard-rejects unknown flags with
+    // "Unknown option" — a typo like --allowed-hostname falls through to
+    // command lookup and fails there instead
+    let { default: which } = await import('which');
+    spyOn(which, 'sync').and.returnValue(null);
+
+    await expectAsync(exec(['--allowed-hostname', 'percy.io']))
+      .toBeRejectedWithError('Command not found "--allowed-hostname"');
   });
 
   it('parses loosely when the command separator is missing', async () => {
     // some environments (e.g. npx PowerShell shims) strip the `--` separator;
     // the command should warn and run instead of throwing a parse error
     expect(exec.definition.loose).toEqual(ExecPlugin.default.definition.loose);
-    await expectAsync(exec(['dotnet', 'test'])).not.toBeRejectedWithError(
-      "Unexpected argument 'dotnet'");
+
+    // stub command resolution so no real binary is looked up or spawned; the
+    // "Command not found" rejection proves `dotnet` was parsed as the command
+    // (not rejected as an unexpected argument) before reaching the lookup
+    let { default: which } = await import('which');
+    spyOn(which, 'sync').and.returnValue(null);
+
+    await expectAsync(exec(['dotnet', 'test']))
+      .toBeRejectedWithError('Command not found "dotnet"');
+
+    expect(logger.stderr).toEqual(jasmine.arrayContaining([
+      `[percy] ${ExecPlugin.default.definition.loose}`,
+      '[percy] Error: Command not found "dotnet"'
+    ]));
   });
 
   describe('maybeInjectMaestroServer', () => {

--- a/packages/cli-exec/src/exec.js
+++ b/packages/cli-exec/src/exec.js
@@ -8,7 +8,7 @@ import { waitForTimeout } from '@percy/client/utils';
 
 export const exec = command('exec', {
   description: 'Start and stop Percy around a supplied command',
-  usage: '[options] -- <command>',
+  usage: '[options] [--] <command>',
   commands: [start, stop, ping, replay],
 
   flags: [{


### PR DESCRIPTION
## Summary
- Some environments strip the `--` separator before argv reaches the CLI (notably npm's npx PowerShell shim on Windows), which made `percy app:exec -- dotnet test` fail with `ParseError: Unexpected argument 'dotnet'` while the equivalent `percy exec` invocation only warned and ran the command.
- Reuse the exec command's `loose` definition for `app:exec` so both commands degrade the same way when the separator is missing.
- Update the `usage` help text of both `exec` and `app:exec` to `[options] [--] <command>` since the separator is now optional for both.

## Known trade-off (deliberate)
With `loose` parsing, `app:exec` no longer hard-rejects unrecognized flags: a typo such as `--allowed-hostname` used to fail with `Unknown option '--allowed-hostname'` and now falls through to command lookup, failing with `Command not found "--allowed-hostname"` after the loose warning. This matches the long-standing behavior of `percy exec` and is the accepted cost of tolerating a stripped `--` separator; it is covered by the `degrades unrecognized exec options into the command (loose parsing trade-off)` spec.

## Test plan
- `yarn test` in `packages/cli-app` — 45/45 specs pass. The `parses loosely when the command separator is missing` spec is hermetic (mocks `which.sync`, no real subprocess) and asserts both the loose warning and that the argv is parsed as a command.
- `yarn test` in `packages/cli-exec` — 40/40 specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
