### PR TITLE
chore(security): add hardened .npmrc.sample (PER-9672)

### DIFF
--- a/.npmrc.sample
+++ b/.npmrc.sample
@@ -1,0 +1,6 @@
+ignore-scripts=true
+strict-ssl=true
+save-exact=true
+engine-strict=true
+legacy-peer-deps=false
+audit-level=high


### PR DESCRIPTION
Adds a hardened `.npmrc.sample` flagged missing by the Enigma npmrc audit (PER-9672).

Directives:
- `ignore-scripts=true` — block install-time lifecycle scripts (supply-chain)
- `strict-ssl=true`, `audit-level=high`, `save-exact=true`, `engine-strict=true`, `legacy-peer-deps=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)