### PR TITLE
feat(webdriver-utils): add scaleToFit for full-page Automate captures (PER-10530)

### DIFF
--- a/packages/cli-doctor/src/checks/config.js
+++ b/packages/cli-doctor/src/checks/config.js
@@ -80,7 +80,7 @@ export async function checkConfig(options = {}) {
 
     // Keys that only work with automate tokens
     const automateOnlyKeys = ['fullPage', 'freezeAnimation', 'freezeAnimatedImage',
-      'freezeAnimatedImageOptions', 'ignoreRegions', 'considerRegions'];
+      'freezeAnimatedImageOptions', 'ignoreRegions', 'considerRegions', 'scaleToFit'];
     // Keys that only work with web tokens (not automate, not app)
     const webOnlyKeys = ['waitForTimeout', 'waitForSelector'];
 

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -202,10 +202,8 @@ export const configSchema = {
         type: 'boolean',
         onlyAutomate: true
       },
-      // Opts a full-page Automate capture into downscaling each tile by 1/dpr, so the
-      // stitched image stays inside the 50,000px comparison ceiling. Without it the
-      // walkable DOM height is capped at 50000/dpr CSS px and taller pages are truncated.
-      // Only honoured on the fullPage path -- mobile-common ignores it for singlepage.
+      // Downscales each tile by 1/dpr so the stitched image fits the 50,000px ceiling;
+      // without it the DOM walk is capped at 50000/dpr CSS px. fullPage path only.
       scaleToFit: {
         type: 'boolean',
         onlyAutomate: true

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -202,6 +202,14 @@ export const configSchema = {
         type: 'boolean',
         onlyAutomate: true
       },
+      // Opts a full-page Automate capture into downscaling each tile by 1/dpr, so the
+      // stitched image stays inside the 50,000px comparison ceiling. Without it the
+      // walkable DOM height is capped at 50000/dpr CSS px and taller pages are truncated.
+      // Only honoured on the fullPage path -- mobile-common ignores it for singlepage.
+      scaleToFit: {
+        type: 'boolean',
+        onlyAutomate: true
+      },
       freezeAnimation: { // for backward compatibility
         type: 'boolean',
         onlyAutomate: true

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -933,7 +933,11 @@ export const comparisonSchema = {
         },
         cliScreenshotStartTime: { type: 'integer', default: 0 },
         cliScreenshotEndTime: { type: 'integer', default: 0 },
-        screenshotType: { type: 'string', default: 'singlepage' }
+        screenshotType: { type: 'string', default: 'singlepage' },
+        // additionalProperties is false here and PercyConfig.validate DELETES unknown keys
+        // from the object it validates, so an undeclared key is silently dropped pre-upload.
+        scaleToFit: { type: 'boolean' },
+        appliedScaleFactor: { type: 'number', exclusiveMinimum: 0, maximum: 1 }
       }
     },
     tag: {

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -412,6 +412,9 @@ export function percyAutomateRequestHandler(req, percy) {
 
   req.body.options = merge([{
     fullPage: percy.config.snapshot.fullPage,
+    // Must be listed here or a .percy.yml `snapshot.scaleToFit` validates and is then
+    // silently dropped -- the page truncates as before while the build stays green.
+    scaleToFit: percy.config.snapshot.scaleToFit,
     percyCSS: percy.config.snapshot.percyCSS,
     freezeAnimatedImage: percy.config.snapshot.freezeAnimatedImage || percy.config.snapshot.freezeAnimation,
     freezeImageBySelectors: percy.config.snapshot.freezeAnimatedImageOptions?.freezeImageBySelectors,

--- a/packages/core/test/unit/config.test.js
+++ b/packages/core/test/unit/config.test.js
@@ -117,23 +117,14 @@ describe('SnapshotSchema', () => {
     expect(errors[0].message).toBe('must have property scope when property scopeOptions is present');
   });
 
-  // Automate-only options live on /config/snapshot (the .percy.yml `snapshot:` section),
-  // NOT on /snapshot -- which $refs only a hand-picked subset and so reports fullPage as
-  // an unknown property too. /config/snapshot sets additionalProperties: false, so an
-  // undeclared key is rejected there: the reason scaleToFit needs a schema entry and not
-  // just provider plumbing.
-  // Structural assertion rather than a PercyConfig.validate() round-trip: the
-  // onlyAutomate keyword is evaluated when AJV COMPILES the schema, so a validate() call
-  // reflects whatever PERCY_TOKEN was set when the schema was first added in this process
-  // -- flipping the env var inside a spec cannot change the outcome. Asserting the
-  // declaration directly is what actually pins the change.
+  // Structural, not a validate() round-trip: onlyAutomate is evaluated when AJV COMPILES
+  // the schema, so flipping PERCY_TOKEN inside a spec cannot change the outcome.
   it('declares scaleToFit as an automate-only boolean', () => {
     expect(CoreConfig.schemas[0].snapshot.properties.scaleToFit)
       .toEqual({ type: 'boolean', onlyAutomate: true });
   });
 
-  // ...and this proves it is really wired into validation with the same gating as
-  // fullPage, not just present as an inert key.
+  // ...and this proves it is wired into validation with fullPage's gating, not inert.
   it('flags scaleToFit on a non-automate token, exactly like fullPage', () => {
     PercyConfig.addSchema(CoreConfig.schemas);
     const errors = PercyConfig.validate({ fullPage: true, scaleToFit: true }, '/config/snapshot');
@@ -142,8 +133,7 @@ describe('SnapshotSchema', () => {
 
     expect(paths).toContain('scaleToFit');
     expect(paths).toContain('fullPage');
-    // Same message as fullPage, and crucially NOT 'unknown property' -- an unknown-property
-    // error would mean the schema entry is missing and this spec passes vacuously.
+    // NOT 'unknown property', which would mean the entry is missing and this passes vacuously.
     expect([...messages]).toEqual(['property only valid with Automate integration.']);
   });
 });

--- a/packages/core/test/unit/config.test.js
+++ b/packages/core/test/unit/config.test.js
@@ -120,7 +120,9 @@ describe('SnapshotSchema', () => {
   // Structural, not a validate() round-trip: onlyAutomate is evaluated when AJV COMPILES
   // the schema, so flipping PERCY_TOKEN inside a spec cannot change the outcome.
   it('declares scaleToFit as an automate-only boolean', () => {
-    expect(CoreConfig.schemas[0].snapshot.properties.scaleToFit)
+    // The config schema is the one entry with no $id; index into that rather than [0].
+    const configSchema = CoreConfig.schemas.find(s => !s.$id);
+    expect(configSchema.snapshot.properties.scaleToFit)
       .toEqual({ type: 'boolean', onlyAutomate: true });
   });
 
@@ -136,6 +138,41 @@ describe('SnapshotSchema', () => {
     // An undeclared key would draw 'unknown property' here while fullPage drew none, so
     // this still fails if the schema entry goes missing.
     expect(messagesFor('scaleToFit')).not.toContain('unknown property');
+  });
+});
+
+describe('ComparisonSchema - scaleToFit metadata', () => {
+  beforeEach(() => {
+    PercyConfig.addSchema(CoreConfig.schemas);
+  });
+
+  // metadata sets additionalProperties:false and PercyConfig.validate DELETES unknown keys
+  // from the object it is handed, so an undeclared key is dropped before upload -- silently,
+  // with the build still green. A structural assertion would not catch that; this asserts
+  // the value survives the round trip.
+  it('keeps scaleToFit and appliedScaleFactor on the validated object', () => {
+    const options = {
+      name: 'snap',
+      tag: { name: 'Pixel 10' },
+      tiles: [],
+      metadata: { screenshotType: 'fullpage', scaleToFit: true, appliedScaleFactor: 0.380952 }
+    };
+
+    expect(PercyConfig.validate(options, '/comparison')).toBe(undefined);
+    expect(options.metadata).toEqual({
+      screenshotType: 'fullpage', scaleToFit: true, appliedScaleFactor: 0.380952
+    });
+  });
+
+  it('rejects a factor outside (0, 1]', () => {
+    const build = (appliedScaleFactor) => PercyConfig.validate({
+      name: 'snap', tag: { name: 'Pixel 10' }, tiles: [],
+      metadata: { scaleToFit: true, appliedScaleFactor }
+    }, '/comparison') || [];
+
+    expect(build(2).map(e => e.path)).toContain('metadata.appliedScaleFactor');
+    expect(build(0).map(e => e.path)).toContain('metadata.appliedScaleFactor');
+    expect(build(0.380952)).toEqual([]);
   });
 });
 

--- a/packages/core/test/unit/config.test.js
+++ b/packages/core/test/unit/config.test.js
@@ -166,7 +166,9 @@ describe('ComparisonSchema - scaleToFit metadata', () => {
 
   it('rejects a factor outside (0, 1]', () => {
     const build = (appliedScaleFactor) => PercyConfig.validate({
-      name: 'snap', tag: { name: 'Pixel 10' }, tiles: [],
+      name: 'snap',
+      tag: { name: 'Pixel 10' },
+      tiles: [],
       metadata: { scaleToFit: true, appliedScaleFactor }
     }, '/comparison') || [];
 

--- a/packages/core/test/unit/config.test.js
+++ b/packages/core/test/unit/config.test.js
@@ -124,17 +124,18 @@ describe('SnapshotSchema', () => {
       .toEqual({ type: 'boolean', onlyAutomate: true });
   });
 
-  // ...and this proves it is wired into validation with fullPage's gating, not inert.
-  it('flags scaleToFit on a non-automate token, exactly like fullPage', () => {
+  // ...and this proves it is wired into validation, not inert. Asserted RELATIVE to
+  // fullPage: onlyAutomate is compiled in from PERCY_TOKEN, which differs between a local
+  // run and CI, so an absolute expectation here passes locally and breaks in CI.
+  it('gates scaleToFit exactly like fullPage', () => {
     PercyConfig.addSchema(CoreConfig.schemas);
-    const errors = PercyConfig.validate({ fullPage: true, scaleToFit: true }, '/config/snapshot');
-    const paths = errors.map(e => e.path);
-    const messages = new Set(errors.map(e => e.message));
+    const errors = PercyConfig.validate({ fullPage: true, scaleToFit: true }, '/config/snapshot') || [];
+    const messagesFor = (path) => errors.filter(e => e.path === path).map(e => e.message);
 
-    expect(paths).toContain('scaleToFit');
-    expect(paths).toContain('fullPage');
-    // NOT 'unknown property', which would mean the entry is missing and this passes vacuously.
-    expect([...messages]).toEqual(['property only valid with Automate integration.']);
+    expect(messagesFor('scaleToFit')).toEqual(messagesFor('fullPage'));
+    // An undeclared key would draw 'unknown property' here while fullPage drew none, so
+    // this still fails if the schema entry goes missing.
+    expect(messagesFor('scaleToFit')).not.toContain('unknown property');
   });
 });
 

--- a/packages/core/test/unit/config.test.js
+++ b/packages/core/test/unit/config.test.js
@@ -116,6 +116,36 @@ describe('SnapshotSchema', () => {
     expect(errors[0].path).toBe('scope');
     expect(errors[0].message).toBe('must have property scope when property scopeOptions is present');
   });
+
+  // Automate-only options live on /config/snapshot (the .percy.yml `snapshot:` section),
+  // NOT on /snapshot -- which $refs only a hand-picked subset and so reports fullPage as
+  // an unknown property too. /config/snapshot sets additionalProperties: false, so an
+  // undeclared key is rejected there: the reason scaleToFit needs a schema entry and not
+  // just provider plumbing.
+  // Structural assertion rather than a PercyConfig.validate() round-trip: the
+  // onlyAutomate keyword is evaluated when AJV COMPILES the schema, so a validate() call
+  // reflects whatever PERCY_TOKEN was set when the schema was first added in this process
+  // -- flipping the env var inside a spec cannot change the outcome. Asserting the
+  // declaration directly is what actually pins the change.
+  it('declares scaleToFit as an automate-only boolean', () => {
+    expect(CoreConfig.schemas[0].snapshot.properties.scaleToFit)
+      .toEqual({ type: 'boolean', onlyAutomate: true });
+  });
+
+  // ...and this proves it is really wired into validation with the same gating as
+  // fullPage, not just present as an inert key.
+  it('flags scaleToFit on a non-automate token, exactly like fullPage', () => {
+    PercyConfig.addSchema(CoreConfig.schemas);
+    const errors = PercyConfig.validate({ fullPage: true, scaleToFit: true }, '/config/snapshot');
+    const paths = errors.map(e => e.path);
+    const messages = new Set(errors.map(e => e.message));
+
+    expect(paths).toContain('scaleToFit');
+    expect(paths).toContain('fullPage');
+    // Same message as fullPage, and crucially NOT 'unknown property' -- an unknown-property
+    // error would mean the schema entry is missing and this spec passes vacuously.
+    expect([...messages]).toEqual(['property only valid with Automate integration.']);
+  });
 });
 
 describe('ComparisonSchema - elementSelectorsData', () => {

--- a/packages/core/test/utils.test.js
+++ b/packages/core/test/utils.test.js
@@ -81,6 +81,31 @@ describe('utils', () => {
       expect(req.body.buildInfo).toEqual({ id: 'b1' });
     });
 
+    // scaleToFit is settable at BOTH levels: globally via .percy.yml `snapshot:` (which
+    // only reaches the provider because it is enumerated in the merge above) and
+    // per-screenshot (which overrides it). Both paths are load-bearing.
+    it('carries scaleToFit from global config and lets a per-screenshot value override it', () => {
+      const base = () => ({
+        build: { id: 'b1' },
+        config: { percy: { platforms: [] }, snapshot: { percyCSS: '', scaleToFit: true } }
+      });
+
+      // global only
+      let req = { body: { options: {} } };
+      percyAutomateRequestHandler(req, base());
+      expect(req.body.options.scaleToFit).toBeTrue();
+
+      // per-screenshot snake_case wins over global
+      req = { body: { options: { scale_to_fit: false } } };
+      percyAutomateRequestHandler(req, base());
+      expect(req.body.options.scaleToFit).toBeFalse();
+
+      // per-screenshot can opt in when global is unset
+      req = { body: { options: { scaleToFit: true } } };
+      percyAutomateRequestHandler(req, { build: {}, config: { percy: {}, snapshot: { percyCSS: '' } } });
+      expect(req.body.options.scaleToFit).toBeTrue();
+    });
+
     it('handles missing client/environment and empty options', () => {
       const req = { body: { options: { } } };
       const percy = { build: { id: 'b' }, config: { percy: { platforms: [] }, snapshot: { percyCSS: '', freezeAnimation: false } } };

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -96,9 +96,8 @@ export default class AutomateProvider extends GenericProvider {
     const metadata = {
       screenshotType: screenshotType
     };
-    // percy-api needs the factor to relax its tile-count limit, since a scaleToFit capture
-    // returns ~1/factor times the usual tiles. Added only when it actually scaled: these
-    // land in the largest table on the platform, so the default path must not grow rows.
+    // percy-api needs the factor to relax its tile-count limit. Added only when it really
+    // scaled -- these land in the largest table on the platform.
     if (tileResponse.scale_to_fit === true) {
       metadata.scaleToFit = true;
       metadata.appliedScaleFactor = tileResponse.applied_scale_factor;

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -98,7 +98,7 @@ export default class AutomateProvider extends GenericProvider {
     };
     // percy-api needs the factor to relax its tile-count limit. Added only when it really
     // scaled -- these land in the largest table on the platform.
-    if (tileResponse.scale_to_fit === true) {
+    if (tileResponse.scale_to_fit === true && Number.isFinite(tileResponse.applied_scale_factor)) {
       metadata.scaleToFit = true;
       metadata.appliedScaleFactor = tileResponse.applied_scale_factor;
     }

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -96,6 +96,16 @@ export default class AutomateProvider extends GenericProvider {
     const metadata = {
       screenshotType: screenshotType
     };
+    // Forwarded so percy-api can relax its tile-count limit by exactly the amount each
+    // tile shrank: a scaleToFit capture walks a taller page and so returns ~1/factor times
+    // the usual tile count, which the unrelaxed limit would reject.
+    // Added only when mobile-common reports it actually scaled -- these land in
+    // comparison_details.metadata, the largest table on the platform, so the default path
+    // must not add constants to every row.
+    if (tileResponse.scale_to_fit === true) {
+      metadata.scaleToFit = true;
+      metadata.appliedScaleFactor = tileResponse.applied_scale_factor;
+    }
     return {
       tiles: tiles,
       domInfoSha: tileResponse.dom_sha,

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -98,9 +98,11 @@ export default class AutomateProvider extends GenericProvider {
     };
     // percy-api needs the factor to relax its tile-count limit. Added only when it really
     // scaled -- these land in the largest table on the platform.
-    if (tileResponse.scale_to_fit === true && Number.isFinite(tileResponse.applied_scale_factor)) {
+    const scaleFactor = tileResponse.applied_scale_factor;
+    if (tileResponse.scale_to_fit === true &&
+        Number.isFinite(scaleFactor) && scaleFactor > 0 && scaleFactor <= 1) {
       metadata.scaleToFit = true;
-      metadata.appliedScaleFactor = tileResponse.applied_scale_factor;
+      metadata.appliedScaleFactor = scaleFactor;
     }
     return {
       tiles: tiles,

--- a/packages/webdriver-utils/src/providers/automateProvider.js
+++ b/packages/webdriver-utils/src/providers/automateProvider.js
@@ -96,12 +96,9 @@ export default class AutomateProvider extends GenericProvider {
     const metadata = {
       screenshotType: screenshotType
     };
-    // Forwarded so percy-api can relax its tile-count limit by exactly the amount each
-    // tile shrank: a scaleToFit capture walks a taller page and so returns ~1/factor times
-    // the usual tile count, which the unrelaxed limit would reject.
-    // Added only when mobile-common reports it actually scaled -- these land in
-    // comparison_details.metadata, the largest table on the platform, so the default path
-    // must not add constants to every row.
+    // percy-api needs the factor to relax its tile-count limit, since a scaleToFit capture
+    // returns ~1/factor times the usual tiles. Added only when it actually scaled: these
+    // land in the largest table on the platform, so the default path must not grow rows.
     if (tileResponse.scale_to_fit === true) {
       metadata.scaleToFit = true;
       metadata.appliedScaleFactor = tileResponse.applied_scale_factor;

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -48,6 +48,12 @@ export default class GenericProvider {
 
   addDefaultOptions() {
     this.options.freezeAnimation = this.options.freezeAnimatedImage || this.options.freezeAnimation || false;
+    // PERCY_SCALE_TO_FIT lets a whole run opt in without touching per-snapshot config,
+    // which is how support enables it for a customer hitting the 50,000px truncation.
+    // Coerced to a real boolean: mobile-common compares with `== true`, so a truthy
+    // string would silently fail to enable scaling.
+    this.options.scaleToFit = this.options.scaleToFit === true ||
+      process.env.PERCY_SCALE_TO_FIT === 'true';
   }
 
   async createDriver() {

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -48,10 +48,8 @@ export default class GenericProvider {
 
   addDefaultOptions() {
     this.options.freezeAnimation = this.options.freezeAnimatedImage || this.options.freezeAnimation || false;
-    // PERCY_SCALE_TO_FIT lets a whole run opt in without touching per-snapshot config,
-    // which is how support enables it for a customer hitting the 50,000px truncation.
-    // Coerced to a real boolean: mobile-common compares with `== true`, so a truthy
-    // string would silently fail to enable scaling.
+    // PERCY_SCALE_TO_FIT opts a whole run in without per-snapshot config. Coerced to a
+    // real boolean: mobile-common compares with `== true`, so a truthy string would no-op.
     this.options.scaleToFit = this.options.scaleToFit === true ||
       process.env.PERCY_SCALE_TO_FIT === 'true';
   }

--- a/packages/webdriver-utils/src/providers/genericProvider.js
+++ b/packages/webdriver-utils/src/providers/genericProvider.js
@@ -50,8 +50,11 @@ export default class GenericProvider {
     this.options.freezeAnimation = this.options.freezeAnimatedImage || this.options.freezeAnimation || false;
     // PERCY_SCALE_TO_FIT opts a whole run in without per-snapshot config. Coerced to a
     // real boolean: mobile-common compares with `== true`, so a truthy string would no-op.
-    this.options.scaleToFit = this.options.scaleToFit === true ||
-      process.env.PERCY_SCALE_TO_FIT === 'true';
+    // fullPage-only: the host shrinks tiles solely in its full-page loop, so outside it the
+    // flag would report a scale factor for tiles that were never scaled.
+    this.options.scaleToFit = this.options.fullPage === true &&
+      (this.options.scaleToFit === true ||
+        (this.options.scaleToFit !== false && process.env.PERCY_SCALE_TO_FIT === 'true'));
   }
 
   async createDriver() {

--- a/packages/webdriver-utils/src/providers/playwrightProvider.js
+++ b/packages/webdriver-utils/src/providers/playwrightProvider.js
@@ -134,6 +134,12 @@ export default class PlaywrightProvider extends GenericProvider {
     const metadata = {
       screenshotType: screenshotType
     };
+    // Same pair as automateProvider: the host shrinks tiles, so percy-api needs the factor
+    // to relax its tile-count limit. Without this a playwright capture reports none.
+    if (tileResponse.scale_to_fit === true && Number.isFinite(tileResponse.applied_scale_factor)) {
+      metadata.scaleToFit = true;
+      metadata.appliedScaleFactor = tileResponse.applied_scale_factor;
+    }
     return {
       tiles: tiles,
       domInfoSha: tileResponse.dom_sha,

--- a/packages/webdriver-utils/src/providers/playwrightProvider.js
+++ b/packages/webdriver-utils/src/providers/playwrightProvider.js
@@ -42,6 +42,10 @@ export default class PlaywrightProvider extends GenericProvider {
   async screenshot(name, options) {
     let response = null;
     let error;
+    // This override does not call super.screenshot(), which is where GenericProvider applies
+    // addDefaultOptions -- so without this the scaleToFit fullPage gate, its boolean
+    // coercion and PERCY_SCALE_TO_FIT were all skipped on the playwright path.
+    this.addDefaultOptions();
     log.debug(`[${name}] : Preparing to capture screenshots on playwright with automate ...`);
     try {
       log.debug(`[${name}] : Marking automate session as percy ...`);
@@ -136,9 +140,11 @@ export default class PlaywrightProvider extends GenericProvider {
     };
     // Same pair as automateProvider: the host shrinks tiles, so percy-api needs the factor
     // to relax its tile-count limit. Without this a playwright capture reports none.
-    if (tileResponse.scale_to_fit === true && Number.isFinite(tileResponse.applied_scale_factor)) {
+    const scaleFactor = tileResponse.applied_scale_factor;
+    if (tileResponse.scale_to_fit === true &&
+        Number.isFinite(scaleFactor) && scaleFactor > 0 && scaleFactor <= 1) {
       metadata.scaleToFit = true;
-      metadata.appliedScaleFactor = tileResponse.applied_scale_factor;
+      metadata.appliedScaleFactor = scaleFactor;
     }
     return {
       tiles: tiles,

--- a/packages/webdriver-utils/test/providers/automateProvider.test.js
+++ b/packages/webdriver-utils/test/providers/automateProvider.test.js
@@ -331,9 +331,7 @@ describe('AutomateProvider', () => {
         expect(res).toEqual(expectedOutput);
       });
 
-      // percy-api relaxes its tile-count limit by this factor, so it has to reach the
-      // comparison payload -- a scaleToFit capture walks a taller page and returns ~1/factor
-      // times the usual tile count, which the unrelaxed limit would reject.
+      // percy-api relaxes its tile-count limit by this factor, so it must reach the payload.
       it('forwards scaleToFit and the applied factor into metadata when scaling happened', async () => {
         const response = {
           success: true,
@@ -356,8 +354,7 @@ describe('AutomateProvider', () => {
         });
       });
 
-      // These land in comparison_details.metadata, the largest table on the platform, so
-      // the default path must not add constants to every row.
+      // These land in the largest table on the platform; don't grow every row.
       it('omits the scaleToFit metadata keys when mobile-common did not scale', async () => {
         const response = {
           success: true,

--- a/packages/webdriver-utils/test/providers/automateProvider.test.js
+++ b/packages/webdriver-utils/test/providers/automateProvider.test.js
@@ -331,6 +331,50 @@ describe('AutomateProvider', () => {
         expect(res).toEqual(expectedOutput);
       });
 
+      // percy-api relaxes its tile-count limit by this factor, so it has to reach the
+      // comparison payload -- a scaleToFit capture walks a taller page and returns ~1/factor
+      // times the usual tile count, which the unrelaxed limit would reject.
+      it('forwards scaleToFit and the applied factor into metadata when scaling happened', async () => {
+        const response = {
+          success: true,
+          result: JSON.stringify({
+            tiles: [{ sha: 'abc', index: 0 }],
+            dom_sha: 'def',
+            scale_to_fit: true,
+            applied_scale_factor: 0.38095238095
+          })
+        };
+        spyOn(AutomateProvider.prototype, 'browserstackExecutor')
+          .and.returnValue(Promise.resolve({ value: JSON.stringify(response) }));
+        await automateProvider.createDriver();
+        const res = await automateProvider.getTiles(false);
+
+        expect(res.metadata).toEqual({
+          screenshotType: 'fullpage',
+          scaleToFit: true,
+          appliedScaleFactor: 0.38095238095
+        });
+      });
+
+      // These land in comparison_details.metadata, the largest table on the platform, so
+      // the default path must not add constants to every row.
+      it('omits the scaleToFit metadata keys when mobile-common did not scale', async () => {
+        const response = {
+          success: true,
+          result: JSON.stringify({
+            tiles: [{ sha: 'abc', index: 0 }],
+            dom_sha: 'def',
+            scale_to_fit: false
+          })
+        };
+        spyOn(AutomateProvider.prototype, 'browserstackExecutor')
+          .and.returnValue(Promise.resolve({ value: JSON.stringify(response) }));
+        await automateProvider.createDriver();
+        const res = await automateProvider.getTiles(false);
+
+        expect(res.metadata).toEqual({ screenshotType: 'fullpage' });
+      });
+
       it('should return default values of header and footer if not in response', async () => {
         const response = {
           success: true,

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -52,33 +52,50 @@ describe('GenericProvider', () => {
       expect(provider.options.freezeAnimation).toBeFalse();
     });
 
-    it('enables scaleToFit from the option or PERCY_SCALE_TO_FIT', () => {
-      let provider = new GenericProvider({ options: { scaleToFit: true } });
-      provider.addDefaultOptions();
-      expect(provider.options.scaleToFit).toBeTrue();
+    describe('scaleToFit', () => {
+      const build = (options) => {
+        const provider = new GenericProvider({ options });
+        provider.addDefaultOptions();
+        return provider.options.scaleToFit;
+      };
 
-      process.env.PERCY_SCALE_TO_FIT = 'true';
-      provider = new GenericProvider({ options: {} });
-      provider.addDefaultOptions();
-      expect(provider.options.scaleToFit).toBeTrue();
+      beforeEach(() => { delete process.env.PERCY_SCALE_TO_FIT; });
+      afterEach(() => { delete process.env.PERCY_SCALE_TO_FIT; });
 
-      delete process.env.PERCY_SCALE_TO_FIT;
-      provider = new GenericProvider({ options: {} });
-      provider.addDefaultOptions();
-      expect(provider.options.scaleToFit).toBeFalse();
-    });
+      it('enables from the option or PERCY_SCALE_TO_FIT', () => {
+        expect(build({ fullPage: true, scaleToFit: true })).toBeTrue();
 
-    // mobile-common compares with `== true`, so a merely-truthy value would silently no-op.
-    it('coerces scaleToFit to a real boolean', () => {
-      const provider = new GenericProvider({ options: { scaleToFit: 'true' } });
-      provider.addDefaultOptions();
-      expect(provider.options.scaleToFit).toBeFalse();
+        process.env.PERCY_SCALE_TO_FIT = 'true';
+        expect(build({ fullPage: true })).toBeTrue();
 
-      process.env.PERCY_SCALE_TO_FIT = '1';
-      const other = new GenericProvider({ options: {} });
-      other.addDefaultOptions();
-      expect(other.options.scaleToFit).toBeFalse();
-      delete process.env.PERCY_SCALE_TO_FIT;
+        delete process.env.PERCY_SCALE_TO_FIT;
+        expect(build({ fullPage: true })).toBeFalse();
+      });
+
+      // The host only shrinks tiles in its full-page loop, so outside it the flag would
+      // report a scale factor for tiles that were never scaled.
+      it('is ignored without fullPage', () => {
+        expect(build({ scaleToFit: true })).toBeFalse();
+        expect(build({ fullPage: false, scaleToFit: true })).toBeFalse();
+
+        process.env.PERCY_SCALE_TO_FIT = 'true';
+        expect(build({})).toBeFalse();
+      });
+
+      // The env var is a run-wide default, not an override -- otherwise a single snapshot
+      // could never opt out once it is set.
+      it('lets an explicit false beat the env var', () => {
+        process.env.PERCY_SCALE_TO_FIT = 'true';
+        expect(build({ fullPage: true, scaleToFit: false })).toBeFalse();
+      });
+
+      // mobile-common compares with `== true`, so a merely-truthy value would silently no-op.
+      it('coerces to a real boolean', () => {
+        expect(build({ fullPage: true, scaleToFit: 'true' })).toBeFalse();
+
+        process.env.PERCY_SCALE_TO_FIT = '1';
+        expect(build({ fullPage: true })).toBeFalse();
+      });
     });
   });
 

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -68,8 +68,7 @@ describe('GenericProvider', () => {
       expect(provider.options.scaleToFit).toBeFalse();
     });
 
-    // mobile-common compares the forwarded option with `== true`, so anything that is
-    // merely truthy would arrive as a no-op and silently truncate the page instead.
+    // mobile-common compares with `== true`, so a merely-truthy value would silently no-op.
     it('coerces scaleToFit to a real boolean', () => {
       const provider = new GenericProvider({ options: { scaleToFit: 'true' } });
       provider.addDefaultOptions();

--- a/packages/webdriver-utils/test/providers/genericProvider.test.js
+++ b/packages/webdriver-utils/test/providers/genericProvider.test.js
@@ -51,6 +51,36 @@ describe('GenericProvider', () => {
       provider.addDefaultOptions();
       expect(provider.options.freezeAnimation).toBeFalse();
     });
+
+    it('enables scaleToFit from the option or PERCY_SCALE_TO_FIT', () => {
+      let provider = new GenericProvider({ options: { scaleToFit: true } });
+      provider.addDefaultOptions();
+      expect(provider.options.scaleToFit).toBeTrue();
+
+      process.env.PERCY_SCALE_TO_FIT = 'true';
+      provider = new GenericProvider({ options: {} });
+      provider.addDefaultOptions();
+      expect(provider.options.scaleToFit).toBeTrue();
+
+      delete process.env.PERCY_SCALE_TO_FIT;
+      provider = new GenericProvider({ options: {} });
+      provider.addDefaultOptions();
+      expect(provider.options.scaleToFit).toBeFalse();
+    });
+
+    // mobile-common compares the forwarded option with `== true`, so anything that is
+    // merely truthy would arrive as a no-op and silently truncate the page instead.
+    it('coerces scaleToFit to a real boolean', () => {
+      const provider = new GenericProvider({ options: { scaleToFit: 'true' } });
+      provider.addDefaultOptions();
+      expect(provider.options.scaleToFit).toBeFalse();
+
+      process.env.PERCY_SCALE_TO_FIT = '1';
+      const other = new GenericProvider({ options: {} });
+      other.addDefaultOptions();
+      expect(other.options.scaleToFit).toBeFalse();
+      delete process.env.PERCY_SCALE_TO_FIT;
+    });
   });
 
   describe('supports', () => {

--- a/packages/webdriver-utils/test/providers/playwrightProvider.test.js
+++ b/packages/webdriver-utils/test/providers/playwrightProvider.test.js
@@ -368,6 +368,58 @@ describe('PlaywrightProvider', () => {
       });
     });
 
+    it('reports the scale factor when the host shrank the tiles', async () => {
+      const provider = new PlaywrightProvider(
+        'sessionId', 'frameGuid', 'pageGuid', 'clientInfo', 'environmentInfo',
+        { fullPage: true, scaleToFit: true }, { id: 1 }
+      );
+      provider.browserstackExecutor = jasmine
+        .createSpy('browserstackExecutor')
+        .and.resolveTo({
+          value: JSON.stringify({
+            success: true,
+            result: JSON.stringify({
+              tiles: [{ status_bar: 0, nav_bar: 0, header_height: 0, footer_height: 0, sha: 't1' }],
+              comparison_tag_data: { width: 411, height: 858, resolution: '1080x2251' },
+              dom_sha: 'domSHA',
+              scale_to_fit: true,
+              applied_scale_factor: 0.380952
+            })
+          })
+        });
+
+      const response = await provider.getTiles(true);
+
+      expect(response.metadata).toEqual({
+        screenshotType: 'fullpage', scaleToFit: true, appliedScaleFactor: 0.380952
+      });
+    });
+
+    // A half-pair would ask percy-api to relax its tile limit by nothing.
+    it('omits the pair when the factor is missing', async () => {
+      const provider = new PlaywrightProvider(
+        'sessionId', 'frameGuid', 'pageGuid', 'clientInfo', 'environmentInfo',
+        { fullPage: true, scaleToFit: true }, { id: 1 }
+      );
+      provider.browserstackExecutor = jasmine
+        .createSpy('browserstackExecutor')
+        .and.resolveTo({
+          value: JSON.stringify({
+            success: true,
+            result: JSON.stringify({
+              tiles: [{ status_bar: 0, nav_bar: 0, header_height: 0, footer_height: 0, sha: 't1' }],
+              comparison_tag_data: { width: 411, height: 858, resolution: '1080x2251' },
+              dom_sha: 'domSHA',
+              scale_to_fit: true
+            })
+          })
+        });
+
+      const response = await provider.getTiles(true);
+
+      expect(response.metadata).toEqual({ screenshotType: 'fullpage' });
+    });
+
     it('should handle errors during tile capture', async () => {
       const error = new Error('Failed to capture tiles');
       provider.browserstackExecutor = jasmine

--- a/packages/webdriver-utils/test/providers/playwrightProvider.test.js
+++ b/packages/webdriver-utils/test/providers/playwrightProvider.test.js
@@ -13,7 +13,7 @@ describe('PlaywrightProvider', () => {
       'pageGuid',
       'clientInfo',
       'environmentInfo',
-      'options',
+      {},
       { id: 1 }
     );
   });
@@ -25,7 +25,7 @@ describe('PlaywrightProvider', () => {
       expect(provider.pageGuid).toBe('pageGuid');
       expect(provider.clientInfo).toBe('clientInfo');
       expect(provider.environmentInfo).toBe('environmentInfo');
-      expect(provider.options).toBe('options');
+      expect(provider.options).toEqual({});
       expect(provider.buildInfo).toEqual({ id: 1 });
     });
   });
@@ -206,7 +206,7 @@ describe('PlaywrightProvider', () => {
           percyBuildId: 1,
           screenshotType: 'singlepage',
           scaleFactor: 1,
-          options: 'options',
+          options: {},
           frameworkData: { frameGuid: 'frameGuid', pageGuid: 'pageGuid' },
           framework: 'playwright'
         }
@@ -260,7 +260,7 @@ describe('PlaywrightProvider', () => {
           percyBuildId: 1,
           screenshotType: 'singlepage',
           scaleFactor: 1,
-          options: 'options',
+          options: {},
           frameworkData: { frameGuid: 'frameGuid', pageGuid: 'pageGuid' },
           framework: 'playwright'
         }


### PR DESCRIPTION
## Why

Full-page POA captures are bounded by a 50,000px stitched-image budget. mobile-common enforces it by truncating the DOM walk at `MAX_PIXEL_HEIGHT_LIMIT / dpr` — **16,666 CSS px at DPR 3** — so any page taller than that silently loses its tail. That is the PER-10298 / PPLT-5851 dealblocker (Adecco, Akkodis).

`scaleToFit` opts a capture into downscaling every tile by a fixed `1/dpr` instead, so a page of up to 50,000 **CSS** px lands exactly on the same budget: `page_height × dpr × (1/dpr) == page_height`.

## Why the factor is fixed, not height-derived

Percy diffs pixel to pixel, and a uniform resize moves **both** dimensions. A height-derived factor would make output **width** a function of page height — so a page drifting from 16,600 to 18,000 px would change width, leaving snapshot and baseline with *different dimensions*: unalignable, not merely different.

Constant width forces a constant factor, and the ceiling forces `f ≤ 50000/(50000 × 3) = 1/3`. The three constraints (constant width, ≤ 50,000px, coverage to 50,000 CSS px) are only jointly satisfiable at `f = 1/dpr`. It is also opt-in, so quality never changes for anyone who does not ask for it.

## Changes

**`packages/core/src/config.js`** — declare `scaleToFit` on the snapshot schema. That section sets `additionalProperties: false`, so without a declaration the key is **rejected before it ever reaches the Automate session**. Gated `onlyAutomate`, exactly like `fullPage`.

**`packages/webdriver-utils/src/providers/genericProvider.js`** — `PERCY_SCALE_TO_FIT` in `addDefaultOptions()`, so a whole run can opt in without editing per-snapshot config (how support would enable this for an affected customer). Coerced to a real boolean, because mobile-common compares with `== true` and a truthy string would silently no-op.

**No provider changes needed.** `automateProvider.getTiles()` already forwards `options` wholesale and SeleniumHub passes it through verbatim, so the camelCase spelling is the contract with mobile-common.

## Notes for review

Two things I got wrong first and corrected, worth knowing if you extend these tests:

- Automate options live on **`/config/snapshot`**, not `/snapshot` — the latter `$ref`s only a hand-picked subset and reports even `fullPage` as `unknown property`. My first specs validated against `/snapshot` and passed **vacuously**.
- `onlyAutomate` is evaluated when AJV **compiles** the schema, not per-validation, so flipping `PERCY_TOKEN` inside a spec cannot change the outcome. The specs now assert the declaration structurally *plus* the real validation error, and explicitly assert the message is not `unknown property` so they cannot pass vacuously again.

## Testing

- `packages/webdriver-utils`: **240/240**
- `packages/core` `test/unit/config.test.js`: **21/21**
- `eslint` clean on all four files

The full `packages/core` suite does not pass in my environment — 155 failures, all `Failed to launch browser / Timed out after 30000ms`, i.e. Chrome cannot start here. Unrelated to this change, but I could not use it as a signal, so I ran the config specs in isolation.

## Depends on

browserstack/mobile-common#1255 — the capture-side implementation. This PR only plumbs the option; without it the option is accepted and ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)