### PR TITLE
fix(core): customElements wait read its timeout from the wrong argument, hanging the CLI forever (PER-10405)

### DIFF
--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -25,22 +25,40 @@ export const DEFAULT_WAIT_FOR_CUSTOM_ELEMENTS_TIMEOUT = 500;
 // IMPORTANT: this body is intentionally ES5 — it is evaluated in the
 // page's realm and must work in any browser the page targets. Don't
 // "modernize" with arrow functions, let/const, or optional chaining.
+//
+// serializeFunction() injects the Percy helpers object as `arguments[0]`, so
+// the caller's first argument is `arguments[1]`.
 export const WAIT_FOR_CUSTOM_ELEMENTS_BODY = `
-  var deadline = Date.now() + (arguments[0] || 500);
+  var timeoutMs = typeof arguments[1] === 'number' && isFinite(arguments[1]) && arguments[1] > 0
+    ? arguments[1]
+    : 500;
+  var deadline = Date.now() + timeoutMs;
   return new Promise(function(resolve) {
+    var settled = false;
+    function finish() {
+      if (settled) return;
+      settled = true;
+      resolve();
+    }
+    setTimeout(finish, timeoutMs);
     function tick() {
+      if (settled) return;
       var undef = document.querySelectorAll(":not(:defined)");
-      if (!undef.length) return resolve();
-      if (Date.now() >= deadline) return resolve();
+      if (!undef.length) return finish();
+      if (Date.now() >= deadline) return finish();
       var names = {};
       for (var i = 0; i < undef.length; i++) names[undef[i].localName] = true;
       var promises = Object.keys(names).map(function(n) {
-        return window.customElements.whenDefined(n).catch(function(){});
+        try {
+          return window.customElements.whenDefined(n).catch(function(){});
+        } catch (e) {
+          return Promise.resolve();
+        }
       });
       Promise.race([
         Promise.all(promises),
         new Promise(function(r) { setTimeout(r, 100); })
-      ]).then(tick);
+      ]).then(tick, finish);
     }
     tick();
   });

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -4,7 +4,11 @@ import Percy from '@percy/core';
 import Pako from 'pako';
 import DetectProxy from '@percy/client/detect-proxy';
 import { validateSnapshotOptions } from '../src/snapshot.js';
-import { Page, WAIT_FOR_CUSTOM_ELEMENTS_BODY } from '../src/page.js';
+import {
+  Page,
+  WAIT_FOR_CUSTOM_ELEMENTS_BODY,
+  DEFAULT_WAIT_FOR_CUSTOM_ELEMENTS_TIMEOUT
+} from '../src/page.js';
 
 describe('Percy', () => {
   let percy, server;
@@ -214,6 +218,31 @@ describe('Percy', () => {
     expect(logger.stderr).toEqual(jasmine.arrayContaining([
       jasmine.stringMatching(/Custom elements wait failed: boom/)
     ]));
+  });
+
+  it('does not hang on a page holding a never-defined custom element', async () => {
+    // PER-10405: an unregistered tag matches `:not(:defined)` forever and its
+    // `customElements.whenDefined()` never resolves, so the wait must fall back
+    // on its own ceiling.
+    server.reply('/', () => [200, 'text/html', (
+      '<p>hi</p><next-route-announcer></next-route-announcer>'
+    )]);
+    await percy.browser.launch();
+    let page = await percy.browser.page();
+    await page.goto('http://localhost:8000');
+
+    let undefinedCount = await page.eval(
+      () => document.querySelectorAll(':not(:defined)').length);
+    expect(undefinedCount).toBe(1);
+
+    let start = Date.now();
+    await expectAsync(page.eval(
+      WAIT_FOR_CUSTOM_ELEMENTS_BODY,
+      DEFAULT_WAIT_FOR_CUSTOM_ELEMENTS_TIMEOUT
+    )).toBeResolved();
+    let elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(5000);
   });
 
   it('runs readiness check before serializing when readiness option is set', async () => {


### PR DESCRIPTION
Fixes [PER-10405](https://browserstack.atlassian.net/browse/PER-10405) / closes #2376

## Symptom

`percy snapshot` hangs indefinitely — no error, no timeout, no output — against any live Next.js `next start` server. Bisects cleanly to `@percy/cli`: **1.31.13 works, 1.32.0 / 1.32.3 / 1.32.6 all hang identically**. Reproduces on a completely unmodified `create-next-app`.

The reporter ruled out (all correctly): Chromium version (forced 1.31.13's binary into a 1.32.3 run), custom `.percy.yml`, snapshot count, `localhost` vs `127.0.0.1`, the disk-backed logger, `autoConfigureAllowedHostnames`, and page content (a byte-identical **static** mirror of the same page does **not** hang). Only *live Next server + 1.32.x* hangs.

## Root cause

`packages/core/src/page.js:29` — `WAIT_FOR_CUSTOM_ELEMENTS_BODY` (added in 1.32.0) read its timeout from the wrong argument index.

`serializeFunction()` wraps a string body as:

```js
(async function eval() { <body> })(percyHelpers, ...args)
```

so **`arguments[0]` is the injected Percy helpers object** and the caller's first argument lands at `arguments[1]`. The body read `arguments[0]`:

```js
var deadline = Date.now() + (arguments[0] || 500);
```

The helpers object is truthy, so this became `number + object` → **string concatenation**. Probed live in the page during the repro:

```
{"argsLen":2,
 "arg0Type":"object",
 "arg0Keys":["config","snapshot","generatePromise","yieldFor","waitFor",
             "waitForTimeout","waitForSelector","waitForXPath","scrollToBottom"],
 "arg1":500,
 "deadlineValue":"1786389350594[object Object]",
 "deadlineType":"string",
 "comparisonResult":false}
```

`Date.now() >= deadline` therefore coerced to `NaN` and was **permanently false** — the deadline could never fire.

That is latent on most pages, because the other exit (`if (!undef.length) return resolve()`) clears immediately. Next.js is what makes it fatal: the app router mounts **`<next-route-announcer>`**, a tag Next never passes to `customElements.define()`. It matches `:not(:defined)` forever, and `customElements.whenDefined('next-route-announcer')` never resolves. Probe from the same run:

```
{"count":1,"names":["next-route-announcer"],"whenDefinedErrors":[]}
```

With both exits dead the poll re-ticked every 100 ms forever and the promise never settled. The body is awaited over CDP with `awaitPromise: true`, which has **no protocol-level timeout**, so `page.snapshot()` blocked forever.

This also explains the two things that made the report confusing:

- **Why no timeout fired.** The hang is *upstream* of everything with a budget. `PERCY_NETWORK_IDLE_WAIT_TIMEOUT` is not involved — instrumenting the run shows `network.idle()` resolving normally twice before the hang.
- **Why a static mirror works.** `<next-route-announcer>` is created by Next's *client runtime* at hydration, so it is absent from a static mirror of the server HTML → `undef.length === 0` → immediate resolve.

Not Next-specific in principle: any page holding a never-registered custom-element tag (blocked third-party widget loader, typo'd tag name) hits the same hang. Next.js just guarantees one on every page.

## Blast radius

The run hangs *before* build creation — the CLI issues exactly one API call (`Fetching project domain config`) and never calls `POST /builds`. **No build appears in Percy at all**, so these failures leave no server-side trace and are invisible to backend telemetry. Users see a wedged CI job.

## Fix

`packages/core/src/page.js`:

- Read the timeout from `arguments[1]`, validated as a finite positive number. The `serializeFunction` argument-injection contract is now documented at the constant, since it is invisible from inside the body.
- Add a `settled` guard plus an absolute `setTimeout(finish, timeoutMs)`. This promise is awaited over CDP with no timeout of its own, so failing to settle must be *structurally impossible*, not merely unlikely — a ceiling, independent of the poll's own bookkeeping.
- Route the tick chain's rejection path to `finish` (previously `.then(tick)` with no rejection handler: a throw on any tick after the first orphaned the outer promise), and wrap `whenDefined()`, which throws `SyntaxError` on an invalid custom element name.

## Why tests didn't catch this

Useful for anyone adding a page-realm body later: **the existing specs never execute this one.** Both identity-match the exported constant and then bypass it — one asserts the wait eval count is `0`, the other replaces the eval with `throw new Error('boom')`. The body only ever runs inside the page realm, where `serializeFunction`'s argument injection applies, so a node-side suite can't reach it by construction. The spec below is the first that runs it in a real browser.

## Testing

New regression spec in `packages/core/test/percy.test.js`, using the real browser harness against `<next-route-announcer>`. It asserts the fixture really is stuck (`:not(:defined)` count is 1) before asserting the wait settles on its own ceiling, so it can't silently pass without exercising the deadline branch.

```
✓ does not hang on a page holding a never-defined custom element
Executed 140 of 140 specs SUCCESS in 3 mins 14 secs.
```

End-to-end, against a bare `create-next-app` (`next@16.3.0`, `react@19.2.8`, node 22) served by `next start -p 4176`:

| | result |
|---|---|
| `@percy/cli@1.32.6` | hangs past **120 s**, killed by `timeout`, **no build created** |
| same run, patched | **finalizes in 23 s** — [build #377](https://percy.io/test/web/test123-ak-0c50fbe2/builds/52797857) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PER-10405]: https://browserstack.atlassian.net/browse/PER-10405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ