### PR TITLE
feat(cli-exec): add --fail-on-error so CI fails when Percy can't start

### DIFF
--- a/packages/cli-exec/src/exec.js
+++ b/packages/cli-exec/src/exec.js
@@ -22,6 +22,10 @@ export const exec = command('exec', {
     description: 'Marks the build as a partial build',
     parse: () => !!(process.env.PERCY_PARTIAL_BUILD ||= '1')
   }, {
+    name: 'fail-on-error',
+    description: 'Exit non-zero when Percy fails to start, even if the command succeeds',
+    parse: () => !!(process.env.PERCY_FAIL_ON_ERROR ||= 'true')
+  }, {
     name: 'archive-dir',
     description: 'Save snapshot data to an archive directory for deferred upload',
     percyrc: 'percy.archiveDir',
@@ -65,6 +69,12 @@ export const exec = command('exec', {
     exit(127, `Command not found "${command}"`, false);
   }
 
+  // Tracks a Percy startup failure so `--fail-on-error` can surface it as a non-zero
+  // exit after the wrapped command has run. Keyed off the thrown error rather than
+  // scraped error logs, which also carry non-fatal diagnostics (e.g. the error-analysis
+  // and build-log upload side channels) that must not fail a CI run.
+  let startError = null;
+
   // attempt to start percy if enabled
   if (!percy) {
     log.warn('Percy is disabled');
@@ -101,6 +111,7 @@ export const exec = command('exec', {
       yield* percy.yield.start();
     } catch (error) {
       if (error.name === 'AbortError') throw error;
+      startError = error;
       log.warn('Skipping visual tests');
       log.error(error);
     }
@@ -124,8 +135,19 @@ export const exec = command('exec', {
   await percy?.stop(force);
 
   log.info(`Command "${[command, ...args].join(' ')}" exited with status: ${status}`);
-  // forward any returned status code
+  // forward any returned status code — the wrapped command's own failure takes
+  // priority over a Percy startup failure, since it is the more specific signal
   if (status) exit(status, error, false);
+
+  // Opt-in: fail the run when Percy never started, so a CI pipeline does not report
+  // success for a build that produced no visual coverage. Default behavior is
+  // unchanged — without the flag the wrapped command's status is still the only
+  // thing that determines the exit code.
+  let failOnError = flags.failOnError || process.env.PERCY_FAIL_ON_ERROR === 'true';
+
+  if (failOnError && startError) {
+    exit(1, 'Percy failed to start and --fail-on-error was set; no visual tests ran', false);
+  }
 
   // force exit post timeout
   await waitForTimeout(10000);

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -212,6 +212,68 @@ describe('percy exec', () => {
     ]));
   });
 
+  describe('--fail-on-error', () => {
+    afterEach(() => {
+      delete process.env.PERCY_FAIL_ON_ERROR;
+    });
+
+    it('exits non-zero when percy fails to start', async () => {
+      delete process.env.PERCY_TOKEN;
+
+      await expectAsync(
+        exec(['--fail-on-error', '--', 'node', '--eval', ''])
+      ).toBeRejectedWithError(
+        'Percy failed to start and --fail-on-error was set; no visual tests ran'
+      );
+
+      // the wrapped command still runs — only the exit code changes
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Running "node --eval "'
+      ]));
+      expect(logger.stderr).toEqual(jasmine.arrayContaining([
+        '[percy] Skipping visual tests'
+      ]));
+    });
+
+    it('exits non-zero when PERCY_FAIL_ON_ERROR is set without the flag', async () => {
+      delete process.env.PERCY_TOKEN;
+      process.env.PERCY_FAIL_ON_ERROR = 'true';
+
+      await expectAsync(
+        exec(['--', 'node', '--eval', ''])
+      ).toBeRejectedWithError(
+        'Percy failed to start and --fail-on-error was set; no visual tests ran'
+      );
+    });
+
+    it('exits zero when percy starts successfully', async () => {
+      await exec(['--fail-on-error', '--', 'node', '--eval', '']);
+
+      expect(logger.stdout).toEqual(jasmine.arrayContaining([
+        '[percy] Command "node --eval " exited with status: 0'
+      ]));
+    });
+
+    it('forwards the command status ahead of a percy start failure', async () => {
+      delete process.env.PERCY_TOKEN;
+
+      // the wrapped command's own status is the more specific signal, so it wins
+      await expectAsync(
+        exec(['--fail-on-error', '--', 'node', '--eval', 'process.exit(3)'])
+      ).toBeRejectedWithError('EEXIT: 3');
+    });
+
+    it('does not affect the exit code when the flag is not set', async () => {
+      delete process.env.PERCY_TOKEN;
+
+      await exec(['--', 'node', '--eval', '']);
+
+      expect(logger.stderr).toEqual(jasmine.arrayContaining([
+        '[percy] Skipping visual tests'
+      ]));
+    });
+  });
+
   it('forwards the command status', async () => {
     await expectAsync(
       exec(['--', 'node', '--eval', 'process.exit(3)'])


### PR DESCRIPTION
Refs #1181. **Related to PER-10368 but NOT the fix for it** — see "Provenance" at the bottom.

## Problem

`percy exec` derives its exit code **solely from the wrapped command**. When Percy itself fails to start — invalid/missing token, browser launch failure — the error is logged and then swallowed, and the pipeline reports success:

```
[percy] Skipping visual tests
[percy] Error: Invalid API token.
[percy] Running "echo TESTS RAN"
TESTS RAN
[percy] Command "echo TESTS RAN" exited with status: 0
$ echo $?
0
```

The visual tests silently never ran. This is the long-standing complaint in #1181 (open since 2023).

## Root cause

`packages/cli-exec/src/exec.js`:

- The `catch` around `percy.yield.start()` logs `Skipping visual tests` and continues — the error is discarded.
- The exit code is then taken only from the spawned child: `if (status) exit(status, error, false)`.

So Percy's own error state can never influence the exit code. `PERCY_EXIT_WITH_ZERO_ON_ERROR` is the opposite knob (it forces 0); there was no way to opt *into* failing.

## Fix

Adds an opt-in `--fail-on-error` flag (or `PERCY_FAIL_ON_ERROR=true`) that exits `1` when Percy failed to start.

**Default behavior is unchanged** — without the flag, the wrapped command's status is still the only input to the exit code, so this is not a breaking change for existing pipelines.

Two deliberate design points:

1. **Keyed off the thrown exception, not error-level logs.** Scraping `logger.query(l => l.level === 'error')` looked tempting but would false-positive: `percy.js:869` logs `Unable to analyze error logs` at *error* level from the error-analysis side channel, and that fires on healthy runs. Verified: a real successful build with `--fail-on-error` still exits 0.
2. **The wrapped command's status wins.** If the child exits 3 and Percy also failed to start, the exit code is 3 — the more specific signal.

## Scope

This covers **startup** failures (Percy never started → zero visual coverage). It deliberately does **not** cover:

- Builds that were created but failed server-side — already covered by `percy build:wait`.
- **Per-snapshot capture failures** (e.g. `Could not take DOM snapshot`). These still produce a `finished` build with fewer snapshots and exit 0. That is a real remaining gap, called out here so it is not mistaken for covered.

## Testing

`yarn workspace @percy/cli-exec test` — 78/78 pass, including 5 new specs:

- exits non-zero when percy fails to start
- exits non-zero when `PERCY_FAIL_ON_ERROR` is set without the flag
- exits zero when percy starts successfully
- forwards the command status ahead of a percy start failure
- does not affect the exit code when the flag is not set

Also verified end-to-end against the built CLI:

| scenario | exit |
|---|---|
| invalid token, no flag (default, unchanged) | 0 |
| invalid token, `--fail-on-error` | 1 |
| invalid token, `PERCY_FAIL_ON_ERROR=true` | 1 |
| child exits 3 + `--fail-on-error` | 3 |
| **valid token, successful build, `--fail-on-error`** | **0** |

## Provenance / honest scoping

This started as an investigation into PER-10368 ("Percy errors not failing pipeline"). The ticket's attached screenshot later revealed that customer's actual failure was a **`@percy/dom` bug dropping individual snapshots** — fixed separately in #2372 — not a startup failure. So this PR does **not** resolve PER-10368.

It stands on its own as a fix for #1181, which is a distinct and independently-reported problem. Reviewers should judge it on that basis alone.

## Note for reviewers

#1181 was previously answered with "it's by design; we'll evaluate the need for this in the future." This PR keeps that default intact and only adds an opt-in, but the flag name / whether this should eventually become the default is a product call worth confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)