### PR TITLE
fix(core): SDK version check blocked every snapshot POST, hanging Cypress at 45s (PER-10514)

### DIFF
--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -228,6 +228,19 @@ export async function request(url, options = {}, callback) {
     let req = http.request(requestOptions);
     req.on('response', handleResponse);
     req.on('error', handleError);
+
+    // Node's `timeout` option only *emits* a 'timeout' event once the socket
+    // has been idle that long — it does not abort anything. Without this
+    // listener a caller passing `timeout` still waits forever on a peer that
+    // accepts the connection and then goes silent, and the promise never
+    // settles. Destroying the request surfaces it through 'error' instead.
+    if (requestOptions.timeout) {
+      req.on('timeout', () => req.destroy(Object.assign(
+        new Error(`Request to ${url} timed out after ${requestOptions.timeout}ms`),
+        { code: 'ETIMEDOUT' }
+      )));
+    }
+
     req.end(body);
   }, { retries, interval });
 }

--- a/packages/client/test/unit/request.test.js
+++ b/packages/client/test/unit/request.test.js
@@ -210,6 +210,29 @@ describe('Unit / Request', () => {
       .toBeRejectedWithError('403 \nSTOP');
   });
 
+  describe('timeout', () => {
+    let silent;
+
+    beforeEach(async () => {
+      // a server that accepts the connection and then never answers
+      silent = await createTestServer({ port: 8081 }, () => {}).start();
+    });
+
+    afterEach(async () => {
+      await silent?.close();
+    });
+
+    it('rejects instead of hanging forever when a timeout is given', async () => {
+      await expectAsync(silent.request('/', { timeout: 200, retries: 0 }))
+        .toBeRejectedWithError(/timed out after 200ms/);
+    });
+
+    it('does not time out requests that answer in time', async () => {
+      await expectAsync(server.request('/', { timeout: 10000 }))
+        .toBeResolvedTo('test');
+    });
+  });
+
   describe('retries', () => {
     it('automatically retries server 500 errors', async () => {
       let responses = [[502], [503], [520], [200]];

--- a/packages/core/src/percy.js
+++ b/packages/core/src/percy.js
@@ -646,10 +646,18 @@ export class Percy {
       let server;
 
       try {
-        // Check SDK version
+        // Check SDK version. This generator runs inside the POST /percy/snapshot
+        // request handler (see api.js), so anything awaited here delays the HTTP
+        // response the SDK is blocked on. checkSDKVersion reaches out to
+        // api.github.com — an unrelated third party that a corporate proxy,
+        // egress firewall or GitHub throttling can leave hanging — so it must
+        // never gate a snapshot. Set the flag first so exactly one check is ever
+        // started (it used to be set after the await, which meant every snapshot
+        // posted during a slow check started its own), and run it detached:
+        // checkSDKVersion swallows its own errors and only logs.
         if (!this.sdkInfoDisplayed && options.clientInfo) {
-          await checkSDKVersion(options.clientInfo);
           this.sdkInfoDisplayed = true;
+          checkSDKVersion(options.clientInfo);
         }
         if ('serve' in options) {
           // create and start a static server

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -978,6 +978,12 @@ export async function* maybeScrollToBottom(page, discovery) {
   }
 }
 
+// How long the (purely informational) SDK version check may spend talking to
+// api.github.com before it gives up. Kept short deliberately: the check now runs
+// detached, so its socket is a live handle that would otherwise hold the event
+// loop open at shutdown for as long as the peer stays silent.
+const SDK_VERSION_CHECK_TIMEOUT = 5000;
+
 // Package to GitHub repo mapping
 const PACKAGE_TO_REPO = {
   '@percy/selenium-webdriver': 'percy-selenium-js',
@@ -1022,9 +1028,13 @@ export async function checkSDKVersion(clientInfo) {
       return;
     }
 
-    // Fetch latest version from GitHub releases
+    // Fetch latest version from GitHub releases. api.github.com is a third
+    // party we don't control and networks routinely black-hole it (proxies,
+    // egress firewalls, rate limiting), so this is bounded — without a timeout
+    // the socket stays open for the life of the CLI process.
     const githubData = await request(`https://api.github.com/repos/percy/${repoName}/releases?page=1`, {
       headers: { 'User-Agent': '@percy/cli' },
+      timeout: SDK_VERSION_CHECK_TIMEOUT,
       retries: 0
     });
 

--- a/packages/core/test/snapshot.test.js
+++ b/packages/core/test/snapshot.test.js
@@ -1,5 +1,5 @@
 import { sha256hash, base64encode } from '@percy/client/utils';
-import { logger, api, setupTest, createTestServer, dedent } from './helpers/index.js';
+import { logger, api, setupTest, createTestServer, dedent, mockRequests } from './helpers/index.js';
 import { waitFor } from '@percy/core/utils';
 import Percy from '@percy/core';
 import { handleSyncJob } from '../src/snapshot.js';
@@ -46,6 +46,34 @@ describe('Snapshot', () => {
   it('errors when not running', async () => {
     await percy.stop();
     expect(() => percy.snapshot({})).toThrowError('Not running');
+  });
+
+  // PER-10514: POST /percy/snapshot does not answer until percy.snapshot()
+  // resolves, so anything the generator awaits stalls the SDK. The version
+  // check talks to api.github.com — a third party that proxies and egress
+  // firewalls routinely leave hanging — and it must never gate a snapshot.
+  it('does not wait on the SDK version check to take a snapshot', async () => {
+    let ghAPI = await mockRequests('https://api.github.com');
+    // accept the request and never answer, the way a black-holing proxy does
+    ghAPI.and.returnValue(new Promise(() => {}));
+
+    let tooSlow = new Promise((resolve, reject) => setTimeout(() => {
+      reject(new Error('percy.snapshot() blocked on the SDK version check'));
+    }, 10000));
+
+    await expectAsync(Promise.race([
+      percy.snapshot({
+        name: 'test snapshot',
+        url: 'http://localhost:8000',
+        domSnapshot: testDOM,
+        clientInfo: '@percy/cypress/3.1.9'
+      }),
+      tooSlow
+    ])).toBeResolved();
+
+    await percy.idle();
+    expect(api.requests['/builds/123/snapshots'][0].body.data.attributes.name)
+      .toEqual('test snapshot');
   });
 
   it('errors when missing a url', () => {


### PR DESCRIPTION
Fixes [PER-10514](https://browserstack.atlassian.net/browse/PER-10514).

## The report

A Cypress customer (`@percy/cypress@3.1.9`, `@percy/cli@1.32.6`) intermittently gets, on and off for months:

```
cy.then() timed out after waiting 45000ms.
Your callback function returned a promise that never resolved.

The callback function was:
async doc => {
  ...
  let response = await withRetry(async () => await withLog(async () => {
    return await utils.postSnapshot({ ... });
  }, 'posting dom snapshot', _throw));
```

The 45 000 ms is ours, not theirs — `@percy/cypress` hard-codes `CY_TIMEOUT = 30 * 1000 * 1.5` (`index.js:10`) and applies it to the `cy.document().then({ timeout: CY_TIMEOUT }, …)` that posts the snapshot (`index.js:540`). So the message means exactly one thing: **`POST localhost:5338/percy/snapshot` did not answer within 45 s.**

## Root cause

`POST /percy/snapshot` doesn't answer until `percy.snapshot()` resolves (`core/src/api.js:230-239`). The first thing that generator awaited was not asset discovery — it was the SDK version check (`core/src/percy.js:649-653`):

```js
if (!this.sdkInfoDisplayed && options.clientInfo) {
  await checkSDKVersion(options.clientInfo);   // ← the SDK's HTTP response waits on this
  this.sdkInfoDisplayed = true;
}
```

`checkSDKVersion()` (`core/src/utils.js:1016-1046`) calls `https://api.github.com/repos/percy/<sdk-repo>/releases?page=1` purely so we can log an `[SDK Update Available]` warning. `@percy/cypress` is in `PACKAGE_TO_REPO`, so every Cypress user takes this path.

That request goes through `client/src/utils.js:228` — `http.request(requestOptions)` with **no socket timeout and no `'timeout'` handler**. Node's default socket timeout is 0 (never). A peer that completes the TCP handshake and then goes silent — a corporate proxy, an egress firewall that drops instead of rejecting, GitHub throttling — hangs the promise forever. `retries: 0` can't help: the single attempt never settles, so there is nothing to retry. The SDK's own `withRetry` can't help either — it only retries rejections.

So one unreachable third party we don't own stalls snapshots indefinitely.

**Aggravator in the same block:** `this.sdkInfoDisplayed = true` was set *after* the await. While the first check hangs the flag is still `false`, so every subsequent snapshot in that CLI process enters the branch and fires its own GitHub request. A single bad network moment costs the whole run, not one test — which is why the customer reports run-level failures rather than one flaky spec.

## Reproduction

Black-hole `api.github.com` the way a dropping firewall does — a TCP server that accepts the connection and never writes a byte — set it as `HTTPS_PROXY`, `NO_PROXY` the local addresses, then `POST /percy/snapshot` with `clientInfo: '@percy/cypress/3.1.9'`:

```
[repro] percy core started, address = http://localhost:5338
[blackhole] connection accepted, holding it open forever
[repro] *** 45000ms elapsed and POST /percy/snapshot has NOT responded ***
[repro] still hanging at 70002ms — no timeout exists on the github call
```

Identical run with `api.github.com` reachable:

```
[repro] RESPONSE after 617ms: 200 {"success":true}
```

617 ms vs >70 s. The whole difference is that one call.

## The fix

- **`packages/core/src/percy.js`** — set `sdkInfoDisplayed` *before* the call and run `checkSDKVersion()` detached. A snapshot never waits on it, and exactly one check is started per CLI process. `checkSDKVersion` already swallows its own errors, so nothing escapes.
- **`packages/core/src/utils.js`** — bound the GitHub request at 5 s. Deliberately short: now that the check is detached, its socket is a live handle that would otherwise hold the event loop open at shutdown for as long as the peer stays silent.
- **`packages/client/src/utils.js`** — make the `timeout` option actually do something. Node's `timeout` option only *emits* a `'timeout'` event; without destroying the request, passing a timeout was a no-op. Now `timeout` destroys the request with `ETIMEDOUT`, which surfaces through the existing `'error'` path. `ETIMEDOUT` is not in `RETRY_ERROR_CODES`, so this does not change retry behaviour for any existing caller — and no existing caller passes `timeout`, so behaviour is unchanged unless opted into.

## Testing

- `packages/core/test/snapshot.test.js` — *"does not wait on the SDK version check to take a snapshot"*: mocks `api.github.com` with a reply that never resolves and asserts `percy.snapshot()` still resolves (and the snapshot still uploads). Hangs on `master`, passes here.
- `packages/client/test/unit/request.test.js` — a request with `timeout` against a server that accepts and never answers now rejects with *"timed out after 200ms"*; a normal request with a generous timeout is unaffected.

`yarn workspace @percy/core test --node`: 104 specs, 5 failures — the same 5 pre-existing `runDoctorOnFailure` failures that fail on unmodified `master` in this environment (`@percy/cli-doctor` isn't linked locally).
`yarn workspace @percy/client test`: 279 specs, 2 failures — the same 2 pre-existing `proxy` failures that fail on unmodified `master` (Node-version-dependent `Invalid URL` message).

## Follow-ups, not in this PR

- `@percy/sdk-utils`'s `request.post` passes `timeout: 600000` (`sdk-utils/src/request.js:32`) — dead code for the same reason, in both the node and the `window.fetch` implementations. Worth fixing, but it changes behaviour for every SDK, so it doesn't belong here.
- Even with this fixed, `POST /percy/snapshot` still blocks on asset discovery. `api.js` already supports `?async`; whether the Cypress SDK should use it is an SDK-side design question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-10514]: https://browserstack.atlassian.net/browse/PER-10514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ