### PR TITLE
fix(dom): stop duplicating authored <style> text in cloneNodeAndShadow

### DIFF
--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -79,21 +79,26 @@ export function cloneNodeAndShadow(ctx) {
 
       // Handle <style> tag specifically for media queries
       if (node.nodeName === 'STYLE' && !enableJavaScript) {
-        let cssText = node.textContent?.trim() || '';
-        if (!cssText && node.sheet) {
+        let ownText = node.textContent?.trim() || '';
+        // Only synthesize text for CSSOM-only sheets (JS-inserted, no text
+        // node of their own). A <style> that already has its own text gets
+        // it from walkTree below — setting clone.textContent here as well
+        // would duplicate it (walkTree re-clones the live text node right
+        // after), doubling the parsed rule count and defeating
+        // serializeCSSOM's identity guard (styleSheetsMatch).
+        if (!ownText && node.sheet) {
           try {
             const cssRules = node.sheet.cssRules;
             if (cssRules && cssRules.length > 0) {
-              cssText = Array.from(cssRules).map(rule => rule.cssText).join('\n');
+              let cssText = Array.from(cssRules).map(rule => rule.cssText).join('\n');
+              if (cssText) {
+                clone.textContent = cssText;
+                clone.setAttribute('data-percy-cssom-serialized', 'true');
+              }
             }
           } catch (_) {
             // ignore errors
           }
-        }
-
-        if (cssText) {
-          clone.textContent = cssText;
-          clone.setAttribute('data-percy-cssom-serialized', 'true');
         }
       }
 

--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -80,12 +80,6 @@ export function cloneNodeAndShadow(ctx) {
       // Handle <style> tag specifically for media queries
       if (node.nodeName === 'STYLE' && !enableJavaScript) {
         let ownText = node.textContent?.trim() || '';
-        // Only synthesize text for CSSOM-only sheets (JS-inserted, no text
-        // node of their own). A <style> that already has its own text gets
-        // it from walkTree below — setting clone.textContent here as well
-        // would duplicate it (walkTree re-clones the live text node right
-        // after), doubling the parsed rule count and defeating
-        // serializeCSSOM's identity guard (styleSheetsMatch).
         if (!ownText && node.sheet) {
           try {
             const cssRules = node.sheet.cssRules;

--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -27,8 +27,7 @@ function styleSheetsMatch(sheetA, sheetB) {
   // Only treat as mismatch when the live sheet has MORE rules than the
   // clone — that signals rules were added via CSSOM (insertRule/adopted)
   // and must be re-serialized. When lenA <= lenB, the clone already
-  // contains all of the live rules (often duplicated by clone-dom's
-  // <style> textContent handling); trust the clone's source text so that
+  // contains all of the live rules; trust the clone's source text so that
   // CSS shorthand semantics (e.g. `all: initial; border-radius: var(...)`)
   // survive — `cssRule.cssText` expansion appends logical longhands like
   // `border-end-end-radius: initial` AFTER the shorthand, which silently

--- a/packages/dom/test/serialize-css.test.js
+++ b/packages/dom/test/serialize-css.test.js
@@ -44,8 +44,14 @@ describe('serializeCSSOM', () => {
       it(`${platform}: serializes CSSOM and does not mutate the orignal DOM`, () => {
         let $cssom = parseDOM(serializeDOM(), platform)('[data-percy-cssom-serialized]');
 
-        // linked and unmodified stylesheets are not included
-        expect($cssom).toHaveSize(3);
+        // linked and unmodified stylesheets are not included. Plain
+        // authored <style> tags with unchanged content (e.g. `style`
+        // below, `.box { background: green; }`) are cloned via walkTree,
+        // not synthesized from CSSOM, so they never carry this marker
+        // either — clone-dom previously set it unconditionally whenever
+        // it had any text to clone, which falsely flagged every ordinary
+        // <style> as CSSOM-serialized (PER-10567).
+        expect($cssom).toHaveSize(2);
         expect($cssom[0].innerHTML).toBe('.box { height: 500px; }');
         expect($cssom[1].innerHTML).toBe('.box { width: 1000px; }');
 
@@ -83,7 +89,9 @@ describe('serializeCSSOM', () => {
         cssomSheet.deleteRule(0); // Remove all rules to make it empty
         const serialized = serializeDOM();
         let $cssom = parseDOM(serialized, platform)('[data-percy-cssom-serialized]');
-        expect($cssom).toHaveSize(2); // should skip the empty stylesheet
+        // should skip the empty stylesheet; only `mod` (genuinely
+        // CSSOM-mutated) remains marked — see PER-10567 note above.
+        expect($cssom).toHaveSize(1);
       });
 
       it(`${platform}: preserves media queries inside CSSOM`, () => {
@@ -548,6 +556,31 @@ describe('serializeCSSOM', () => {
       const reserialized = clone.querySelector('[data-percy-cssom-serialized]');
       expect(reserialized).not.toBeNull();
       expect(reserialized.textContent).toContain('.live-only');
+    });
+
+    it('clone-dom does not duplicate authored <style> text end-to-end (preserves `background: var(--x)` shorthand)', () => {
+      // PER-10567: clone-dom previously set clone.textContent = cssText for
+      // every <style> (even ones with their own authored text), and the
+      // subsequent generic walkTree call re-cloned the live text node on
+      // top of that — doubling the parsed rule count. This is the same
+      // failure mode the styleSheetsMatch relaxation above tolerates for a
+      // clean duplicate, but a real page's stylesheet can still fail that
+      // guard (e.g. any unrelated CSSOM mutation elsewhere in the same
+      // sheet), forcing a full lossy re-serialization that expands
+      // shorthands like `background: var(--x)` into empty longhands. The
+      // fix is to never duplicate in the first place: only synthesize
+      // clone.textContent for CSSOM-only sheets that have no text node of
+      // their own.
+      withExample('<style id="var-shorthand">.box { all: initial; background: var(--x); background-clip: text; }</style>', { withShadow: false });
+
+      let liveStyle = document.getElementById('var-shorthand');
+      let liveText = liveStyle.textContent;
+
+      let $ = parseDOM(serializeDOM(), 'plain');
+      let clonedStyle = $('#var-shorthand')[0];
+
+      expect(clonedStyle.innerHTML).toBe(liveText);
+      expect(clonedStyle.getAttribute('data-percy-cssom-serialized')).toBeNull();
     });
   });
 });

--- a/packages/dom/test/serialize-css.test.js
+++ b/packages/dom/test/serialize-css.test.js
@@ -463,23 +463,14 @@ describe('serializeCSSOM', () => {
 
   describe('regression: cloned <style> text-node duplication', () => {
     // serializeCSSOM decides whether to re-serialize each in-memory CSSOM
-    // stylesheet via styleSheetsMatch(liveSheet, cloneSheet). Cloned <style>
-    // elements in real snapshots can end up with the original text node
-    // appended twice (clone-dom assigns clone.textContent = ... and the
-    // subsequent generic walkTree re-clones the original text node). The
-    // parsed cloneSheet then has 2x the rules of liveSheet.
-    //
-    // Strict length equality (`lenA !== lenB`) treats that as a mismatch
-    // and forces re-serialization via Array.from(liveSheet.cssRules).map(
-    // r => r.cssText), which is NOT semantically identity-preserving:
-    // Chromium expands `all: initial` into hundreds of longhands and
-    // emits logical-property longhands (border-end-end-radius: initial,
-    // ...) AFTER the shorthand it sat next to in source, silently
-    // overriding `border-radius: var(--x)` with 0.
-    //
-    // styleSheetsMatch must therefore tolerate lenB > lenA when every
-    // live rule still appears in the clone (re-serialization is only
-    // required when the live sheet has rules the clone is missing).
+    // stylesheet via styleSheetsMatch(liveSheet, cloneSheet). It must
+    // tolerate lenB > lenA when every live rule still appears in the clone:
+    // re-serialization via Array.from(liveSheet.cssRules).map(r => r.cssText)
+    // is NOT semantically identity-preserving — Chromium expands
+    // `all: initial` into hundreds of longhands and emits logical-property
+    // longhands (border-end-end-radius: initial, ...) AFTER the shorthand
+    // it sat next to in source, silently overriding
+    // `border-radius: var(--x)` with 0.
 
     it('skips re-serialization when clone <style> text duplicates the live rules — preserves `all: initial; border-radius: var(--x)` semantics', () => {
       withExample('<div class="box"></div>', { withShadow: false });
@@ -492,8 +483,7 @@ describe('serializeCSSOM', () => {
       const clone = document.createDocumentFragment();
       const cloneOwner = document.createElement('style');
       cloneOwner.setAttribute('data-percy-element-id', 'dup-regression');
-      // Duplicate the source rule — what clone-dom currently produces.
-      // styleSheetFromNode will parse this into a sheet with 2 rules,
+      // styleSheetFromNode parses this into a sheet with 2 rules,
       // while the live sheet has 1.
       cloneOwner.textContent = liveRuleText + '\n' + liveRuleText;
       clone.appendChild(cloneOwner);

--- a/packages/dom/test/serialize-css.test.js
+++ b/packages/dom/test/serialize-css.test.js
@@ -44,13 +44,7 @@ describe('serializeCSSOM', () => {
       it(`${platform}: serializes CSSOM and does not mutate the orignal DOM`, () => {
         let $cssom = parseDOM(serializeDOM(), platform)('[data-percy-cssom-serialized]');
 
-        // linked and unmodified stylesheets are not included. Plain
-        // authored <style> tags with unchanged content (e.g. `style`
-        // below, `.box { background: green; }`) are cloned via walkTree,
-        // not synthesized from CSSOM, so they never carry this marker
-        // either — clone-dom previously set it unconditionally whenever
-        // it had any text to clone, which falsely flagged every ordinary
-        // <style> as CSSOM-serialized (PER-10567).
+        // linked, unmodified and plain authored stylesheets are not included
         expect($cssom).toHaveSize(2);
         expect($cssom[0].innerHTML).toBe('.box { height: 500px; }');
         expect($cssom[1].innerHTML).toBe('.box { width: 1000px; }');
@@ -89,9 +83,7 @@ describe('serializeCSSOM', () => {
         cssomSheet.deleteRule(0); // Remove all rules to make it empty
         const serialized = serializeDOM();
         let $cssom = parseDOM(serialized, platform)('[data-percy-cssom-serialized]');
-        // should skip the empty stylesheet; only `mod` (genuinely
-        // CSSOM-mutated) remains marked — see PER-10567 note above.
-        expect($cssom).toHaveSize(1);
+        expect($cssom).toHaveSize(1); // should skip the empty stylesheet
       });
 
       it(`${platform}: preserves media queries inside CSSOM`, () => {
@@ -558,19 +550,7 @@ describe('serializeCSSOM', () => {
       expect(reserialized.textContent).toContain('.live-only');
     });
 
-    it('clone-dom does not duplicate authored <style> text end-to-end (preserves `background: var(--x)` shorthand)', () => {
-      // PER-10567: clone-dom previously set clone.textContent = cssText for
-      // every <style> (even ones with their own authored text), and the
-      // subsequent generic walkTree call re-cloned the live text node on
-      // top of that — doubling the parsed rule count. This is the same
-      // failure mode the styleSheetsMatch relaxation above tolerates for a
-      // clean duplicate, but a real page's stylesheet can still fail that
-      // guard (e.g. any unrelated CSSOM mutation elsewhere in the same
-      // sheet), forcing a full lossy re-serialization that expands
-      // shorthands like `background: var(--x)` into empty longhands. The
-      // fix is to never duplicate in the first place: only synthesize
-      // clone.textContent for CSSOM-only sheets that have no text node of
-      // their own.
+    it('does not duplicate authored <style> text, preserving `background: var(--x)` shorthands', () => {
       withExample('<style id="var-shorthand">.box { all: initial; background: var(--x); background-clip: text; }</style>', { withShadow: false });
 
       let liveStyle = document.getElementById('var-shorthand');


### PR DESCRIPTION
Fixes [PER-10567](https://browserstack.atlassian.net/browse/PER-10567)

## Root cause

`cloneNodeAndShadow`'s `STYLE` branch — added in #1884 to capture CSSOM-only (JS-inserted) `<style>` sheets — set `clone.textContent = cssText` for **every** `<style>`, including ones with their own authored text:

```js
let cssText = node.textContent?.trim() || '';   // authored text
if (!cssText && node.sheet) { /* synthesize from cssRules */ }
if (cssText) {                                  // ran for authored styles too
  clone.textContent = cssText;
  clone.setAttribute('data-percy-cssom-serialized', 'true');
}
```

`clone` is a **shallow** clone (`element.cloneNode()`), and the generic `walkTree(node.firstChild, clone)` call further down re-clones the live text node onto it. So for any `<style>` with authored text, the CSS was written into the clone twice — once manually here, once by `walkTree`.

Three consequences:

1. **Every inline `<style>` with authored text shipped twice** in the serialized DOM of every snapshot, since March 2025.
2. **`data-percy-cssom-serialized="true"` was set on every non-empty `<style>`**, not only on sheets actually re-serialized from CSSOM — a false positive for essentially every ordinary `<style>` tag.
3. The doubled clone sheet parses to twice the rule count, which broke `serializeCSSOM`'s identity guard `styleSheetsMatch(liveSheet, styleSheetFromNode(cloneOwnerNode))`. Before #2228 that guard rejected on `lenA !== lenB`, so a doubled sheet **always** fell through to the lossy `cssRules.map(r => r.cssText)` path.

That lossy path is what produced the reported symptom. Chrome cannot serialize a `var()`-containing shorthand that a later longhand partially overrides, so it expands it into pending-substitution longhands that serialize empty:

```css
/* live */
#global-translate-button .button__text { background: var(--nyc-ref-gradient-rainbow); background-clip: text; color: transparent }

/* re-serialized from cssRules */
#global-translate-button .button__text { background-image: ; background-position-x: ; …; background-color: ; background-clip: text; color: transparent }
```

`color: transparent` and `background-clip: text` survive, the gradient does not — the text renders invisible. One customer page produced 278 empty declarations in a single sheet this way. The loss is not recoverable downstream: `rule.style.getPropertyValue('background')` also returns `""` for this shape, so the authored text is the only source of truth.

## Fix

Only synthesize `clone.textContent` when the `<style>` has no text node of its own — i.e. CSSOM-only sheets, which is what #1884 was actually for. A `<style>` with authored text now gets it exactly once, from `walkTree`, and no longer carries the CSSOM marker.

## Verification

Repro page (`background: var(--gradient); background-clip: text; color: transparent`, mirroring the customer rule), served locally, serialized in real Chrome via CDP with the `@percy/dom` bundle built from each branch:

| | master (`9352a73`) | this PR |
|---|---|---|
| serialized DOM | 2618 chars | **1943 chars (−25.8%)** |
| total `<style>` content | 1664 chars | **1024 chars (−38.5%)** |
| authored `<style>` content | 1284 chars (CSS present twice) | **644 chars (present once)** |
| `data-percy-cssom-serialized` markers | 2 (1 false) | **1 (correct)** |

Percy builds on the same page, fix build based on the master build:

- baseline (master bundle): https://percy.io/9560f98d/web/test-pranav-8a4f5725/builds/53173287
- fix (this branch): https://percy.io/9560f98d/web/test-pranav-8a4f5725/builds/53173297 — **0 diffs / 5 comparisons**

So the change is render-neutral while removing ~26% of the serialized DOM on a page with two inline `<style>` tags.

Tests: `yarn workspace @percy/dom test --karma.browsers ChromeHeadless` — 496/496 passing. `yarn workspace @percy/dom build` — passes.

- New regression test: an authored `<style>` with a `var()` shorthand survives `serializeDOM()` with its text intact, exactly once, and unmarked.
- Two pre-existing `serialize-cssom` tests had the false-positive marker counts baked in as expectations (3 → 2, 2 → 1) and are corrected.
- No regression to #1884's intent: a CSSOM-only `<style>` (including `@media` rules inserted via `insertRule`) is still captured and still marked — covered by the existing `preserves media queries inside CSSOM` / `maintains order of CSSOM serialization` tests, and re-confirmed manually.

## Scope — what this does not fix

#2228 later relaxed `styleSheetsMatch` to only reject when `lenA > lenB`, which tolerates a *clean* doubling. So on 1.32.0+ the duplication no longer forces the lossy path by itself; consequence 3 above only bites on 1.30.x–1.31.x (relevant to products bundling an older `percyDom.js`).

A sheet that has any genuine CSSOM delta — `insertRule`, `deleteRule`, or an in-place `rule.style` mutation — still fails the guard and still goes through the lossy re-serialization, losing `var()` shorthands for the **whole** sheet. Verified on both master and this branch: the repro page's second `<style>` (authored text + one `insertRule`) yields 8 empty declarations on both, i.e. the invisible-gradient symptom persists there.

That remaining defect is in `serializeCSSOM`, not `clone-dom`: it replaces the clone's authored text wholesale instead of applying only the delta, and the lost value is unrecoverable from CSSOM. It needs a separate fix and is deliberately out of scope here. This PR removes the duplication that made the guard unreliable in the first place, and is a prerequisite for any per-rule delta approach.


[PER-10567]: https://browserstack.atlassian.net/browse/PER-10567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ