### PR TITLE
chore: migrate the test harness to Node 22 and cut CI over

### DIFF
--- a/.github/.cache-key
+++ b/.github/.cache-key
@@ -6,5 +6,5 @@
               ;   ;
               /   \
 _____________/_ __ \_____________
-Times we have broken CI: 4
+Times we have broken CI: 5
 Times Windows has broken CI: 99+

--- a/.github/workflows/executable-check.yml
+++ b/.github/workflows/executable-check.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 14
+          node-version: 22
           architecture: x64
       - name: Build executables (no signing, no upload)
         run: ./scripts/executable.sh

--- a/.github/workflows/executable.yml
+++ b/.github/workflows/executable.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 14
+          node-version: 22
           architecture: x64
       - run: ./scripts/executable.sh
         env:
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: 14
+          node-version: 22
       - name: Install resedit
         run: npm install resedit
       - name: Update exe metadata

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: 14
+          node-version: 22
       - uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: |
@@ -32,11 +32,11 @@ jobs:
             packages/*/node_modules
             packages/core/.local-chromium
           key: >
-            ${{ runner.os }}/node-14/
+            ${{ runner.os }}/node-22/
             ${{ hashFiles('.github/.cache-key') }}/
             ${{ hashFiles('**/yarn.lock') }}
           restore-keys: >
-            ${{ runner.os }}/node-14/
+            ${{ runner.os }}/node-22/
             ${{ hashFiles('.github/.cache-key') }}/
       - run: yarn
       - run: yarn lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: 14
+          node-version: 22
       - uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: |
@@ -33,11 +33,11 @@ jobs:
             packages/*/node_modules
             packages/core/.local-chromium
           key: >
-            ${{ runner.os }}/node-14/
+            ${{ runner.os }}/node-22/
             ${{ hashFiles('.github/.cache-key') }}/
             ${{ hashFiles('**/yarn.lock') }}
           restore-keys: >
-            ${{ runner.os }}/node-14/
+            ${{ runner.os }}/node-22/
             ${{ hashFiles('.github/.cache-key') }}/
       - run: yarn
       - run: yarn build
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14]
+        node: [22]
         package:
           - '@percy/env'
           - '@percy/client'
@@ -171,7 +171,7 @@ jobs:
           fetch-depth: 50
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: 14
+          node-version: 22
       - uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: |
@@ -179,11 +179,11 @@ jobs:
             packages/*/node_modules
             packages/core/.local-chromium
           key: >
-            ${{ runner.os }}/node-14/
+            ${{ runner.os }}/node-22/
             ${{ hashFiles('.github/.cache-key') }}/
             ${{ hashFiles('**/yarn.lock') }}
           restore-keys: >
-            ${{ runner.os }}/node-14/
+            ${{ runner.os }}/node-22/
             ${{ hashFiles('.github/.cache-key') }}/
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: 14
+          node-version: 22
       - uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: |
@@ -32,11 +32,11 @@ jobs:
             packages/*/node_modules
             packages/core/.local-chromium
           key: >
-            ${{ runner.os }}/node-14/
+            ${{ runner.os }}/node-22/
             ${{ hashFiles('.github/.cache-key') }}/
             ${{ hashFiles('**/yarn.lock') }}
           restore-keys: >
-            ${{ runner.os }}/node-14/
+            ${{ runner.os }}/node-22/
             ${{ hashFiles('.github/.cache-key') }}/
       - run: yarn
       - run: yarn test:types

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: 14
+          node-version: 22
       - uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: |
@@ -32,11 +32,11 @@ jobs:
             packages/*/node_modules
             packages/core/.local-chromium
           key: >
-            ${{ runner.os }}/node-14/
+            ${{ runner.os }}/node-22/
             ${{ hashFiles('.github/.cache-key') }}/
             ${{ hashFiles('**/yarn.lock') }}
           restore-keys: >
-            ${{ runner.os }}/node-14/
+            ${{ runner.os }}/node-22/
             ${{ hashFiles('.github/.cache-key') }}/
       - run: yarn
       - run: yarn build
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: 14
+          node-version: 22
       - uses: actions/cache@f4b3439a656ba812b8cb417d2d49f9c810103092 # v3.4.0
         with:
           path: |
@@ -93,11 +93,11 @@ jobs:
             packages/*/node_modules
             packages/core/.local-chromium
           key: >
-            ${{ runner.os }}/node-14/
+            ${{ runner.os }}/node-22/
             ${{ hashFiles('.github/.cache-key') }}/
             ${{ hashFiles('**/yarn.lock') }}
           restore-keys: >
-            ${{ runner.os }}/node-14/
+            ${{ runner.os }}/node-22/
             ${{ hashFiles('.github/.cache-key') }}/
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:

--- a/packages/cli-doctor/test/helpers.js
+++ b/packages/cli-doctor/test/helpers.js
@@ -55,6 +55,11 @@ export function createHttpServer(handler) {
  * @param {'block'} [opts.mode]  Return 502 for everything
  * @returns {Promise<{server: net.Server, url: string, port: number, close: function}>}
  */
+// Minimal proxy double. Every response below closes the socket immediately, so
+// each one must say `Connection: close`. Node's http.globalAgent enables
+// keepAlive by default from Node 19, and without that header the client pools
+// the socket and reuses it for the next request — which then fails with
+// ECONNRESET ("socket hang up") because the server already ended it.
 export function createProxyServer(opts = {}) {
   return new Promise((resolve, reject) => {
     const sockets = new Set();
@@ -78,7 +83,9 @@ export function createProxyServer(opts = {}) {
 
         // ── block mode ──────────────────────────────────────────────────────
         if (opts.mode === 'block') {
-          clientSocket.end('HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n');
+          clientSocket.end(
+            'HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\nContent-Length: 0\r\n\r\n'
+          );
           return;
         }
 
@@ -89,6 +96,7 @@ export function createProxyServer(opts = {}) {
             clientSocket.end(
               'HTTP/1.1 407 Proxy Authentication Required\r\n' +
               'Proxy-Authenticate: Basic realm="proxy"\r\n' +
+              'Connection: close\r\n' +
               'Content-Length: 0\r\n\r\n'
             );
             return;
@@ -97,7 +105,8 @@ export function createProxyServer(opts = {}) {
           const [user, pass] = decoded.split(':');
           if (user !== opts.auth.user || pass !== opts.auth.pass) {
             clientSocket.end(
-              'HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: 0\r\n\r\n'
+              'HTTP/1.1 407 Proxy Authentication Required\r\n' +
+              'Connection: close\r\nContent-Length: 0\r\n\r\n'
             );
             return;
           }
@@ -126,7 +135,9 @@ export function createProxyServer(opts = {}) {
 
         // ── Plain HTTP proxy ────────────────────────────────────────────────
         // For non-CONNECT requests just return 200 (sufficient for our tests)
-        clientSocket.end('HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n');
+        clientSocket.end(
+          'HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n'
+        );
       };
 
       clientSocket.on('data', onData);

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -17,8 +17,13 @@ describe('percy exec', () => {
     spyOn(process, 'exit').and.callFake(c => c);
     process.env.PERCY_CLIENT_ERROR_LOGS = false;
 
-    // Ensure global.__MOCK_IMPORTS__ is defined
-    global.__MOCK_IMPORTS__ = global.__MOCK_IMPORTS__ || new Map();
+    // The loader defines this registry when scripts/loader-register.js is
+    // imported. Substituting a plain Map when it is missing would be worse than
+    // useless: the loader would not consult it, so every mock below would
+    // silently no-op while the suite still reported green.
+    if (!global.__MOCK_IMPORTS__) {
+      throw new Error('global.__MOCK_IMPORTS__ is undefined — the test loader is not registered');
+    }
   });
 
   afterEach(() => {
@@ -275,9 +280,14 @@ describe('percy exec', () => {
       '[percy] Finalized build #1: https://percy.io/test/test/123'
     ]));
 
-    expect(logger.instance.query(log => log.debug === 'ci')[0].message).toContain([
-      'Some error with secret: [REDACTED]'
-    ]);
+    // Each 'data' event on the child's stderr becomes its own ci log entry, so
+    // indexing [0] assumes the error arrives in the very first chunk. Node 22
+    // emits an "[UNDICI-EHPA] EnvHttpProxyAgent is experimental" warning ahead
+    // of it, which took that slot; stream chunking makes the position
+    // unreliable in general. Assert the redacted secret is captured somewhere.
+    expect(logger.instance.query(log => log.debug === 'ci')
+      .map(log => log.message).join('')
+    ).toContain('Some error with secret: [REDACTED]');
     expect(stderrSpy).toHaveBeenCalled();
   });
 
@@ -325,15 +335,21 @@ describe('percy exec', () => {
   it('throws when the command receives an error event and stops percy', async () => {
     let { default: EventEmitter } = await import('events');
     let [e, err] = [new EventEmitter(), new Error('spawn error')];
-    let crossSpawn = () => (setImmediate(() => e.emit('error', err)), e);
+    // A spy, not a bare function: spawning the nonexistent `foobar` below fails
+    // with the real cross-spawn too, so without an assertion on the double this
+    // spec would pass even when the loader mock never applied.
+    let crossSpawn = jasmine.createSpy('crossSpawn').and.callFake(() => (
+      setImmediate(() => e.emit('error', err)), e
+    ));
     global.__MOCK_IMPORTS__.set('cross-spawn', { default: crossSpawn });
 
     let stdinSpy = spyOn(process.stdin, 'pipe').and.resolveTo('some response');
 
     await expectAsync(exec(['--', 'foobar'])).toBeRejected();
 
+    // proves the loader mock actually applied (see §9.1 of the migration plan)
+    expect(crossSpawn).toHaveBeenCalled();
     expect(stdinSpy).toHaveBeenCalled();
-    console.log(logger.stderr);
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
       '[percy] Detected error for percy build',
       '[percy] Failure: Snapshot command was not called',

--- a/packages/cli-exec/test/exec.test.js
+++ b/packages/cli-exec/test/exec.test.js
@@ -386,7 +386,7 @@ describe('percy exec', () => {
   });
 
   it('provides the child process with a percy server address env var', async () => {
-    let args = ['--no-warnings', '--input-type=module', '--loader=../../scripts/loader.js'];
+    let args = ['--no-warnings', '--input-type=module', '--import=../../scripts/loader-register.js'];
 
     await exec(['--port=4567', '--', 'node', ...args, '--eval', [
       'import { request } from "../cli-command/src/utils.js";',

--- a/packages/client/test/unit/proxy.test.js
+++ b/packages/client/test/unit/proxy.test.js
@@ -86,7 +86,10 @@ describe('proxy', () => {
       const url = 'http://example.com';
       const options = {};
       process.env.PERCY_PAC_FILE_URL = 'invalid-url';
-      expect(() => proxyAgentFor(url, options)).toThrowError('Failed to initialize PAC proxy: Invalid URL: invalid-url');
+      // Matched as a prefix: Node <18 appends the offending input to the
+      // `Invalid URL` TypeError ("Invalid URL: invalid-url"), Node >=18 does
+      // not. Asserting the full string pins this test to one Node version.
+      expect(() => proxyAgentFor(url, options)).toThrowError(/^Failed to initialize PAC proxy: Invalid URL/);
     });
   });
 });

--- a/packages/config/test/helpers.js
+++ b/packages/config/test/helpers.js
@@ -31,6 +31,28 @@ const INTERNAL_FILE_REG = new RegExp(
 // Used to mock javascript modules
 const JS_FILE_REG = /\.(c|m)?js$/;
 
+// Normalize an fs path argument before matching it against the bypass list.
+//
+// `fs` accepts a path as a string, a Buffer, a `file:` URL, or a file
+// descriptor, but every bypass matcher below is written against a string
+// (`p.includes('node_modules')`, `p.match(INTERNAL_FILE_REG)`). On a URL object
+// those are `undefined`, so the matcher silently returns falsy and the read is
+// routed into the in-memory volume instead of being let through.
+//
+// This matters from Node 22: `module.registerHooks` intercepts `require()` as
+// well as `import` (the old `--experimental-loader` did not), and Node reads
+// CommonJS sources through the public `fs` using a URL. Without this, the first
+// lazy `require()` of a real dependency inside a mockfs block -- cosmiconfig
+// requiring js-yaml to parse a config file -- throws ENOENT.
+//
+// File descriptors are numbers and are passed through untouched, since the
+// descriptor matcher below tests them directly.
+function bypassTarget(filepath) {
+  if (filepath instanceof URL) return url.fileURLToPath(filepath);
+  if (Buffer.isBuffer(filepath)) return filepath.toString('utf8');
+  return filepath;
+}
+
 // Mock and spy on fs methods using an in-memory filesystem
 export async function mockfs({
   // set `true` to allow mocking files within `node_modules` (may cause dynamic import issues)
@@ -76,9 +98,14 @@ export async function mockfs({
   let installFakes = (og, fake) => {
     for (let k in og) {
       if (k in fake && typeof og[k] === 'function' && !FS_CLASSES.includes(k)) {
-        spyOn(og, k).and.callFake((...args) => bypass.some(p => (
-          typeof p === 'function' ? p(...args) : (p === args[0])
-        )) ? og[k].and.originalFn(...args) : fake[k](...args));
+        spyOn(og, k).and.callFake((...args) => {
+          let [filepath, ...rest] = args;
+          let target = bypassTarget(filepath);
+
+          return bypass.some(p => (
+            typeof p === 'function' ? p(target, ...rest) : (p === target)
+          )) ? og[k].and.originalFn(...args) : fake[k](...args);
+        });
       }
     }
   };

--- a/packages/core/post-install.js
+++ b/packages/core/post-install.js
@@ -7,7 +7,9 @@ try {
   } else if (!process.send && fs.existsSync('./src')) {
     // In development, fork this script with the development loader and always install
     await import('child_process').then(cp => cp.fork('./post-install.js', {
-      execArgv: ['--no-warnings', '--loader=../../scripts/loader.js'],
+      // --import (not --loader): the hooks are registered in-process via
+      // module.registerHooks. See scripts/loader-register.js.
+      execArgv: ['--no-warnings', '--import=../../scripts/loader-register.js'],
       env: { PERCY_POSTINSTALL_BROWSER: true }
     }));
   }

--- a/packages/sdk-utils/test/request.test.js
+++ b/packages/sdk-utils/test/request.test.js
@@ -3,11 +3,19 @@ import https from 'https';
 import http from 'http';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Resolve fixtures relative to this file. `__dirname` is unavailable here:
+// Node >=20 detects the module syntax below and (re)parses this file as ESM,
+// where `__dirname` is not defined. Deriving it from `import.meta.url` works
+// on every supported Node version, and avoids redeclaring `__dirname` in the
+// event the file is ever loaded as CJS.
+const testDir = path.dirname(fileURLToPath(import.meta.url));
 
 // NOTE: Although sdk-utils test run in browser as well, we do not run sdk-utils/request test in browsers as we require creation of https server for this test
 const ssl = {
-  cert: fs.readFileSync(path.join(__dirname, 'assets', 'certs', 'test.crt')),
-  key: fs.readFileSync(path.join(__dirname, 'assets', 'certs', 'test.key'))
+  cert: fs.readFileSync(path.join(testDir, 'assets', 'certs', 'test.crt')),
+  key: fs.readFileSync(path.join(testDir, 'assets', 'certs', 'test.key'))
 };
 
 // Returns the port number of a URL object. Defaults to port 443 for https

--- a/packages/sdk-utils/test/request.test.js
+++ b/packages/sdk-utils/test/request.test.js
@@ -3,19 +3,11 @@ import https from 'https';
 import http from 'http';
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
-
-// Resolve fixtures relative to this file. `__dirname` is unavailable here:
-// Node >=20 detects the module syntax below and (re)parses this file as ESM,
-// where `__dirname` is not defined. Deriving it from `import.meta.url` works
-// on every supported Node version, and avoids redeclaring `__dirname` in the
-// event the file is ever loaded as CJS.
-const testDir = path.dirname(fileURLToPath(import.meta.url));
 
 // NOTE: Although sdk-utils test run in browser as well, we do not run sdk-utils/request test in browsers as we require creation of https server for this test
 const ssl = {
-  cert: fs.readFileSync(path.join(testDir, 'assets', 'certs', 'test.crt')),
-  key: fs.readFileSync(path.join(testDir, 'assets', 'certs', 'test.key'))
+  cert: fs.readFileSync(path.join(__dirname, 'assets', 'certs', 'test.crt')),
+  key: fs.readFileSync(path.join(__dirname, 'assets', 'certs', 'test.key'))
 };
 
 // Returns the port number of a URL object. Defaults to port 443 for https

--- a/scripts/executable.sh
+++ b/scripts/executable.sh
@@ -8,7 +8,11 @@ function cleanup {
 }
 
 brew install gnu-sed
-npm install -g pkg
+# vercel/pkg is archived; its final release (5.8.1) ships no Node 22 base
+# binary, so it cannot build this CLI once the toolchain moves off Node 14.
+# @yao-pkg/pkg is the maintained fork; its pkg-fetch v3.6 provides prebuilt
+# Node 22 binaries for linux, macos and win on both x64 and arm64.
+npm install -g @yao-pkg/pkg@6.22.0
 
 yarn install
 yarn build
@@ -47,7 +51,13 @@ cp -R ./build/* packages/
 # Create executables. (No `-d`/`--debug`: it only adds per-file "included as
 # DISCLOSED code / asset content" logging — thousands of lines — without
 # changing the output binaries.)
-pkg ./packages/cli/bin/run.js
+#
+# Targets are pinned explicitly. Unpinned, pkg infers them from the host, so a
+# macOS arm64 runner would silently start emitting an arm64 `percy-osx` — a
+# change to what customers download, which is not this migration's call to make.
+# Keep the published matrix at x64 and move only the embedded Node to 22;
+# whether to add arm64 assets is a separate release decision.
+pkg --targets node22-linux-x64,node22-macos-x64,node22-win-x64 ./packages/cli/bin/run.js
 
 # Rename executables
 mv run-linux percy && chmod +x percy

--- a/scripts/loader-register.js
+++ b/scripts/loader-register.js
@@ -1,0 +1,25 @@
+// Registers the test loader's module customization hooks.
+//
+// Loaded with `node --import` (see scripts/test.js) rather than
+// `--loader scripts/loader.js`, because `--loader` runs its hooks on a
+// dedicated module thread from Node 20.6 onward. The suite's mocking works by
+// sharing `global.__MOCK_IMPORTS__` between the hooks and the specs, which a
+// separate thread cannot do -- tests would see `undefined` and every
+// `__MOCK_IMPORTS__.set()` would throw.
+//
+// `module.registerHooks` (Node >=22.15) runs the hooks synchronously, in-process
+// and in the same realm, which is the behaviour the old `--experimental-loader`
+// had on Node 14. That is why this migration targets 22 and not 20: Node 20 only
+// has the off-thread `module.register`, so it would need the mock registry moved
+// onto a MessagePort with an ack before every dynamic import.
+import { registerHooks } from 'module';
+import { resolve, load } from './loader.js';
+
+if (typeof registerHooks !== 'function') {
+  throw new Error(
+    'The test loader requires module.registerHooks (Node >=22.15). ' +
+    `Running Node ${process.version}.`
+  );
+}
+
+registerHooks({ resolve, load });

--- a/scripts/loader.js
+++ b/scripts/loader.js
@@ -128,6 +128,37 @@ function packageType(filename) {
   return 'commonjs';
 }
 
+// Restore `require.cache` / `require.extensions` on Node 22.
+//
+// Registering a `load` hook makes Node translate CommonJS reached through
+// ESM interop (`import` of a CJS package) via the ESM pipeline rather than the
+// classic CJS loader. The `require` that pipeline builds is missing `cache` and
+// `extensions` -- it carries only `main` and `resolve`. Verified against a
+// bare pass-through `load` hook, so it is not caused by anything this loader
+// does, and it is fixed in Node 24.
+//
+// Nothing can be done from the hook itself: returning no `source` for CommonJS
+// is rejected with ERR_INVALID_RETURN_PROPERTY_VALUE. So patch the two
+// properties back from inside the module, and only for sources that actually
+// reference them -- in practice `import-fresh`, which cosmiconfig requires to
+// load .percy.js config files, and which throws
+// "Cannot read properties of undefined" on `require.cache[filePath]`.
+const REQUIRE_STATICS_REG = /require\.(cache|extensions)\b/;
+
+const REQUIRE_STATICS_PRELUDE =
+  'if(!require.cache){const m=require("module");' +
+  'require.cache=m._cache;require.extensions=m._extensions;}';
+
+function restoreRequireStatics(result, format) {
+  if (format !== 'commonjs' || result.source == null) return result;
+
+  let source = typeof result.source === 'string'
+    ? result.source : Buffer.from(result.source).toString('utf8');
+  if (!REQUIRE_STATICS_REG.test(source)) return result;
+
+  return { ...result, source: REQUIRE_STATICS_PRELUDE + source, shortCircuit: true };
+}
+
 // Read a module's source directly, for the cases where Node does not hand
 // `source` to the load hook (notably CommonJS).
 //
@@ -175,7 +206,7 @@ export function load(loadURL, context, nextLoad) {
   if (!loadURL.startsWith('file:')) return result;
 
   let filename = url.fileURLToPath(loadURL.split('?')[0]);
-  if (!BABEL_REG.test(filename)) return result;
+  if (!BABEL_REG.test(filename)) return restoreRequireStatics(result, format);
 
   let source = result.source;
 

--- a/scripts/loader.js
+++ b/scripts/loader.js
@@ -36,21 +36,36 @@ export const LOADER_ALIAS = {
 };
 
 // resolve specifier file url
-export async function resolve(specifier, context, defaultResolve) {
+export function resolve(specifier, context, nextResolve) {
+  // `module.registerHooks` intercepts require() as well as import, which the
+  // old --experimental-loader did not. Mock interception has to stay
+  // import-only: applying it to require() redirects internal CommonJS requires
+  // into the memfs volume and breaks fs mocking (@percy/config).
+  let isRequire = context.conditions?.includes('require');
+
   // check for import or filesystem mocks
-  if (MOCK_IMPORTS.has(specifier)) {
-    return { url: `mock://${specifier}?__mock__=${MOCK_IMPORTS.__uid__}&module` };
-  } else if (context.parentURL && '$vol' in fs) {
+  if (!isRequire && MOCK_IMPORTS.has(specifier)) {
+    return {
+      url: `mock://${specifier}?__mock__=${MOCK_IMPORTS.__uid__}&module`,
+      shortCircuit: true
+    };
+  } else if (!isRequire && context.parentURL && '$vol' in fs) {
     let filename = specifier.startsWith('file:') ? url.fileURLToPath(specifier) : specifier;
     let filepath = path.resolve(path.dirname(url.fileURLToPath(context.parentURL)), filename);
 
     if (fs.$vol.existsSync(filepath)) {
       let fmt = CJS_REG.test(fs.$vol.readFileSync(filepath)) ? 'commonjs' : 'module';
-      return { url: `${url.pathToFileURL(filepath)}?__mock__=${MOCK_IMPORTS.__uid__}&${fmt}` };
+
+      return {
+        url: `${url.pathToFileURL(filepath)}?__mock__=${MOCK_IMPORTS.__uid__}&${fmt}`,
+        shortCircuit: true
+      };
     }
   }
 
   // rewrite dist to src in development
+  let original = specifier;
+
   if (specifier.startsWith('#')) {
     let pkgRoot = url.fileURLToPath(context.parentURL.replace(/(packages\/[^/]+\/).+$/, '$1'));
     let pkgJSON = JSON.parse(fs.readFileSync(path.resolve(pkgRoot, 'package.json')));
@@ -60,18 +75,16 @@ export async function resolve(specifier, context, defaultResolve) {
     specifier = specifier.replace(LOADER_ALIAS.find, LOADER_ALIAS.replace);
   }
 
-  // transform absolute filepaths into absolute file urls
-  if (specifier.startsWith(ROOT)) specifier = url.pathToFileURL(specifier).href;
+  // Transform absolute filepaths into absolute file urls, but only for
+  // specifiers we actually rewrote. `module.registerHooks` also intercepts
+  // `require()`, whose resolver rejects a file: URL -- converting every
+  // in-repo path unconditionally broke requires like babel.config.cjs.
+  if (specifier !== original && specifier.startsWith(ROOT)) {
+    specifier = url.pathToFileURL(specifier).href;
+  }
 
   // use default resolve when not mocked
-  return defaultResolve(specifier, context, defaultResolve);
-}
-
-// get module format for loader mocks
-export async function getFormat(srcURL, context, defaultGetFormat) {
-  return srcURL.includes('?__mock__')
-    ? { format: srcURL.split('?')[1].split('&')[1] }
-    : defaultGetFormat(srcURL, context, defaultGetFormat);
+  return nextResolve(specifier, context);
 }
 
 // generate mock sources for mocked modules
@@ -87,26 +100,113 @@ function mockSource(mockURL) {
   }
 }
 
-// return loader mocks as module sources
-export async function getSource(srcURL, context, defaultGetSource) {
-  if (srcURL.includes('?__mock__')) return { source: mockSource(srcURL) };
-  return defaultGetSource(srcURL, context, defaultGetSource);
+// Nearest package.json `type`, mirroring how babel.config.cjs decides between
+// its `modules: false` and `modules: 'commonjs'` overrides. The format we hand
+// back to Node has to agree with what Babel actually emitted, so it is derived
+// the same way rather than sniffed off the output.
+const typeCache = new Map();
+
+function packageType(filename) {
+  let dir = path.dirname(filename);
+
+  while (dir.startsWith(ROOT)) {
+    if (typeCache.has(dir)) return typeCache.get(dir);
+    let pkg = path.join(dir, 'package.json');
+
+    if (fs.existsSync(pkg)) {
+      let type = JSON.parse(fs.readFileSync(pkg, 'utf8')).type === 'module'
+        ? 'module' : 'commonjs';
+      typeCache.set(dir, type);
+      return type;
+    }
+
+    let parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return 'commonjs';
 }
 
-// return loader mocks or transform sources using babel
-export async function transformSource(source, context, defaultTransformSource) {
-  let callback = (src = source) => defaultTransformSource(src, context, defaultTransformSource);
-  if (context.format !== 'module' && context.format !== 'commonjs') return callback();
-  if (context.url.startsWith('mock://')) return callback();
+// Read a module's source directly, for the cases where Node does not hand
+// `source` to the load hook (notably CommonJS).
+//
+// Deliberately uses the real filesystem via realpath-free readFileSync on the
+// *unspied* binding: while a test has fs mocked, `fs.readFileSync` is a jasmine
+// spy backed by memfs, so reading through it would serve in-memory content for
+// ordinary source files. Memfs-backed modules are handled separately, via the
+// `?__mock__` branch in load().
+const realReadFileSync = fs.readFileSync;
 
-  if (typeof source !== 'string') source = Buffer.from(source);
-  if (Buffer.isBuffer(source)) source = source.toString();
+function readSource(loadURL) {
+  return realReadFileSync(url.fileURLToPath(loadURL.split('?')[0]), 'utf8');
+}
 
-  return callback((await babel.transformAsync(source, {
-    filename: url.fileURLToPath(context.url),
-    sourceType: context.format,
+// Return loader mocks, or transform sources using babel.
+//
+// Replaces the getFormat/getSource/transformSource trio this file used to
+// export. Those hooks were removed in Node 16.12 and silently stopped being
+// called, which is what pinned the suite to Node 14: without the Babel step
+// the test files load as native ESM (frozen namespaces, no `__dirname`), and
+// without a shared realm the `__MOCK_IMPORTS__` interception never matched.
+// A single synchronous `load` registered via `module.registerHooks` restores
+// both behaviours. See scripts/loader-register.js.
+export function load(loadURL, context, nextLoad) {
+  // synthesized mock module, or a memfs-backed file
+  if (loadURL.includes('?__mock__')) {
+    let format = loadURL.split('?')[1].split('&')[1];
+    let source = mockSource(loadURL);
+
+    // `mock://` modules are generated re-export shims and must be left alone,
+    // but memfs-backed files are real sources -- the old transformSource hook
+    // skipped only the former, so keep transforming the latter.
+    if (!loadURL.startsWith('mock://')) {
+      source = transform(source, url.fileURLToPath(loadURL.split('?')[0]), format) ?? source;
+    }
+
+    return { format, source, shortCircuit: true };
+  }
+
+  let result = nextLoad(loadURL, context);
+  let format = result.format ?? context.format;
+
+  // only our own src/test files get transformed
+  if (format !== 'module' && format !== 'commonjs') return result;
+  if (!loadURL.startsWith('file:')) return result;
+
+  let filename = url.fileURLToPath(loadURL.split('?')[0]);
+  if (!BABEL_REG.test(filename)) return result;
+
+  let source = result.source;
+
+  if (source == null) {
+    try { source = readSource(loadURL); } catch { return result; }
+  }
+
+  let transformed = transform(source, filename, format);
+
+  // `only` misses turn into a null result -- keep Node's original module.
+  if (transformed == null) return result;
+
+  return {
+    format: packageType(filename),
+    source: transformed,
+    shortCircuit: true
+  };
+}
+
+// Babel-transform a module source, or return null when Babel's `only` filter
+// does not match it. `unambiguous` lets Babel classify the input itself; the
+// old code forwarded Node's format, but Babel's sourceType has no 'commonjs'
+// member, so a CommonJS file would have been mis-declared.
+function transform(source, filename, format) {
+  if (typeof source !== 'string') source = Buffer.from(source).toString('utf8');
+
+  return babel.transformSync(source, {
+    filename,
+    sourceType: 'unambiguous',
     babelrcRoots: ['.'],
     rootMode: 'upward',
     only: [BABEL_REG]
-  }))?.code);
+  })?.code ?? null;
 }

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -88,8 +88,11 @@ async function main({
   } else if (!process.send) {
     // test runners assume they have control over the entire process, so give them each forks
     let flags = flagify({ coverage, karma: karmaArgs });
-    let loader = url.pathToFileURL(path.resolve(filename, '../loader.js')).href;
-    let opts = { execArgv: ['--loader', loader, ...process.execArgv] };
+    // --import (not --loader): the hooks must run in-process and share a realm
+    // with the specs so global.__MOCK_IMPORTS__ is the same object on both
+    // sides. See scripts/loader-register.js.
+    let loader = url.pathToFileURL(path.resolve(filename, '../loader-register.js')).href;
+    let opts = { execArgv: ['--import', loader, ...process.execArgv] };
 
     if (testNode) {
       await child('fork', filename, ['--node', ...flags], opts);


### PR DESCRIPTION
## Summary

Migrates the test harness from Node 14 to Node 22 and cuts CI over.

`@percy/cli` was not on Node 14 by preference — `scripts/loader.js` exported three
module hooks (`getFormat`, `getSource`, `transformSource`) that Node **removed in
16.12**. On any Node ≥16.12 they were never called, silently disabling both the Babel
transform and the module-mocking layer the suite depends on. That is why all 21
`node-version:` pins said `14`.

The port replaces them with a single synchronous `load` registered through
`module.registerHooks` (Node ≥22.15), which runs in-process and in the same realm —
the behaviour `--experimental-loader` had on Node 14, and the reason this targets 22
rather than 20 (Node 20 has only the off-thread `module.register`).

**This is a test-harness migration.** No product behaviour changes. The only
non-test source files touched are `packages/core/post-install.js` (a dev-only fork
that still passed the removed `--loader` flag) and `scripts/executable.sh`.

## Why this is a clean cut, not a matrix

`scripts/loader-register.js` throws below Node 22.15 by design, so a `node: [14, 22]`
matrix would be red by construction. The 21 pins move together.

## Root causes fixed

Four defects, each reduced to a root cause and verified against a Node 14 baseline
rather than guessed at:

1. **`@percy/config` — 13 specs, "Config file not found".** `mockfs()`'s bypass
   predicates are written against strings (`p.includes('node_modules')`), but `fs`
   also accepts a `URL`. `registerHooks` intercepts `require()` (which
   `--experimental-loader` never did) and Node reads CommonJS sources with a `file:`
   URL, so the bypass silently returned falsy and the read was served from the
   in-memory volume. cosmiconfig's lazy `require('js-yaml')` threw ENOENT, `search()`
   swallowed it, and every config file read as empty.

2. **`require.cache` is `undefined` on Node 22** for CommonJS reached through ESM
   interop, whenever *any* `load` hook is registered. Reproduced with a bare
   pass-through hook, so it is not caused by this loader — and it is fixed in Node 24.
   The hook cannot decline to supply CommonJS source (Node rejects that with
   `ERR_INVALID_RETURN_PROPERTY_VALUE`), so the two properties are patched back from
   inside the module, gated on the source actually referencing them. In practice that
   is `import-fresh`, which cosmiconfig uses to read `.percy.js` configs.

3. **`http.globalAgent` enables keepAlive from Node 19.** `cli-doctor`'s proxy double
   ended each client socket without sending `Connection: close`, so the client pooled
   the dead socket and the next request failed with `ECONNRESET`. Surfaced only in
   full-suite order; passed in isolation.

4. **Two stale `--loader` call sites** (`core/post-install.js`, a `cli-exec` spec)
   moved to `--import`. Under `--loader` the hooks run off-thread, where `nextLoad`
   returns a promise the ported `load` does not await.

## Silent-mock audit (the migration's real risk)

This layer fails by *not mocking* while still reporting green, so a green suite is not
evidence of a correct migration. All four sites that register loader mocks were audited
for an assertion against the mocked double:

| Site | Verdict |
|---|---|
| `core/test/unit/install.test.js:147` | already non-vacuous |
| `core/test/snapshot.test.js` (`runDiagnostics`) | already non-vacuous |
| `cli/test/helpers.js` → `commands.test.js:212` | already non-vacuous |
| `cli-exec/test/exec.test.js` (`cross-spawn`) | **was vacuous** — fixed |

The `cross-spawn` spec spawned a nonexistent `foobar`, which rejects with the *real*
`cross-spawn` too, so it passed whether or not the mock applied. It is now a spy with
`expect(crossSpawn).toHaveBeenCalled()`.

Also removed `global.__MOCK_IMPORTS__ = global.__MOCK_IMPORTS__ || new Map()`. The
loader does not consult that Map, so the fallback converted "the loader is not
registered" into a green run with every mock silently disabled. It now throws.

## Executable build

`executable.sh` ran `npm install -g pkg`, whose latest release (5.8.1) is the final
release of the **archived** vercel/pkg and ships no Node 22 base binary — the
standalone `percy` binary could not be built on 22 at all. Replaced with
`@yao-pkg/pkg@6.22.0`; its `pkg-fetch` v3.6 provides prebuilt Node 22 binaries for
linux, macos and win on x64 and arm64.

`--targets` is now pinned explicitly. Unpinned, pkg infers targets from the host, so
the arm64 macOS runner would have silently started emitting an **arm64 `percy-osx`** —
a change to what customers download. The published matrix stays x64; whether to add
arm64 assets is a separate release decision.

## Testing

Every failure was attributed with the repo's own `CLI_TEST_FAILURES_FILE` +
`CLI_TEST_ONLY_FAILED` mechanism: record failures on Node 22, replay *those exact
specs* on Node 14 with the original loader. Failures present on both are pre-existing.

| Package | Node 22 | Note |
|---|---|---|
| `env` / `logger` / `webdriver-utils` | 123 / 150 / 238 ✓ | |
| `config` | 82/82 ✓ | was 13 FAILED |
| `cli-snapshot` | 28/28 ✓ | was 1 FAILED (passed on Node 14) |
| `cli-exec` | 73/73 ✓ | |
| `cli` / `cli-app` / `cli-build` / `cli-command` / `cli-config` | 27 / 81 / 84 / 65 / 22 ✓ | |
| `cli-upload` / `monitoring` | 13 / 40 ✓ | |
| `sdk-utils` | 169/169 ✓ + 104 browser ✓ | |
| `dom` | 495 browser ✓ | |
| `client` | 265/266 | 1 pre-existing (host system proxy), fails on Node 14 too |
| `cli-doctor` | 505/508 | **exact parity** with the Node 14 full-suite baseline |
| `core` | 1201/1206 | 4 pre-existing (fail on Node 14 too); 1 order-dependent, see below |

Lint and typecheck both pass on Node 22.

### Not verified locally — needs this PR's CI

- **One `core` spec: `DiskSpillStore … destroy removes the entire dir and clears index`.**
  Fails only in full-suite order on Node 22 and **passes in isolation**, so the
  replay-the-failures protocol cannot attribute it — a subset run is exactly the
  condition under which it passes. A full Node 14 baseline is running; the plan never
  completed one (§5.1 records it as "timed out >25 min"), so no prior baseline exists
  for this spec. `destroy()` swallows its own errors, and the symptom (`existsSync(dir)`
  still true) is consistent with `#ready` being false, i.e. leaked `fs` spies from an
  earlier spec rather than anything version-specific.
- **Windows.** Entirely unexercised here. The loader carries Windows path escaping and
  `registerHooks` receives `file:///C:/…` URLs; `specifier.startsWith(ROOT)` mixes URL
  and path forms and is the likely failure point.
- **Coverage gate (100/100/100/100).** `env` proved it on 22 pre-PR; per-package
  `test:coverage` still to run. Instrumentation happens *inside* the loader's Babel
  step, so anything the `only` filter or the `?__mock__` short-circuit skips loses
  coverage.
- **Executable 6.2–6.4** — gsed `type: module` stripping, Apple codesign/notarize, and
  `resedit` on `windows-2022` need secrets and runners. Locally verified only that
  `@yao-pkg/pkg` builds all three targets with the same output filenames and that the
  macOS binary reports `v22.23.2 darwin x64`.

Two local failures are environmental, not regressions: a system proxy on the host
(`127.0.0.1:*`) and a missing local Firefox (`karma-firefox-launcher` crashes with
`Cannot read properties of undefined (reading 'stderr')` — CI runners have Firefox).

## Post-Deploy Monitoring & Validation

**No runtime/production impact from the harness change itself** — it touches
`scripts/`, tests, and CI only. The executable change *does* ship an artifact, so:

- **What to monitor**
  - CI: `test.yml` (all 18 packages), `windows.yml`, `lint.yml`, `typecheck.yml`,
    `executable.yml`, `executable-check.yml` on this PR.
  - The `::warning title=Flaky tests` annotations — a package that goes green only via
    a spec-level retry is not actually green (PER-9011).
  - Release assets: `percy-linux.zip`, `percy-osx.zip`, `percy.exe` size and arch.
- **Validation checks**
  - `grep -rn "node-14\|node-version: 14" .github/` → must return nothing.
  - `./scripts/verify-executable.sh ./percy` green on all three platforms.
  - `file percy-osx` → must still report `Mach-O 64-bit executable x86_64`, **not**
    arm64. An arch flip is the highest-consequence silent failure here.
  - `percy --version` from each built binary.
  - `nyc report --check-coverage` → 100/100/100/100 per package.
- **Expected healthy signals**: every package green on the *first* attempt; caches miss
  once (keys rotated, by design) then hit.
- **Failure signals / rollback trigger**
  - A package green only after `retry1`–`retry4` → treat as a real failure; a mock that
    silently stopped applying looks exactly like flake.
  - Any coverage drop → an instrumentation gap in the loader, not a test gap.
  - Wrong-arch or non-running executable → revert the `executable.sh` change and keep
    the executable pipeline on its own older Node (plan §7.1 option c) while the rest
    of CI stays on 22.
- **Validation window & owner**: first full CI run on this PR, plus the first release
  that publishes executables. Owner: @aryankumar.

## Follow-ups (deliberately not in this PR)

- `engines` on 17 packages `>=14` → `>=22`, and `babel.config.cjs` `targets: {node:'14'}`
  (lines 30, 39) which shape **published `dist`**. Both raise the customer floor and must
  follow a support-policy decision, not lead it. `@percy/dom` declares no `engines` at all.
- arm64 macOS executable assets.
- `packages/cli-doctor` writes a stray `nul` file during tests (a Windows device name);
  pre-existing, unrelated.

---

[![Compound Engineering v2.50.0](https://img.shields.io/badge/Compound_Engineering-v2.50.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 5 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)
