### PR TITLE
fix(core): follow BS App Automate tmp dir relocation for Maestro screenshots

### DIFF
--- a/packages/core/src/maestro-screenshot-file.js
+++ b/packages/core/src/maestro-screenshot-file.js
@@ -2,6 +2,19 @@ import fs from 'fs';
 import path from 'path';
 import { ServerError } from './server.js';
 
+// Root under which BrowserStack App Automate hosts write Maestro session
+// artifacts (screenshots + debug output). Historically /tmp; hosts that
+// relocate it inject PERCY_APP_AUTOMATE_TMP_DIR with the new root, so the
+// location is never hardcoded here and can move again without a CLI release.
+// Trailing separators are trimmed so glob patterns and the realpath prefix
+// check compose cleanly; a non-absolute value falls back to /tmp rather than
+// producing a cwd-relative glob. BrowserStack-mode only — self-hosted scoping
+// stays on PERCY_MAESTRO_SCREENSHOT_DIR.
+export function appAutomateTmpDir() {
+  let dir = (process.env.PERCY_APP_AUTOMATE_TMP_DIR || '/tmp').replace(/[/\\]+$/, '');
+  return path.isAbsolute(dir) ? dir : '/tmp';
+}
+
 /* istanbul ignore next — defensive manual directory walker invoked only when
    fast-glob import fails (broken install / FS corruption). Unit tests
    exercise the primary glob path; integration tests on BS hosts exercise
@@ -12,7 +25,7 @@ async function manualScreenshotWalk(platform, sessionId, name) {
   const files = [];
   try {
     if (platform === 'ios') {
-      const sessionDir = `/tmp/${sessionId}`;
+      const sessionDir = `${appAutomateTmpDir()}/${sessionId}`;
       const walk = async (dir, depth) => {
         if (depth > 15) return; // sanity cap
         let entries;
@@ -28,7 +41,7 @@ async function manualScreenshotWalk(platform, sessionId, name) {
       };
       await walk(sessionDir, 0);
     } else {
-      const baseDir = `/tmp/${sessionId}_test_suite/logs`;
+      const baseDir = `${appAutomateTmpDir()}/${sessionId}_test_suite/logs`;
       const logDirs = await fs.promises.readdir(baseDir);
       for (const dir of logDirs) {
         const screenshotPath = path.join(baseDir, dir, 'screenshots', `${name}.png`);
@@ -58,9 +71,9 @@ export async function locateScreenshot({ platform, sessionId, name, filePath, sc
   if (filePath) {
     chosenFile = filePath;
   } else {
-    // Glob pattern depends on deployment shape:
-    //   BrowserStack Android: /tmp/{sid}_test_suite/logs/*/screenshots/{name}.png
-    //   BrowserStack iOS:     /tmp/{sid}/<maestro_debug_dir>/**/{name}.png
+    // Glob pattern depends on deployment shape (TMP = appAutomateTmpDir()):
+    //   BrowserStack Android: {TMP}/{sid}_test_suite/logs/*/screenshots/{name}.png
+    //   BrowserStack iOS:     {TMP}/{sid}/<maestro_debug_dir>/**/{name}.png
     //     (realmobile builds a deeply nested {device}_maestro_debug_ tree; `**`
     //     handles any depth, exact {name}.png filters Maestro's emoji-prefixed
     //     debug frames, e.g. `screenshot-❌-<timestamp>-(flow).png`).
@@ -75,9 +88,12 @@ export async function locateScreenshot({ platform, sessionId, name, filePath, sc
       const globRoot = scopeRoot.replace(/\\/g, '/');
       searchPattern = `${globRoot}/**/${name}.png`;
     } else {
+      // Same forward-slash normalization as the self-hosted branch — the env
+      // override could carry backslashes when exercised on Windows CI.
+      const tmpRoot = appAutomateTmpDir().replace(/\\/g, '/');
       searchPattern = platform === 'ios'
-        ? `/tmp/${sessionId}/*_maestro_debug_*/**/${name}.png`
-        : `/tmp/${sessionId}_test_suite/logs/*/screenshots/${name}.png`;
+        ? `${tmpRoot}/${sessionId}/*_maestro_debug_*/**/${name}.png`
+        : `${tmpRoot}/${sessionId}_test_suite/logs/*/screenshots/${name}.png`;
     }
 
     let files;
@@ -122,7 +138,8 @@ export async function locateScreenshot({ platform, sessionId, name, filePath, sc
 
   // Canonicalize and confirm the resolved path still lives under scopeRoot.
   // Defeats symlink swaps where the root points elsewhere. Both ends are
-  // realpath'd because /tmp is a symlink on macOS (where iOS hosts run). The
+  // realpath'd because the tmp root can resolve through a symlink (as /tmp
+  // does on macOS, where iOS hosts run). The
   // trailing `/` on the prefix is load-bearing — it prevents sibling-prefix
   // bypass (e.g. /x/.maestro vs /x/.maestro-secrets). Both sides are
   // normalized to forward-slashes so the check works on Windows (real-fs

--- a/packages/core/src/maestro-screenshot.js
+++ b/packages/core/src/maestro-screenshot.js
@@ -4,7 +4,7 @@ import { normalize } from '@percy/config/utils';
 import { ServerError } from './server.js';
 import { encodeURLSearchParams } from './utils.js';
 import { handleSyncJob } from './snapshot.js';
-import { locateScreenshot } from './maestro-screenshot-file.js';
+import { locateScreenshot, appAutomateTmpDir } from './maestro-screenshot-file.js';
 import { validateRegionInputs, resolveRegions } from './maestro-regions.js';
 import { deriveDeviceInsets } from './maestro-hierarchy.js';
 
@@ -90,7 +90,8 @@ export async function handleMaestroScreenshot(req, res, percy) {
   }
 
   // Resolve the file-find scope root. On BrowserStack (sessionId present), the
-  // root is the BS host's /tmp/{sessionId}{_test_suite} convention. Self-hosted
+  // root is the BS host's {appAutomateTmpDir()}/{sessionId}{_test_suite}
+  // convention (PERCY_APP_AUTOMATE_TMP_DIR, defaulting to /tmp). Self-hosted
   // (sessionId absent) requires PERCY_MAESTRO_SCREENSHOT_DIR (read from
   // process.env, never the request body) to be an absolute, existing directory
   // — typically the customer's `maestro test --test-output-dir <DIR>` path. The
@@ -125,8 +126,8 @@ export async function handleMaestroScreenshot(req, res, percy) {
     scopeRoot = dir;
   } else {
     scopeRoot = platform === 'ios'
-      ? `/tmp/${sessionId}`
-      : `/tmp/${sessionId}_test_suite`;
+      ? `${appAutomateTmpDir()}/${sessionId}`
+      : `${appAutomateTmpDir()}/${sessionId}_test_suite`;
   }
 
   // Validate regions input shape early (before file I/O and ADB work) so

--- a/packages/core/test/api.test.js
+++ b/packages/core/test/api.test.js
@@ -5,6 +5,7 @@ import { logger, setupTest, fs } from './helpers/index.js';
 import Percy from '@percy/core';
 import WebdriverUtils from '@percy/webdriver-utils';
 import { getPercyDomPath, _applyHttpReadOnlyStripping } from '../src/api.js';
+import { appAutomateTmpDir } from '../src/maestro-screenshot-file.js';
 
 describe('API Server', () => {
   let percy;
@@ -24,7 +25,7 @@ describe('API Server', () => {
     // suite (works in isolation; returns [] mid-suite), so route the
     // self-hosted root to the REAL filesystem — this also tests the true
     // production glob path. Only paths under this unique root are affected.
-    await setupTest({ filesystem: { $bypass: [p => typeof p === 'string' && p.includes('percy-self-hosted-real')] } });
+    await setupTest({ filesystem: { $bypass: [p => typeof p === 'string' && (p.includes('percy-self-hosted-real') || p.includes('percy-bs-tmp-real'))] } });
 
     percy = new Percy({
       token: 'PERCY_TOKEN',
@@ -1269,11 +1270,14 @@ describe('API Server', () => {
   describe('/percy/maestro-screenshot', () => {
     const SID = 'testsession';
     const SS_NAME = 'HomeScreen';
-    const ANDROID_DIR = `/tmp/${SID}_test_suite/logs/run1/screenshots`;
-    const IOS_DIR = `/tmp/${SID}/emu_maestro_debug_abc/flow_x`;
-    // New SDK convention (filePath path): /tmp/<sid>{_test_suite}/percy/<name>.png
-    const ANDROID_FILEPATH_DIR = `/tmp/${SID}_test_suite/percy`;
-    const IOS_FILEPATH_DIR = `/tmp/${SID}/percy`;
+    // Default BS App Automate tmp root when PERCY_APP_AUTOMATE_TMP_DIR is
+    // unset (the legacy /tmp convention)
+    const TMP_ROOT = '/tmp';
+    const ANDROID_DIR = `${TMP_ROOT}/${SID}_test_suite/logs/run1/screenshots`;
+    const IOS_DIR = `${TMP_ROOT}/${SID}/emu_maestro_debug_abc/flow_x`;
+    // New SDK convention (filePath path): {TMP_ROOT}/<sid>{_test_suite}/percy/<name>.png
+    const ANDROID_FILEPATH_DIR = `${TMP_ROOT}/${SID}_test_suite/percy`;
+    const IOS_FILEPATH_DIR = `${TMP_ROOT}/${SID}/percy`;
     const FILEPATH_NAME = 'FromFilePath';
 
     beforeEach(async () => {
@@ -1786,19 +1790,20 @@ describe('API Server', () => {
     });
 
     it('returns 404 when filePath resolves outside the session root', async () => {
-      // File exists, but lives at /tmp/<other>.png — not under /tmp/<sid>_test_suite/.
-      fs.writeFileSync('/tmp/percy-outside.png', 'OUTSIDE');
+      // File exists, but lives at the tmp root — not under {TMP_ROOT}/<sid>_test_suite/.
+      fs.mkdirSync(TMP_ROOT, { recursive: true });
+      fs.writeFileSync(`${TMP_ROOT}/percy-outside.png`, 'OUTSIDE');
       await percy.start();
       await expectAsync(postMaestro({
         name: SS_NAME,
         sessionId: SID,
         platform: 'android',
-        filePath: '/tmp/percy-outside.png'
+        filePath: `${TMP_ROOT}/percy-outside.png`
       })).toBeRejectedWithError(/Screenshot not found/);
     });
 
     it('returns 404 when filePath is in a different sessionId\'s subtree', async () => {
-      const otherDir = '/tmp/othersession_test_suite/percy';
+      const otherDir = `${TMP_ROOT}/othersession_test_suite/percy`;
       fs.mkdirSync(otherDir, { recursive: true });
       fs.writeFileSync(`${otherDir}/Foo.png`, 'OTHER-SID');
       await percy.start();
@@ -1824,6 +1829,90 @@ describe('API Server', () => {
       let [payload] = percy.upload.calls.mostRecent().args;
       // Glob found the legacy fixture, not the filePath fixture
       expect(payload.tiles[0].content).toBe(Buffer.from('PNGBYTES-ANDROID').toString('base64'));
+    });
+
+    // PERCY_APP_AUTOMATE_TMP_DIR override — BS hosts that relocate the
+    // session tmp root away from /tmp inject the new root via this env var,
+    // so the location is never hardcoded in the CLI.
+    // Real-fs root (matched by the top-level $bypass) — fast-glob caches its
+    // fs bindings on first import, so a memfs-only root created in a later
+    // test is invisible to it; real-fs fixtures sidestep the staleness.
+    describe('PERCY_APP_AUTOMATE_TMP_DIR override', () => {
+      const CUSTOM_ROOT = path.join(os.tmpdir(), 'percy-bs-tmp-real-root');
+      let priorEnv;
+
+      beforeEach(() => {
+        priorEnv = process.env.PERCY_APP_AUTOMATE_TMP_DIR;
+        process.env.PERCY_APP_AUTOMATE_TMP_DIR = CUSTOM_ROOT;
+        fs.rmSync(CUSTOM_ROOT, { recursive: true, force: true });
+        const customAndroidDir = path.join(CUSTOM_ROOT, `${SID}_test_suite`, 'logs', 'run1', 'screenshots');
+        fs.mkdirSync(customAndroidDir, { recursive: true });
+        fs.writeFileSync(path.join(customAndroidDir, `${SS_NAME}.png`), 'PNGBYTES-CUSTOM-ROOT');
+      });
+
+      afterEach(() => {
+        if (priorEnv === undefined) delete process.env.PERCY_APP_AUTOMATE_TMP_DIR;
+        else process.env.PERCY_APP_AUTOMATE_TMP_DIR = priorEnv;
+        fs.rmSync(CUSTOM_ROOT, { recursive: true, force: true });
+      });
+
+      it('globs under the overridden tmp root instead of the default', async () => {
+        spyOn(percy, 'upload').and.resolveTo();
+        await percy.start();
+
+        await expectAsync(postMaestro({ name: SS_NAME, sessionId: SID, platform: 'android' }))
+          .toBeResolvedTo(jasmine.objectContaining({ success: true }));
+
+        let [payload] = percy.upload.calls.mostRecent().args;
+        expect(payload.tiles[0].content).toBe(Buffer.from('PNGBYTES-CUSTOM-ROOT').toString('base64'));
+      });
+
+      it('tolerates a trailing slash on the override', async () => {
+        process.env.PERCY_APP_AUTOMATE_TMP_DIR = `${CUSTOM_ROOT}/`;
+        spyOn(percy, 'upload').and.resolveTo();
+        await percy.start();
+
+        await expectAsync(postMaestro({ name: SS_NAME, sessionId: SID, platform: 'android' }))
+          .toBeResolvedTo(jasmine.objectContaining({ success: true }));
+
+        let [payload] = percy.upload.calls.mostRecent().args;
+        expect(payload.tiles[0].content).toBe(Buffer.from('PNGBYTES-CUSTOM-ROOT').toString('base64'));
+      });
+
+      it('falls back to /tmp when the override is not an absolute path', async () => {
+        process.env.PERCY_APP_AUTOMATE_TMP_DIR = 'relative/path';
+        spyOn(percy, 'upload').and.resolveTo();
+        await percy.start();
+
+        await expectAsync(postMaestro({ name: SS_NAME, sessionId: SID, platform: 'android' }))
+          .toBeResolvedTo(jasmine.objectContaining({ success: true }));
+
+        let [payload] = percy.upload.calls.mostRecent().args;
+        // Found the fixture under the default /tmp root, not a cwd-relative glob
+        expect(payload.tiles[0].content).toBe(Buffer.from('PNGBYTES-ANDROID').toString('base64'));
+      });
+
+      it('pins the trim + fallback semantics of the exported helper', () => {
+        process.env.PERCY_APP_AUTOMATE_TMP_DIR = `${CUSTOM_ROOT}///`;
+        expect(appAutomateTmpDir()).toBe(CUSTOM_ROOT);
+        process.env.PERCY_APP_AUTOMATE_TMP_DIR = '/';
+        expect(appAutomateTmpDir()).toBe('/tmp');
+        delete process.env.PERCY_APP_AUTOMATE_TMP_DIR;
+        expect(appAutomateTmpDir()).toBe('/tmp');
+      });
+
+      it('scopes filePath containment to the overridden root — default-root files 404', async () => {
+        // Fixture exists under the DEFAULT root (created by the outer
+        // beforeEach), but with the override active the session scopeRoot
+        // moved — the default-root file now resolves outside it.
+        await percy.start();
+        await expectAsync(postMaestro({
+          name: FILEPATH_NAME,
+          sessionId: SID,
+          platform: 'android',
+          filePath: `${ANDROID_FILEPATH_DIR}/${FILEPATH_NAME}.png`
+        })).toBeRejectedWithError(/Screenshot not found/);
+      });
     });
 
     // PNG-header fill: relay reads IHDR from the screenshot and populates


### PR DESCRIPTION
## Summary
- BrowserStack hosts relocated the App Automate session directories away from `/tmp/{sessionId}`, breaking the Maestro screenshot relay's hardcoded `/tmp` globs and scope roots — screenshot lookups started 404'ing.
- All BrowserStack-mode paths (glob patterns, manual-walker fallback, and the `scopeRoot` used by the realpath containment check) now route through a new `appAutomateTmpDir()` helper.
- The helper reads a new `PERCY_APP_AUTOMATE_TMP_DIR` env var — injected by the host with the relocated root — and falls back to the legacy `/tmp` convention when unset, so no internal infra path is hardcoded in the CLI and hosts with older injection keep working during rollout. Trailing separators are trimmed, backslashes normalized for the glob, and non-absolute values fall back to `/tmp`.
- Self-hosted mode is untouched — it continues to scope via `PERCY_MAESTRO_SCREENSHOT_DIR`.

## Test plan
- Existing `/percy/maestro-screenshot` specs (Android + iOS globs, `filePath` acceptance/containment, PNG-fill, regions) — all passing against the default root.
- New `PERCY_APP_AUTOMATE_TMP_DIR override` specs: globbing under an overridden root (real-fs fixture), trailing-slash tolerance, non-absolute fallback to `/tmp`, direct trim/fallback assertions on the exported helper, and `filePath` containment re-scoping to the overridden root.
- Full `packages/core/test/api.test.js` run locally: all maestro specs pass; the single unrelated failure (`when the server is disabled…`, ECONNREFUSED vs AggregateError) also fails on a clean master checkout — pre-existing local Node environment issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)