### PR TITLE
fix(deps): clear audit advisories by dropping rimraf/minimatch and bumping fast-xml-parser

### DIFF
--- a/packages/cli-doctor/package.json
+++ b/packages/cli-doctor/package.json
@@ -42,7 +42,6 @@
     "@percy/env": "1.32.5",
     "@percy/logger": "1.32.5",
     "@percy/monitoring": "1.32.5",
-    "minimatch": "^9.0.0",
     "ws": "^8.17.1"
   }
 }

--- a/packages/cli-doctor/src/checks/pac.js
+++ b/packages/cli-doctor/src/checks/pac.js
@@ -3,7 +3,6 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import vm from 'vm';
-import { minimatch } from 'minimatch';
 
 // Test URL used when evaluating PAC scripts
 const PAC_TEST_URL = 'https://percy.io/';
@@ -319,6 +318,47 @@ export function findInObject(obj, key, depth = 0) {
 }
 
 /**
+ * PAC `shExpMatch` shell-expression match.
+ *
+ * The PAC spec defines exactly two wildcards — `*` (any sequence) and `?`
+ * (exactly one character); every other character is a literal. We match them
+ * directly rather than delegating to a general glob library: brace expansion,
+ * character classes and extglobs are not part of shExpMatch, and expanding
+ * them on PAC content — which is untrusted, attacker-influenced input — is a
+ * memory-exhaustion vector (see GHSA-mh99-v99m-4gvg in brace-expansion). The
+ * `vm` timeout below cannot save us there, since it does not interrupt native
+ * allocation inside a host library.
+ *
+ * Greedy single-star backtracking, so worst case is O(str * shexp) with no
+ * regex construction and no catastrophic backtracking.
+ */
+export function shExpMatch(str, shexp) {
+  let s = 0;
+  let p = 0;
+  let star = -1;
+  let resume = 0;
+
+  while (s < str.length) {
+    if (p < shexp.length && (shexp[p] === '?' || shexp[p] === str[s])) {
+      s++; p++;
+    } else if (p < shexp.length && shexp[p] === '*') {
+      star = p++;
+      resume = s;
+    } else if (star !== -1) {
+      // Backtrack: let the last `*` consume one more character.
+      p = star + 1;
+      s = ++resume;
+    } else {
+      return false;
+    }
+  }
+
+  // Trailing `*`s may match the empty string.
+  while (p < shexp.length && shexp[p] === '*') p++;
+  return p === shexp.length;
+}
+
+/**
  * Evaluate a PAC script using Node's built-in `vm` module.
  * Provides minimal shims for the standard PAC helper functions.
  * Returns the string result of FindProxyForURL(url, host).
@@ -356,8 +396,7 @@ export function runPacScript(script, url, host) {
       value: (str, shexp) => {
         if (typeof str !== 'string' || typeof shexp !== 'string') return false;
         if (shexp.length > 256) return false;
-        // minimatch handles * and ? exactly as PAC shExpMatch requires.
-        return minimatch(str, shexp, { dot: true, nocase: false });
+        return shExpMatch(str, shexp);
       },
       enumerable: true
     },

--- a/packages/cli-doctor/test/pac.test.js
+++ b/packages/cli-doctor/test/pac.test.js
@@ -6,7 +6,7 @@
  * full fetch → evaluate → classify pipeline without system config access.
  */
 
-import { runPacScript, findInObject, PACDetector } from '../src/checks/pac.js';
+import { runPacScript, findInObject, PACDetector, shExpMatch } from '../src/checks/pac.js';
 import { createPacServer, createHttpServer, withEnv, buildPacScript } from './helpers.js';
 import childProcess from 'child_process';
 import fsMod from 'fs';
@@ -78,6 +78,68 @@ describe('runPacScript — argument passing', () => {
     `;
     expect(runPacScript(script, 'https://percy.io/', 'percy.io')).toBe('PROXY percy-proxy:8080');
     expect(runPacScript(script, 'https://example.com/', 'example.com')).toBe('DIRECT');
+  });
+});
+
+// ─── shExpMatch — PAC shell-expression semantics ──────────────────────────────
+
+describe('shExpMatch', () => {
+  it('treats * as any sequence and ? as exactly one character', () => {
+    expect(shExpMatch('dev.percy.io', '*.percy.io')).toBe(true);
+    expect(shExpMatch('percy.io', '*.percy.io')).toBe(false);
+    expect(shExpMatch('percy.io', 'percy.i?')).toBe(true);
+    expect(shExpMatch('percy.ioo', 'percy.i?')).toBe(false);
+    expect(shExpMatch('percy.io', 'percy.io')).toBe(true);
+  });
+
+  it('matches the empty string against * and the empty pattern', () => {
+    expect(shExpMatch('', '*')).toBe(true);
+    expect(shExpMatch('', '')).toBe(true);
+    expect(shExpMatch('percy.io', '')).toBe(false);
+    expect(shExpMatch('percy.io', '***')).toBe(true);
+  });
+
+  it('is case-sensitive, per PAC semantics', () => {
+    expect(shExpMatch('Percy.IO', 'percy.io')).toBe(false);
+  });
+
+  // The PAC spec defines only * and ?. Brace expansion, character classes and
+  // extglobs are NOT shExpMatch syntax, so they must match literally rather
+  // than being expanded — expanding attacker-supplied patterns is the
+  // brace-expansion OOM vector (GHSA-mh99-v99m-4gvg).
+  it('treats brace, bracket and extglob syntax as literal characters', () => {
+    expect(shExpMatch('{a,b}', '{a,b}')).toBe(true);
+    expect(shExpMatch('a', '{a,b}')).toBe(false);
+    expect(shExpMatch('b', '{a,b}')).toBe(false);
+    expect(shExpMatch('[abc]', '[abc]')).toBe(true);
+    expect(shExpMatch('a', '[abc]')).toBe(false);
+    expect(shExpMatch('percy.io', '!(percy.io)')).toBe(false);
+    expect(shExpMatch('a+(b)', 'a+(b)')).toBe(true);
+  });
+
+  it('treats regex metacharacters as literals', () => {
+    expect(shExpMatch('a.c', 'a.c')).toBe(true);
+    expect(shExpMatch('abc', 'a.c')).toBe(false);
+    expect(shExpMatch('a$^(b)', 'a$^(b)')).toBe(true);
+  });
+
+  it('returns promptly for brace-bomb and backtracking-heavy patterns', () => {
+    // Nested braces well under the 256-char sandbox cap: expanding these would
+    // exhaust memory, and `vm`'s timeout cannot interrupt native allocation.
+    const target = 'a'.repeat(200);
+    const braceBomb = '{a,b}'.repeat(40);
+    const starBomb = '*a'.repeat(100);
+    const start = process.hrtime.bigint();
+
+    // Literal braces, so no expansion and no match.
+    expect(shExpMatch(target, braceBomb)).toBe(false);
+    // 100 stars still resolve correctly, both matching and — the worst case for
+    // backtracking — failing only at the very last pattern character.
+    expect(shExpMatch(target, starBomb)).toBe(true);
+    expect(shExpMatch(target, starBomb + 'b')).toBe(false);
+
+    const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+    expect(elapsedMs).toBeLessThan(1000);
   });
 });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,7 @@
     "content-disposition": "^0.5.4",
     "cross-spawn": "^7.0.3",
     "fast-glob": "^3.2.11",
-    "fast-xml-parser": "^5.7.0",
+    "fast-xml-parser": "^4.5.7",
     "micromatch": "^4.0.8",
     "mime-types": "^2.1.34",
     "pako": "^2.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,12 +57,11 @@
     "content-disposition": "^0.5.4",
     "cross-spawn": "^7.0.3",
     "fast-glob": "^3.2.11",
-    "fast-xml-parser": "^4.4.1",
+    "fast-xml-parser": "^5.7.0",
     "micromatch": "^4.0.8",
     "mime-types": "^2.1.34",
     "pako": "^2.1.0",
     "path-to-regexp": "^6.3.0",
-    "rimraf": "^3.0.2",
     "ws": "^8.17.1",
     "yaml": "^2.4.1"
   },

--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -5,7 +5,6 @@ import { execFileSync } from 'child_process';
 import spawn from 'cross-spawn';
 import EventEmitter from 'events';
 import WebSocket from 'ws';
-import rimraf from 'rimraf';
 import logger from '@percy/logger';
 import install from './install.js';
 import { MAX_CDP_PAYLOAD } from './network.js';
@@ -189,9 +188,14 @@ export class Browser extends EventEmitter {
       /* istanbul ignore next:
        *   this might fail on some systems but ultimately it is just a temp file */
       if (this.profile) {
-        // attempt to clean up the profile directory
-        return new Promise((resolve, reject) => {
-          rimraf(this.profile, e => e ? reject(e) : resolve());
+        // attempt to clean up the profile directory. maxRetries mirrors the
+        // busy-retry behaviour rimraf gave us: on Windows the profile dir is
+        // often still locked for a moment after the browser process exits.
+        return fs.promises.rm(this.profile, {
+          recursive: true,
+          force: true,
+          maxRetries: 3,
+          retryDelay: 100
         }).catch(error => {
           this.log.debug('Could not clean up temporary browser profile directory.');
           this.log.debug(error);

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -75,14 +75,15 @@ async function main({
   let testBrowsers = browsers != null ? browsers : (!node && pkg.browser);
 
   if (coverage) {
-    // $ rimraf <cwd>/{.nyc_output,coverage} || true &&
+    // $ rm -rf <cwd>/{.nyc_output,coverage} || true &&
     //   nyc --silent --no-clean node <root>/test.js ... &&
     //   nyc report --reporter <reporter>
     let flags = flagify({ node, browsers });
     let nycbin = path.resolve(filename, '../../node_modules/.bin/nyc');
-    let { default: rimraf } = await import('rimraf');
 
-    await new Promise(r => rimraf(path.join(cwd, '{.nyc_output,coverage}'), r));
+    for (let dir of ['.nyc_output', 'coverage']) {
+      await fs.promises.rm(path.join(cwd, dir), { recursive: true, force: true });
+    }
     await child('spawn', nycbin, ['--silent', '--no-clean', 'node', filename, ...flags]);
     await child('spawn', nycbin, ['report', '--check-coverage', ...flagify({ reporter })]);
   } else if (!process.send) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1946,6 +1946,11 @@
   dependencies:
     eslint-scope "5.1.1"
 
+"@nodable/entities@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-3.0.0.tgz#694703bc864d30eaed55c2e3def00dbd61493670"
+  integrity sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -2647,6 +2652,11 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+anynum@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/anynum/-/anynum-1.0.1.tgz#2aac00e08dfad3726c1d462e60dbc2f831659a44"
+  integrity sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==
+
 append-transform@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz"
@@ -2958,13 +2968,6 @@ brace-expansion@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz"
   integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
-  dependencies:
-    balanced-match "^1.0.0"
-
-brace-expansion@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
   dependencies:
     balanced-match "^1.0.0"
 
@@ -4362,12 +4365,25 @@ fast-uri@^3.0.1:
   resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz"
   integrity sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==
 
-fast-xml-parser@^4.4.1:
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz#4ff57d4aca13a2d11aa42ad460495cf00f32b655"
-  integrity sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==
+fast-xml-builder@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz#bc849804796fe47bf915022dd939b0fc30ba455d"
+  integrity sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==
   dependencies:
-    strnum "^1.0.5"
+    path-expression-matcher "^1.6.2"
+    xml-naming "^0.3.0"
+
+fast-xml-parser@^5.7.0:
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz#19313f7c9386c47fa4a1de527547b73ed2cfcede"
+  integrity sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==
+  dependencies:
+    "@nodable/entities" "^3.0.0"
+    fast-xml-builder "^1.2.0"
+    is-unsafe "^2.0.0"
+    path-expression-matcher "^1.6.2"
+    strnum "^2.4.1"
+    xml-naming "^0.3.0"
 
 fastq@^1.6.0:
   version "1.13.0"
@@ -5460,6 +5476,11 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
+is-unsafe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-2.0.0.tgz#c0dce4e06742662dde26360160e414ea487da2e9"
+  integrity sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==
+
 is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz"
@@ -6202,13 +6223,6 @@ minimatch@^8.0.2:
   integrity sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==
   dependencies:
     brace-expansion "^2.0.1"
-
-minimatch@^9.0.0:
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
-  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
-  dependencies:
-    brace-expansion "^2.0.2"
 
 minimist-options@4.1.0:
   version "4.1.0"
@@ -7008,6 +7022,11 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-expression-matcher@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz#567c73c07197e9dcef24e90edcdc571056599168"
+  integrity sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -8021,10 +8040,12 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-strnum@^1.0.5:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.1.2.tgz#57bca4fbaa6f271081715dbc9ed7cee5493e28e4"
-  integrity sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==
+strnum@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.4.1.tgz#85417f683113badea0fe7e17227676f889ff7e58"
+  integrity sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==
+  dependencies:
+    anynum "^1.0.1"
 
 strong-log-transformer@^2.1.0:
   version "2.1.0"
@@ -8672,6 +8693,11 @@ ws@~8.17.1:
   version "8.17.1"
   resolved "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz"
   integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+
+xml-naming@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.3.0.tgz#46c1e18bfe2858479982dd2accf34d16e749eda2"
+  integrity sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==
 
 xtend@~4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1946,11 +1946,6 @@
   dependencies:
     eslint-scope "5.1.1"
 
-"@nodable/entities@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-3.0.0.tgz#694703bc864d30eaed55c2e3def00dbd61493670"
-  integrity sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -2651,11 +2646,6 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
-
-anynum@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/anynum/-/anynum-1.0.1.tgz#2aac00e08dfad3726c1d462e60dbc2f831659a44"
-  integrity sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==
 
 append-transform@^2.0.0:
   version "2.0.0"
@@ -4365,25 +4355,12 @@ fast-uri@^3.0.1:
   resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz"
   integrity sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==
 
-fast-xml-builder@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz#bc849804796fe47bf915022dd939b0fc30ba455d"
-  integrity sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==
+fast-xml-parser@^4.5.7:
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.7.tgz#ba3479a1eca8abf2cc3e54af254fae6f1f115021"
+  integrity sha512-a6Qh1RMCNbSrU1+sAyAAZH3rTe+OaWJbNZIq0S+ifZciUUOQtlVxBJwoTUE2bYhysmG/RYyI5WJFIKdBahJdrQ==
   dependencies:
-    path-expression-matcher "^1.6.2"
-    xml-naming "^0.3.0"
-
-fast-xml-parser@^5.7.0:
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz#19313f7c9386c47fa4a1de527547b73ed2cfcede"
-  integrity sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==
-  dependencies:
-    "@nodable/entities" "^3.0.0"
-    fast-xml-builder "^1.2.0"
-    is-unsafe "^2.0.0"
-    path-expression-matcher "^1.6.2"
-    strnum "^2.4.1"
-    xml-naming "^0.3.0"
+    strnum "^1.0.5"
 
 fastq@^1.6.0:
   version "1.13.0"
@@ -5475,11 +5452,6 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
-
-is-unsafe@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-2.0.0.tgz#c0dce4e06742662dde26360160e414ea487da2e9"
-  integrity sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==
 
 is-weakref@^1.0.2:
   version "1.0.2"
@@ -7023,11 +6995,6 @@ path-exists@^4.0.0:
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-expression-matcher@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz#567c73c07197e9dcef24e90edcdc571056599168"
-  integrity sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==
-
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
@@ -8040,12 +8007,10 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-strnum@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.4.1.tgz#85417f683113badea0fe7e17227676f889ff7e58"
-  integrity sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==
-  dependencies:
-    anynum "^1.0.1"
+strnum@^1.0.5:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.1.2.tgz#57bca4fbaa6f271081715dbc9ed7cee5493e28e4"
+  integrity sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==
 
 strong-log-transformer@^2.1.0:
   version "2.1.0"
@@ -8693,11 +8658,6 @@ ws@~8.17.1:
   version "8.17.1"
   resolved "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz"
   integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
-
-xml-naming@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.3.0.tgz#46c1e18bfe2858479982dd2accf34d16e749eda2"
-  integrity sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## Problem

`yarn audit --groups dependencies` on the **published production closure** reported 5 advisories (4 high, 1 moderate). All reached us transitively:

| Advisory | Path |
|---|---|
| `brace-expansion` (ReDoS) | `minimatch` ← `glob` ← `rimraf@3` (`@percy/core`) |
| `brace-expansion` (ReDoS) | `minimatch@9` (`@percy/cli-doctor`) |
| `inflight` (memory leak) | `glob` ← `rimraf@3` |
| `fast-xml-parser` | direct dependency of `@percy/core` |

## Why not the override the ticket recommends

PER-10247 recommends pinning `brace-expansion@1 → 1.1.12` / `@2 → 2.0.2` via `resolutions`. **That does not clear the audit** — only `5.0.8` satisfies the advisory, and 5.0.8 requires **Node 20+**. Requiring a newer Node is exactly what broke the reporting customer, so re-pinning trades one break for another. This PR removes the dependency chains instead.

## Changes

- **`@percy/core`: drop `rimraf@3`.** `Browser#close` cleans the temp profile with `fs.promises.rm({ recursive: true, force: true, maxRetries: 3, retryDelay: 100 })`. The retry options preserve rimraf's busy-retry behaviour — on Windows the profile dir stays locked briefly after the browser exits, and a plain `rm` would throw `EBUSY`.
- **`scripts/test.js`:** same swap for the coverage-dir cleanup (the only other `rimraf` consumer).
- **`@percy/cli-doctor`: drop `minimatch@9`.** The PAC check only needed `shExpMatch` semantics (`*` and `?` — no `**`, braces, or character classes), so it is a small self-contained matcher now. 6 new specs cover the semantics, including the cases where `shExpMatch` and minimatch differ.
- **`@percy/core`: `fast-xml-parser` `^4.4.1` → `^4.5.7`.**

### On fast-xml-parser: why 4.5.7 and not 5.x

My first push bumped this to `^5.7.0` and **broke `yarn install` on every CI job**, all of which pin Node 14:

```
error xml-naming@0.3.0: The engine "node" is incompatible with this module.
Expected version ">=16.0.0". Got "14.21.3"
```

`^5.7.0` floats to 5.10.1, which depends on `xml-naming` (engines `>=16`). Pinning fxp alone does not help — 5.7.x depends on `fast-xml-builder ^1.1.7`, and `fast-xml-builder@1.2.0+` pulls `xml-naming` in as well. Holding Node 14 on 5.x would require a `resolutions` pin on a **dependency-of-a-dependency** — the same class of fragile pin this PR set out to avoid.

So this takes the top of the 4.x line (4.5.7, npm `legacy` tag), which clears every fast-xml-parser advisory that has a 4.x fix: `GHSA-m7jm` (CRITICAL, patched 4.5.4), `GHSA-8gc5` (HIGH, 4.5.5), `GHSA-jp2q` (MODERATE, 4.5.5), `GHSA-fj3w` (LOW, 4.5.4).

**One advisory remains and is deliberately accepted:** `GHSA-gh4j-gqv2-49f6` (MODERATE, vulnerable range `< 5.7.0`) — XMLBuilder comment/CDATA injection via unescaped delimiters. It is **not reachable from our code**: `maestro-hierarchy.js` is the only consumer, it imports `XMLParser` only (never `XMLBuilder`), and parses with `processEntities: false`.

So the honest score is **5 advisories → 1**, not zero.

**Decision: hold at 4.5.7 until the Node floor moves to ≥16.** Reaching literal zero is not viable today:

- Every published package declares `"engines": { "node": ">=14" }`. fxp ≥5.7.0 transitively requires Node ≥16, so shipping it would violate our own published contract.
- A root `resolutions` pin on `fast-xml-builder` (to keep `xml-naming` out) **does not help consumers** — `resolutions`/`overrides` are not published. A customer running `npm install @percy/cli` resolves from our declared ranges, pulls `fast-xml-builder@1.3.0` → `xml-naming` (`>=16`), and hits the same engine failure CI hit. That would clean our audit while degrading their install — the exact failure mode PER-10247 was filed about.

The remaining advisory is unreachable in our code, so this is a documented accept, to be revisited when the Node floor is raised.

## Verification

- **Production closure computed from `yarn.lock`** (127 external packages, prod deps only, seeded from each workspace package's `dependencies`): `rimraf`, `minimatch`, `glob`, `inflight`, `brace-expansion` all **absent**; no Node-16-only package present; `fast-xml-parser` resolves to 4.5.7 with `strnum@1.1.2` as its only dependency (`strnum` has no advisories).
- **`@percy/cli-doctor`: 514/514 specs pass** (508 existing + 6 new). Independent confirmation that `minimatch@9` is gone: master's `pac.js` can no longer even load in this tree.
- **Repo-wide lint clean.**
- **`fs.promises.rm` behaviour checked directly:** recursive delete, missing-path tolerance under `force`, and that `maxRetries`/`retryDelay` are accepted on our Node floor.
- **`@percy/core` suite: gating on CI.** Local runs here are contaminated by leftover real temp dirs (`percy-self-hosted-real-root`, `percy-bs-tmp-real-root`) from an earlier crashed run: core mocks `fs` with memfs, so the `fs.rmSync(recursive, force)` cleanup in `api.test.js` cannot clear real leftovers, and the whole maestro self-hosted group then 404s. Those paths do not exist on a fresh CI machine, where `force: true` no-ops. Please gate on the CI result rather than my local run.

Ref: PER-10247

🤖 Generated with [Claude Code](https://claude.com/claude-code)
