### PR TITLE
fix(core): stop compressing discovered resources in place

### DIFF
--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -230,12 +230,21 @@ function processSnapshotResources({ domSnapshot, resources, ...snapshot }) {
     const kept = [];
     for (let index = 0; index < resources.length; index++) {
       const resource = resources[index];
+      // Compression must never be applied in place. These resource objects are
+      // the same ones held by the build-wide resource cache, which replays them
+      // to the browser via Fetch.fulfillRequest using their original headers
+      // (e.g. `content-type: text/css`, no `content-encoding`). Overwriting
+      // `content` with gzip bytes leaves the cache serving compressed bodies
+      // labelled as plain text, so the browser cannot parse them -- a stylesheet
+      // poisoned this way yields no @font-face and no background-image, and the
+      // resources they reference are never requested and so never captured for
+      // any later snapshot. Compress a copy and leave the cached entry intact.
+      let uploaded = resource;
       try {
-        const alreadyZipped = isGzipped(resource.content);
-        /* istanbul ignore next: very hard to mock true */
-        if (!alreadyZipped) {
-          resource.content = Pako.gzip(resource.content);
-          resource.sha = sha256hash(resource.content);
+        /* istanbul ignore else: alreadyZipped is very hard to mock true */
+        if (!isGzipped(resource.content)) {
+          const content = Pako.gzip(resource.content);
+          uploaded = { ...resource, content, sha: sha256hash(content) };
           log.debug(`- Gzipped resource: ${resource.url}`);
         }
       } catch (error) {
@@ -247,9 +256,9 @@ function processSnapshotResources({ domSnapshot, resources, ...snapshot }) {
         continue;
       }
 
-      // resource.content is guaranteed by the try block above (either just
-      // assigned from Pako.gzip, or alreadyZipped was true).
-      const size = resource.content.length;
+      // uploaded.content is guaranteed by the try block above (either just
+      // assigned from Pako.gzip, or the resource was already compressed).
+      const size = uploaded.content.length;
       // Root (DOM HTML) and log resources are required for a valid snapshot;
       // shipping an oversized one and letting the API surface a clear error
       // is better than silently dropping it here.
@@ -263,7 +272,7 @@ function processSnapshotResources({ domSnapshot, resources, ...snapshot }) {
         );
         continue;
       }
-      kept.push(resource);
+      kept.push(uploaded);
     }
     resources = kept;
   }

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -234,7 +234,7 @@ function processSnapshotResources({ domSnapshot, resources, ...snapshot }) {
       // cache, which must keep replaying the original bytes to the browser.
       let uploaded = resource;
       try {
-        /* istanbul ignore else: alreadyZipped is very hard to mock true */
+        /* istanbul ignore else: an already-gzipped resource is very hard to mock */
         if (!isGzipped(resource.content)) {
           const content = Pako.gzip(resource.content);
           uploaded = { ...resource, content, sha: sha256hash(content) };
@@ -249,7 +249,7 @@ function processSnapshotResources({ domSnapshot, resources, ...snapshot }) {
         continue;
       }
 
-      // uploaded.content is guaranteed by the try block above.
+      // Either the gzipped copy or, when already gzipped, the resource itself.
       const size = uploaded.content.length;
       // Root (DOM HTML) and log resources are required for a valid snapshot;
       // shipping an oversized one and letting the API surface a clear error

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -230,15 +230,8 @@ function processSnapshotResources({ domSnapshot, resources, ...snapshot }) {
     const kept = [];
     for (let index = 0; index < resources.length; index++) {
       const resource = resources[index];
-      // Compression must never be applied in place. These resource objects are
-      // the same ones held by the build-wide resource cache, which replays them
-      // to the browser via Fetch.fulfillRequest using their original headers
-      // (e.g. `content-type: text/css`, no `content-encoding`). Overwriting
-      // `content` with gzip bytes leaves the cache serving compressed bodies
-      // labelled as plain text, so the browser cannot parse them -- a stylesheet
-      // poisoned this way yields no @font-face and no background-image, and the
-      // resources they reference are never requested and so never captured for
-      // any later snapshot. Compress a copy and leave the cached entry intact.
+      // Never compress in place: these objects are shared with the resource
+      // cache, which must keep replaying the original bytes to the browser.
       let uploaded = resource;
       try {
         /* istanbul ignore else: alreadyZipped is very hard to mock true */
@@ -256,8 +249,7 @@ function processSnapshotResources({ domSnapshot, resources, ...snapshot }) {
         continue;
       }
 
-      // uploaded.content is guaranteed by the try block above (either just
-      // assigned from Pako.gzip, or the resource was already compressed).
+      // uploaded.content is guaranteed by the try block above.
       const size = uploaded.content.length;
       // Root (DOM HTML) and log resources are required for a valid snapshot;
       // shipping an oversized one and letting the API surface a clear error

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -839,6 +839,37 @@ describe('Discovery', () => {
     );
   });
 
+  it('keeps cached resources uncompressed when PERCY_GZIP is enabled', async () => {
+    // Compressing a resource in place mutates the entry held by the build-wide
+    // resource cache. Later snapshots then have the compressed body replayed to
+    // the browser under the resource's original `text/css` content type, so the
+    // browser cannot parse the stylesheet, never sees the @font-face it declares,
+    // and never requests the font -- leaving it out of every later snapshot.
+    process.env.PERCY_GZIP = true;
+
+    server.reply('/style.css', () => [200, 'text/css', [
+      '@font-face { font-family: "test"; src: url("/font.woff") format("woff"); }',
+      'body { font-family: "test", "sans-serif"; }'
+    ].join('')]);
+
+    await percy.snapshot({ name: 'one', url: 'http://localhost:8000', domSnapshot: testDOM });
+    await percy.snapshot({ name: 'two', url: 'http://localhost:8000', domSnapshot: testDOM });
+
+    await percy.idle();
+
+    let font = jasmine.objectContaining({
+      id: sha256hash(Pako.gzip('<font>')),
+      attributes: jasmine.objectContaining({
+        'resource-url': 'http://localhost:8000/font.woff'
+      })
+    });
+
+    expect(captured[0]).toEqual(jasmine.arrayContaining([font]));
+    // the second snapshot's stylesheet is served from the cache -- it must still
+    // arrive parseable so the font it references is discovered again
+    expect(captured[1]).toEqual(jasmine.arrayContaining([font]));
+  });
+
   it('captures resource larger than 25MB raw when PERCY_GZIP is enabled', async () => {
     process.env.PERCY_GZIP = true;
     const largeCSS = 'A'.repeat(30_000_000);

--- a/packages/core/test/discovery.test.js
+++ b/packages/core/test/discovery.test.js
@@ -840,11 +840,8 @@ describe('Discovery', () => {
   });
 
   it('keeps cached resources uncompressed when PERCY_GZIP is enabled', async () => {
-    // Compressing a resource in place mutates the entry held by the build-wide
-    // resource cache. Later snapshots then have the compressed body replayed to
-    // the browser under the resource's original `text/css` content type, so the
-    // browser cannot parse the stylesheet, never sees the @font-face it declares,
-    // and never requests the font -- leaving it out of every later snapshot.
+    // A cached stylesheet compressed in place is replayed as gzip bytes under its
+    // original text/css type, so the browser never parses it or its @font-face.
     process.env.PERCY_GZIP = true;
 
     server.reply('/style.css', () => [200, 'text/css', [
@@ -865,8 +862,7 @@ describe('Discovery', () => {
     });
 
     expect(captured[0]).toEqual(jasmine.arrayContaining([font]));
-    // the second snapshot's stylesheet is served from the cache -- it must still
-    // arrive parseable so the font it references is discovered again
+    // snapshot two's stylesheet comes from the cache and must still be parseable
     expect(captured[1]).toEqual(jasmine.arrayContaining([font]));
   });
 


### PR DESCRIPTION
## Problem

With `PERCY_GZIP` enabled, webfonts declared via `@font-face` were captured for the **first** snapshot of a build and missing from **every** snapshot after it, so the renderer 404'd fonts the page still needed (icon fonts render as blank boxes).

## Root cause

`processSnapshotResources` compressed resources in place:

```js
resource.content = Pako.gzip(resource.content);
resource.sha = sha256hash(resource.content);
```

Those objects are the same ones held by the build-wide resource cache — `network.intercept.saveResource` stores the object itself, not a copy. So the first snapshot's upload pass replaced every cached body with its gzip bytes.

Every later snapshot then had those entries replayed to the browser via `Fetch.fulfillRequest` using the resource's **original** headers, e.g. `content-type: text/css` with no `content-encoding`. Compressed bytes are not parseable as the text type they are labelled with, so the stylesheet yields no rules — and anything it references is therefore never requested and never captured.

A stylesheet carrying `@font-face` consequently produces no webfont for any snapshot after the first. Only stylesheet-referenced resources are affected: DOM `<img>` URLs are found by the preload scanner directly in markup, whereas `@font-face` and `background-image` URLs require the CSS to be parsed first.

Confirmed in the logs: the stylesheet is gzipped exactly once, then served from cache for the rest of the build, with `isGzipped()` true on it from then on — i.e. the cached entry itself had been mutated.

## Fix

Compress a copy and leave the cached entry holding the original bytes. Cache hit rates are unchanged; only the mutation is gone.

## Verification

Real builds replaying a reporter's own serialized DOMs and config (`PERCY_GZIP=true`, 11 snapshots), identical except for this change:

| | font requests across the build | stylesheets captured |
|---|---|---|
| before | **5** (first snapshot only) | 11/11 |
| after | **11** (every snapshot) | 11/11 |

Cache hits stay at 41–44 per snapshot in both, so caching still works. A control run with `PERCY_GZIP` unset never exhibited the bug.

New regression test `keeps cached resources uncompressed when PERCY_GZIP is enabled`, verified in both directions: it **fails** on the unfixed code — snapshot two's manifest contains the root, `img.gif` and `style.css` but no `font.woff` — and passes with the fix.
