### PR TITLE
fix(ci): notarytool does not support altool's @env: password syntax

### DIFF
--- a/scripts/executable.sh
+++ b/scripts/executable.sh
@@ -76,10 +76,13 @@ if [ -n "${APPLE_DEV_CERT:-}" ]; then
   mv percy-osx percy
   zip percy-osx.zip percy
 
-  # Read the Apple app-specific password from the environment via notarytool's
-  # `@env:` prefix instead of passing it as a CLI argument, so it is not visible
-  # in the process table / `ps aux` (CWE-214).
-  xcrun notarytool submit --apple-id "$APPLE_ID_USERNAME" --password "@env:APPLE_ID_KEY" --team-id "$APPLE_TEAM_ID" percy-osx.zip --wait
+  # NOTE: `@env:VAR` is altool syntax — notarytool does NOT support it and
+  # treats the string as the literal password, so every submission 401s
+  # (this broke the v1.32.3 release). Pass the expanded value instead; argv
+  # visibility (CWE-214) is a non-issue on an ephemeral single-tenant runner,
+  # and GitHub masks the secret in logs. For stronger hardening later, use an
+  # App Store Connect API key (--key/--key-id/--issuer) or --keychain-profile.
+  xcrun notarytool submit --apple-id "$APPLE_ID_USERNAME" --password "$APPLE_ID_KEY" --team-id "$APPLE_TEAM_ID" percy-osx.zip --wait
 
   cleanup
 else


### PR DESCRIPTION
## Summary
- PR #2281 switched the notarization password to `--password "@env:APPLE_ID_KEY"` to keep the secret out of argv (CWE-214), but `@env:`/`@keychain:` prefixes are **altool** syntax — `notarytool --help` documents only a literal password (or interactive prompt / `--keychain-profile`).
- As a result notarytool sent the literal string `@env:APPLE_ID_KEY` as the password, so every submission failed with `HTTP status code: 401. Invalid credentials.` regardless of the stored secrets — this broke the v1.32.3 release build (first release to run the changed line; v1.32.3-beta.2 predates #2281 and passed).
- Revert to passing the expanded value `"$APPLE_ID_KEY"`. The argv-visibility concern is negligible on an ephemeral single-tenant GitHub runner, and GitHub masks the secret in logs. A follow-up can adopt an App Store Connect API key (`--key/--key-id/--issuer`) or `--keychain-profile` for hardening that notarytool actually supports.

## Test plan
- Reproduced locally: `xcrun notarytool submit --password "@env:APPLE_ID_KEY" ...` → 401; identical invocation with `--password "$APPLE_ID_KEY"` → submission accepted and uploaded.
- `bash -n scripts/executable.sh` passes.
- Note: re-running the failed v1.32.3 release job will NOT pick this up (re-runs build the tag's commit); the release needs to be re-cut on a commit containing this fix, or the v1.32.3 assets notarized manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)