### PR TITLE
fix(dom): make interactive-state serialization opt-in, default off (PER-10588)

### DIFF
--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -337,6 +337,10 @@ export const configSchema = {
           minLength: 1
         }
       },
+      enablePseudoClassSerialization: {
+        type: 'boolean',
+        default: false
+      },
       pseudoClassEnabledElements: {
         type: 'object',
         additionalProperties: false,
@@ -571,6 +575,7 @@ export const snapshotSchema = {
         ignoreCanvasSerializationErrors: { $ref: '/config/snapshot#/properties/ignoreCanvasSerializationErrors' },
         ignoreStyleSheetSerializationErrors: { $ref: '/config/snapshot#/properties/ignoreStyleSheetSerializationErrors' },
         ignoreIframeSelectors: { $ref: '/config/snapshot#/properties/ignoreIframeSelectors' },
+        enablePseudoClassSerialization: { $ref: '/config/snapshot#/properties/enablePseudoClassSerialization' },
         pseudoClassEnabledElements: { $ref: '/config/snapshot#/properties/pseudoClassEnabledElements' },
         discovery: {
           type: 'object',

--- a/packages/core/src/discovery.js
+++ b/packages/core/src/discovery.js
@@ -80,6 +80,7 @@ function debugSnapshotOptions(snapshot) {
   debugProp(snapshot, 'ignoreCanvasSerializationErrors');
   debugProp(snapshot, 'ignoreStyleSheetSerializationErrors');
   debugProp(snapshot, 'pseudoClassEnabledElements', JSON.stringify);
+  debugProp(snapshot, 'enablePseudoClassSerialization');
   debugProp(snapshot, 'discovery.autoConfigureAllowedHostnames');
 
   if (Array.isArray(snapshot.domSnapshot)) {

--- a/packages/core/src/page.js
+++ b/packages/core/src/page.js
@@ -249,7 +249,7 @@ export class Page {
     execute,
     ...snapshot
   }) {
-    let { name, width, enableJavaScript, disableShadowDOM, forceShadowAsLightDOM, domTransformation, reshuffleInvalidTags, ignoreCanvasSerializationErrors, ignoreStyleSheetSerializationErrors, ignoreIframeSelectors, pseudoClassEnabledElements } = snapshot;
+    let { name, width, enableJavaScript, disableShadowDOM, forceShadowAsLightDOM, domTransformation, reshuffleInvalidTags, ignoreCanvasSerializationErrors, ignoreStyleSheetSerializationErrors, ignoreIframeSelectors, pseudoClassEnabledElements, enablePseudoClassSerialization } = snapshot;
     this.log.debug(`Taking snapshot: ${name}${width ? ` @${width}px` : ''}`, this.meta);
 
     // wait for any specified timeout
@@ -329,7 +329,8 @@ export class Page {
       ignoreCanvasSerializationErrors,
       ignoreStyleSheetSerializationErrors,
       ignoreIframeSelectors,
-      pseudoClassEnabledElements
+      pseudoClassEnabledElements,
+      enablePseudoClassSerialization
     });
 
     // Attach readiness diagnostics onto the captured DOM snapshot so the backend/UI can surface

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -116,7 +116,7 @@ describe('Percy', () => {
     });
 
     // expect required arguments are passed to PercyDOM.serialize
-    expect(evalSpy.calls.allArgs()[4]).toEqual(jasmine.arrayContaining([jasmine.anything(), { enableJavaScript: undefined, disableShadowDOM: true, domTransformation: undefined, reshuffleInvalidTags: undefined, ignoreCanvasSerializationErrors: undefined, ignoreStyleSheetSerializationErrors: undefined, ignoreIframeSelectors: undefined, forceShadowAsLightDOM: undefined, pseudoClassEnabledElements: undefined }]));
+    expect(evalSpy.calls.allArgs()[4]).toEqual(jasmine.arrayContaining([jasmine.anything(), { enableJavaScript: undefined, disableShadowDOM: true, domTransformation: undefined, reshuffleInvalidTags: undefined, ignoreCanvasSerializationErrors: undefined, ignoreStyleSheetSerializationErrors: undefined, ignoreIframeSelectors: undefined, forceShadowAsLightDOM: undefined, pseudoClassEnabledElements: undefined, enablePseudoClassSerialization: undefined }]));
 
     expect(snapshot.url).toEqual('http://localhost:8000/');
     expect(snapshot.domSnapshot).toEqual(jasmine.objectContaining({

--- a/packages/core/test/percy.test.js
+++ b/packages/core/test/percy.test.js
@@ -89,7 +89,8 @@ describe('Percy', () => {
       ignoreCanvasSerializationErrors: false,
       ignoreStyleSheetSerializationErrors: false,
       forceShadowAsLightDOM: false,
-      ignoreIframeSelectors: []
+      ignoreIframeSelectors: [],
+      enablePseudoClassSerialization: false
     });
   });
 

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -100,8 +100,11 @@ export function serializeDOM(options) {
     ignoreIframeSelectors = options?.ignore_iframe_selectors,
     maxIframeDepth = options?.max_iframe_depth,
     iframeDepth = options?.iframe_depth ?? 0,
-    pseudoClassEnabledElements = options?.pseudo_class_enabled_elements
+    pseudoClassEnabledElements = options?.pseudo_class_enabled_elements,
+    enablePseudoClassSerialization = options?.enable_pseudo_class_serialization
   } = options || {};
+
+  const pseudoClassSerialization = !!(enablePseudoClassSerialization || pseudoClassEnabledElements);
 
   // keep certain records throughout serialization
   let ctx = {
@@ -118,7 +121,8 @@ export function serializeDOM(options) {
     ignoreIframeSelectors,
     maxIframeDepth,
     iframeDepth,
-    pseudoClassEnabledElements
+    pseudoClassEnabledElements,
+    pseudoClassSerialization
   };
 
   ctx.dom = dom;

--- a/packages/dom/src/serialize-frames.js
+++ b/packages/dom/src/serialize-frames.js
@@ -67,7 +67,7 @@ function clampIframeDepth(raw) {
 // is the current nesting level (0 at the top-level document, +1 per recursion).
 // The default fires for direct callers that don't set it (e.g. tests, or
 // any future caller that doesn't go through serializeDOM).
-export function serializeFrames({ dom, clone, warnings, resources, enableJavaScript, disableShadowDOM, ignoreIframeSelectors, forceShadowAsLightDOM, maxIframeDepth, iframeDepth = 0 }) {
+export function serializeFrames({ dom, clone, warnings, resources, enableJavaScript, disableShadowDOM, ignoreIframeSelectors, forceShadowAsLightDOM, maxIframeDepth, iframeDepth = 0, pseudoClassEnabledElements, pseudoClassSerialization }) {
   maxIframeDepth = clampIframeDepth(maxIframeDepth);
 
   for (let frame of dom.querySelectorAll('iframe')) {
@@ -131,7 +131,9 @@ export function serializeFrames({ dom, clone, warnings, resources, enableJavaScr
         forceShadowAsLightDOM,
         ignoreIframeSelectors,
         maxIframeDepth,
-        iframeDepth: iframeDepth + 1
+        iframeDepth: iframeDepth + 1,
+        pseudoClassEnabledElements,
+        enablePseudoClassSerialization: pseudoClassSerialization
       });
 
       // append serialized warnings and resources

--- a/packages/dom/src/serialize-pseudo-classes.js
+++ b/packages/dom/src/serialize-pseudo-classes.js
@@ -2,7 +2,14 @@
 
 // Serializes pseudo-class state into Percy's clone via two paths:
 //
-//   1. Auto-detect path (every snapshot). For :focus / :focus-within we
+// Both paths below are gated on ctx.pseudoClassSerialization, which is off
+// unless the snapshot sets enablePseudoClassSerialization or configures
+// pseudoClassEnabledElements. Open-popover stamping and custom element
+// :state() rewriting are NOT gated — the renderer requires
+// data-percy-popover-open, and :state() is rewritten in place so it cannot
+// reorder the cascade.
+//
+//   1. Auto-detect path (when enabled). For :focus / :focus-within we
 //      stamp the live DOM with the corresponding data-percy-* attribute
 //      and rewrite matching CSS rules to use those attribute selectors.
 //      :focus-within stamps the focused element's ancestor chain across
@@ -329,8 +336,9 @@ export function getElementsToProcess(ctx, config, markWithId = false) {
 // the data-attributes are copied through to the clone via cloneNode.
 export function markPseudoClassElements(ctx, config) {
   ctx._liveMutations = [];
-  markInteractiveStates(ctx);
   markOpenPopovers(ctx);
+  if (!ctx.pseudoClassSerialization) return;
+  markInteractiveStates(ctx);
   if (config) getElementsToProcess(ctx, config, true);
 }
 
@@ -531,10 +539,11 @@ function injectAtSheetPosition(scopeRoot, sheet, styleElement, fallbackTarget) {
 }
 
 export function serializePseudoClasses(ctx) {
-  // Auto-detect path runs unconditionally so `:focus`/`:focus-within`
-  // rules are rewritten regardless of whether the user configured a
-  // pseudoClassEnabledElements list (and regardless of whether that list
-  // matched anything on this page).
+  if (!ctx.pseudoClassSerialization) return;
+
+  // Auto-detect path rewrites `:focus`/`:focus-within` rules whether or not
+  // a pseudoClassEnabledElements list was configured (and regardless of
+  // whether that list matched anything on this page).
   extractPseudoClassRules(ctx);
 
   if (!ctx.pseudoClassEnabledElements) return;

--- a/packages/dom/src/serialize-pseudo-classes.js
+++ b/packages/dom/src/serialize-pseudo-classes.js
@@ -79,6 +79,47 @@ function selectorContainsPseudo(selectorText, pseudoList) {
   });
 }
 
+function splitSelectorList(selectorText) {
+  const parts = [];
+  let depth = 0;
+  let quote = null;
+  let start = 0;
+
+  for (let i = 0; i < selectorText.length; i++) {
+    const char = selectorText[i];
+
+    if (quote) {
+      if (char === '\\') i++;
+      else if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === '"' || char === "'") quote = char;
+    else if (char === '(' || char === '[') depth++;
+    else if (char === ')' || char === ']') depth--;
+    else if (char === ',' && depth === 0) {
+      parts.push(selectorText.slice(start, i));
+      start = i + 1;
+    }
+  }
+
+  parts.push(selectorText.slice(start));
+  return parts;
+}
+
+function rewritePseudoSelectorList(selectorText, pseudoList) {
+  const pseudoParts = [];
+
+  for (const part of splitSelectorList(selectorText)) {
+    const trimmed = part.trim();
+    if (trimmed && selectorContainsPseudo(trimmed, pseudoList)) {
+      pseudoParts.push(rewritePseudoSelector(trimmed));
+    }
+  }
+
+  return pseudoParts.length ? pseudoParts.join(', ') : null;
+}
+
 export function rewritePseudoSelector(selectorText) {
   let out = selectorText;
   for (const [pseudo, re] of PSEUDO_RES) out = out.replace(re, PSEUDO_TO_ATTR[pseudo]);
@@ -426,9 +467,9 @@ function extractPseudoClassRules(ctx) {
       // interactive pseudo. Skips most rules on most stylesheets without
       // touching the regex bank.
       if (!rule.selectorText.includes(':')) continue;
-      if (!selectorContainsPseudo(rule.selectorText, ALL_INTERACTIVE_PSEUDO)) continue;
 
-      const rewrittenSelector = rewritePseudoSelector(rule.selectorText);
+      const rewrittenSelector = rewritePseudoSelectorList(rule.selectorText, ALL_INTERACTIVE_PSEUDO);
+      if (!rewrittenSelector) continue;
 
       const cssText = `${rewrittenSelector} { ${rule.style.cssText} }`;
       const wrapped = rule.wrapper ? `${rule.wrapper} { ${cssText} }` : cssText;

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -799,13 +799,87 @@ describe('serializeDOM', () => {
         '<button class="cbtn later">go</button>',
         { withShadow: false }
       );
-      let html = serializeDOM().html;
+      let html = serializeDOM({ enablePseudoClassSerialization: true }).html;
       let sourceIdx = html.indexOf('.cbtn:hover');
       let copyIdx = html.indexOf('[data-percy-hover]');
       let laterIdx = html.indexOf('.cbtn.later');
       expect(copyIdx).toBeGreaterThan(-1);
       expect(copyIdx).toBeGreaterThan(sourceIdx); // after its own sheet
       expect(copyIdx).toBeLessThan(laterIdx); // before the later sheet
+    });
+  });
+
+  describe('interactive-state serialization opt-in gate (PER-10588)', () => {
+    const HOVER_PAGE =
+      '<style>.gbtn:hover { color: red }</style>' +
+      '<button id="gbtn" class="gbtn">go</button>';
+
+    it('is off by default — no rewritten copy and no state stamps', () => {
+      withExample(HOVER_PAGE, { withShadow: false });
+      let html = serializeDOM().html;
+      expect(html).not.toContain('data-percy-interactive-states');
+      expect(html).not.toContain('[data-percy-hover]');
+      expect(html).not.toContain('data-percy-focus');
+    });
+
+    it('is on when enablePseudoClassSerialization is set', () => {
+      withExample(HOVER_PAGE, { withShadow: false });
+      let html = serializeDOM({ enablePseudoClassSerialization: true }).html;
+      expect(html).toContain('data-percy-interactive-states');
+      expect(html).toContain('[data-percy-hover]');
+    });
+
+    it('accepts the snake_case option name', () => {
+      withExample(HOVER_PAGE, { withShadow: false });
+      let html = serializeDOM({ enable_pseudo_class_serialization: true }).html;
+      expect(html).toContain('[data-percy-hover]');
+    });
+
+    it('is on when pseudoClassEnabledElements is configured, without the flag', () => {
+      withExample(HOVER_PAGE, { withShadow: false });
+      let html = serializeDOM({ pseudoClassEnabledElements: { id: ['gbtn'] } }).html;
+      expect(html).toContain('[data-percy-hover]');
+      expect(html).toContain('data-percy-pseudo-element-id');
+    });
+
+    it('stays on for configured elements even when the flag is materialized false', () => {
+      withExample(HOVER_PAGE, { withShadow: false });
+      let html = serializeDOM({
+        enablePseudoClassSerialization: false,
+        pseudoClassEnabledElements: { id: ['gbtn'] }
+      }).html;
+      expect(html).toContain('[data-percy-hover]');
+    });
+
+    it('still stamps open popovers while disabled — the renderer requires it', () => {
+      withExample(
+        '<div id="gpop" popover="manual">hi</div>',
+        { withShadow: false }
+      );
+      let popover = document.getElementById('gpop');
+      if (typeof popover.showPopover !== 'function') return;
+      popover.showPopover();
+
+      let html = serializeDOM().html;
+      expect(html).not.toContain('data-percy-interactive-states');
+      expect(html).toContain('data-percy-popover-open');
+    });
+
+    it('still rewrites custom element :state() while disabled', () => {
+      withExample(
+        '<style>.gstate:state(checked) { color: red }</style><div class="gstate"></div>',
+        { withShadow: false }
+      );
+      let html = serializeDOM().html;
+      expect(html).not.toContain('data-percy-interactive-states');
+      expect(html).toContain('[data-percy-custom-state~="checked"]');
+    });
+
+    it('leaves no data-percy-* state attributes on the live DOM either way', () => {
+      withExample(HOVER_PAGE, { withShadow: false });
+      serializeDOM({ enablePseudoClassSerialization: true });
+      expect(document.querySelector('[data-percy-hover]')).toBeNull();
+      expect(document.querySelector('[data-percy-focus]')).toBeNull();
     });
   });
 

--- a/packages/dom/test/serialize-frames.test.js
+++ b/packages/dom/test/serialize-frames.test.js
@@ -554,3 +554,56 @@ describe('serializeFrames', () => {
     });
   });
 });
+
+describe('serializeFrames - pseudo-class option propagation', () => {
+  let $container;
+
+  const srcdocOfFrame = (options) => {
+    let $ = parseDOM(serializeDOM(options).html, 'plain');
+    let el = $('#frame-pseudo')[0];
+    let raw = el?.getAttribute('srcdoc') || '';
+    let decoder = document.createElement('textarea');
+    decoder.innerHTML = raw;
+    return decoder.value;
+  };
+
+  beforeEach(async () => {
+    $container = document.createElement('div');
+    $container.id = 'pseudo-frame-host';
+    $container.innerHTML = '<iframe id="frame-pseudo" srcdoc="<style>.ibtn:hover { color: rgb(1, 2, 3); }</style><div class=\'ibtn\'>x</div>"></iframe>';
+    document.body.appendChild($container);
+
+    await when(() => {
+      let $frame = $container.querySelector('#frame-pseudo');
+      assert($frame?.contentDocument?.querySelector('.ibtn'), '#frame-pseudo did not load in time');
+      return $frame;
+    }, 5000);
+  }, 0);
+
+  afterEach(() => {
+    $container?.remove();
+    $container = null;
+  });
+
+  it('does not serialize iframe interactive states by default', () => {
+    let inner = srcdocOfFrame();
+    expect(inner).not.toContain('data-percy-interactive-states');
+    expect(inner).not.toContain('data-percy-hover');
+  });
+
+  it('serializes iframe interactive states when the flag is enabled', () => {
+    let inner = srcdocOfFrame({ enablePseudoClassSerialization: true });
+    expect(inner).toContain('data-percy-interactive-states');
+    expect(inner).toContain('[data-percy-hover]');
+  });
+
+  it('serializes iframe interactive states via the snake_case alias', () => {
+    let inner = srcdocOfFrame({ enable_pseudo_class_serialization: true });
+    expect(inner).toContain('[data-percy-hover]');
+  });
+
+  it('serializes iframe interactive states when pseudoClassEnabledElements is configured', () => {
+    let inner = srcdocOfFrame({ pseudoClassEnabledElements: { selectors: ['.ibtn'] } });
+    expect(inner).toContain('[data-percy-hover]');
+  });
+});

--- a/packages/dom/test/serialize-pseudo-classes.test.js
+++ b/packages/dom/test/serialize-pseudo-classes.test.js
@@ -1499,6 +1499,58 @@ describe('serialize-pseudo-classes', () => {
     });
   });
 
+  describe('grouped selector lists (PER-10588)', () => {
+    function serializeWith(styleText, bodyHTML) {
+      withExample('<style>' + styleText + '</style>' + bodyHTML);
+      ctx = {
+        dom: document,
+        clone: document.implementation.createHTMLDocument('Clone'),
+        warnings: new Set(),
+        cache: new Map(),
+        resources: new Set(),
+        hints: new Set(),
+        shadowRootElements: []
+      };
+      // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
+      ctx.clone.body.innerHTML = document.body.innerHTML;
+      markPseudoClassElements(ctx, null);
+      // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
+      ctx.clone.body.innerHTML = ctx.dom.body.innerHTML;
+      serializePseudoClasses(ctx);
+      let el = ctx.clone.querySelector('style[data-percy-interactive-states]');
+      return el ? el.textContent : null;
+    }
+
+    it('copies only the pseudo-bearing members of a grouped selector', () => {
+      let css = serializeWith(
+        '.card .title, .card .trigger:hover { color: rgb(0, 75, 111) }' +
+        '.card--blue .title { color: rgb(255, 255, 255) }',
+        '<div class="card card--blue"><span class="title">t</span>' +
+        '<a class="trigger" href="#">go</a></div>'
+      );
+      expect(css).toContain('.card .trigger[data-percy-hover]');
+      expect(css).not.toContain('.card .title');
+    });
+
+    it('does not split commas nested in :is()/:not() or attribute values', () => {
+      let css = serializeWith(
+        ':is(.a, .b) .lnk:focus, [data-k="x,y"] .lnk:focus { color: red }',
+        '<div class="a"><a class="lnk" href="#">a</a></div>'
+      );
+      expect(css).toContain(':is(.a, .b) .lnk[data-percy-focus]');
+      expect(css).toContain('[data-k="x,y"] .lnk[data-percy-focus]');
+    });
+
+    it('keeps every member when they all carry a pseudo', () => {
+      let css = serializeWith(
+        '.p:focus, .q:focus { color: red }',
+        '<div><span class="p">p</span><span class="q">q</span></div>'
+      );
+      expect(css).toContain('.p[data-percy-focus]');
+      expect(css).toContain('.q[data-percy-focus]');
+    });
+  });
+
   describe('walkCSSRules charset / import / etc with no selectorText', () => {
     it('skips rules that have neither nested cssRules nor a selector', () => {
       // @charset has no cssRules and no selectorText — exercises the

--- a/packages/dom/test/serialize-pseudo-classes.test.js
+++ b/packages/dom/test/serialize-pseudo-classes.test.js
@@ -26,7 +26,8 @@ describe('serialize-pseudo-classes', () => {
   beforeEach(() => {
     ctx = {
       dom: document,
-      warnings: new Set()
+      warnings: new Set(),
+      pseudoClassSerialization: true
     };
     withExample('<div id="foo" style="color: red;"></div><div class="bar"></div><div id="baz"></div>');
     ctx.clone = document.implementation.createHTMLDocument('Clone');
@@ -179,7 +180,7 @@ describe('serialize-pseudo-classes', () => {
       // We'll temporarily patch getElementsToProcess to expose markWithId
       withExample('<div id="foo"></div>');
       const el = document.getElementById('foo');
-      const ctx2 = { dom: document, warnings: new Set() };
+      const ctx2 = { dom: document, warnings: new Set(), pseudoClassSerialization: true };
       getElementsToProcess(ctx2, { id: ['foo'] });
       expect(el.hasAttribute('data-percy-pseudo-element-id')).toBe(false);
     });
@@ -191,7 +192,7 @@ describe('serialize-pseudo-classes', () => {
     });
 
     it('throws an error if config is null', () => {
-      const ctx2 = { dom: document, warnings: new Set() };
+      const ctx2 = { dom: document, warnings: new Set(), pseudoClassSerialization: true };
       expect(() => {
         getElementsToProcess(ctx2, null);
       }).toThrow();
@@ -476,7 +477,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -531,7 +533,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -562,7 +565,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -679,7 +683,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -709,6 +714,7 @@ describe('serialize-pseudo-classes', () => {
         resources: new Set(),
         hints: new Set(),
         shadowRootElements: [],
+        pseudoClassSerialization: true,
         pseudoClassEnabledElements: { id: ['has-test'] }
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
@@ -738,7 +744,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -763,7 +770,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -793,7 +801,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -836,7 +845,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // Do NOT copy DOM to clone - so the clone element won't be found
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
@@ -873,7 +883,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -908,7 +919,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = '<div>test</div>';
@@ -930,7 +942,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -956,7 +969,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -976,7 +990,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -1004,7 +1019,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // Blur any active element to ensure nothing is focused
       document.activeElement?.blur();
@@ -1025,7 +1041,7 @@ describe('serialize-pseudo-classes', () => {
       let el = document.getElementById('has-percy-id');
       el.setAttribute('data-percy-element-id', '_focus_branch_test');
       withMockedFocus(el, () => {
-        ctx = { dom: document, warnings: new Set() };
+        ctx = { dom: document, warnings: new Set(), pseudoClassSerialization: true };
         markPseudoClassElements(ctx, { id: ['has-percy-id'] });
       });
       expect(el.hasAttribute('data-percy-focus')).toBe(true);
@@ -1078,7 +1094,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -1135,7 +1152,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -1179,7 +1197,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -1234,7 +1253,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -1281,7 +1301,7 @@ describe('serialize-pseudo-classes', () => {
       Object.defineProperty(shadow, 'activeElement', { get: () => deepInput, configurable: true });
       Object.defineProperty(document, 'activeElement', { get: () => host, configurable: true });
       try {
-        ctx = { dom: document, warnings: new Set() };
+        ctx = { dom: document, warnings: new Set(), pseudoClassSerialization: true };
         markPseudoClassElements(ctx, null);
         // The traversal should reach deepInput and stamp [data-percy-focus]
         expect(deepInput.hasAttribute('data-percy-focus')).toBe(true);
@@ -1325,7 +1345,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = '<div id="sh-style-host" data-percy-shadow-host data-percy-element-id="_sh_style_1"></div>';
@@ -1371,7 +1392,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // Clone host exists but WITHOUT a shadow root attached
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
@@ -1447,7 +1469,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -1485,6 +1508,7 @@ describe('serialize-pseudo-classes', () => {
         resources: new Set(),
         hints: new Set(),
         shadowRootElements: [],
+        pseudoClassSerialization: true,
         pseudoClassEnabledElements: { id: ['cm3-btn'] }
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
@@ -1509,7 +1533,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -1566,7 +1591,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -1595,7 +1621,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -1631,7 +1658,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = ctx.dom.body.innerHTML;
@@ -1661,7 +1689,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // Clone intentionally does NOT mirror the source <style>, so no anchor.
       markPseudoClassElements(ctx, null);
@@ -1694,7 +1723,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -1742,6 +1772,7 @@ describe('serialize-pseudo-classes', () => {
         resources: new Set(),
         hints: new Set(),
         shadowRootElements: [],
+        pseudoClassSerialization: true,
         pseudoClassEnabledElements: { id: ['dv'] }
       };
       expect(() => serializePseudoClasses(ctx)).not.toThrow();
@@ -1767,7 +1798,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;
@@ -1927,7 +1959,8 @@ describe('serialize-pseudo-classes', () => {
         cache: new Map(),
         resources: new Set(),
         hints: new Set(),
-        shadowRootElements: []
+        shadowRootElements: [],
+        pseudoClassSerialization: true
       };
       // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       ctx.clone.body.innerHTML = document.body.innerHTML;


### PR DESCRIPTION
Fixes [PER-10588](https://browserstack.atlassian.net/browse/PER-10588)

Three commits, separable if you'd rather land them apart:

1. **grouped-selector cascade fix** — the reported symptom
2. **make interactive-state serialization opt-in, default off** — the strategic ask from the CSS sync
3. **propagate the gate into iframe serialization** — found while verifying (2); without it, opt-in users lose iframe coverage

---

## Why turn it off by default

The interactive-state auto-detect path has shipped four regressions in three months, all the same shape: it copies customer CSS, rewrites a pseudo-class to a `data-percy-*` attribute, and re-injects the copy — reordering the cascade for rules nobody asked it to touch.

| Ticket | PR | Damage |
|---|---|---|
| PER-9775 | #2324 | nested selectors leaked page-wide via a bare `&` |
| PER-9836 | — | `pseudoClassEnabledElements` froze layout / transitions |
| PER-10077 | #2342 | `:checked`/`:disabled` copies recolored Angular Material buttons across 70+ snapshots |
| PER-10588 | this | one `:hover` member of an 82-selector rule repainted every colored-card heading on an AEM site |

Adoption does not justify that risk. On the PER-10588 customer's captured DOM:

- injected block: **289,676 bytes**, containing **629** `data-percy-hover` selectors
- `data-percy-*` state attributes actually stamped on elements: **0**

Not one rule it emitted could match anything. The feature contributed **zero** correct behavior and **all** of the breakage on that page.

## What the gate does

New snapshot option `enablePseudoClassSerialization` (boolean, default `false`; `enable_pseudo_class_serialization` accepted for the SDK path). The predicate is computed **once** in `serializeDOM` and carried as `ctx.pseudoClassSerialization` — one auditable switch rather than a check per call site:

```js
const pseudoClassSerialization = !!(enablePseudoClassSerialization || pseudoClassEnabledElements);
```

Configuring `pseudoClassEnabledElements` is itself an opt-in, so **existing opt-in users are unaffected without touching their config**.

`||` (not `??`) is deliberate: `PercyConfig.getDefaults()` materializes `snapshot.enablePseudoClassSerialization` to `false`, so `??` would short-circuit on that materialized `false` and silently break users who opt in only via `pseudoClassEnabledElements`. Verified against the real schema — `pseudoClassEnabledElements` carries no `default`, so it is never materialized — and covered by a test and a build using that exact production shape.

**No pseudo-class logic is removed** — both paths are intact behind the flag.

## What is deliberately NOT gated

Both verified against `percy-renderer`:

- **Open-popover stamping.** `src/script/popover-element-helper.js` reopens `[popover][data-percy-popover-open]`; its own comment reads *"CLI stamps data-percy-popover-open on the popover elements."* Without the stamp an open popover renders hidden behind the UA `[popover]:not(:popover-open){display:none}` rule.
- **Custom element `:state()` rewriting.** `serialize-custom-states` rewrites `<style>` text **in place**, so it cannot reorder the cascade — a different mechanism from the one causing these regressions.

The renderer consumes only `shadow-host`, `injected`, `popover-open`, `dialog-modal`, `scrolltop`/`scrollleft` and `send-freeze-animation-logs`. It reads **none** of the gated focus/hover/active/pseudo-element-id stamps, so nothing downstream regresses.

## Commit 1 — the grouped-selector fix

Still needed: it makes the path correct for people who *do* opt in.

`extractPseudoClassRules()` copied a rule's **entire selector list** when any one member carried a pseudo-class. In `clientlib-site.css` on the reported site:

| | Byte offset | Selectors | Declaration | Pseudo? |
|---|---|---|---|---|
| **A** | 1,226,827 | **82** grouped, incl. `.dbk-basic-box … [class*="__title"]` | `color:#004b6f` | **1 of 82**: `… .dbk-readmore__trigger:hover` |
| **B** | 1,276,597 (**later, same sheet**) | 243 grouped, incl. `.dbk-basic-box--blue … [class*="__title"]` | `color:#fff` | none |

Both specificity `(0,6,0)`; live, **B** wins on source order. That one `:hover` member dragged all 82 of **A**'s selectors into the injected `<style>` → **A** after **B** → headings dark-on-dark.

PER-10077's per-sheet anchoring doesn't help — **A** and **B** share a sheet. Fix: split the selector list on top-level commas only (paren/bracket/quote aware) and copy only pseudo-bearing members.

## Commit 3 — iframe propagation

`serializeFrames` recurses via `serializeDOM({...})` but forwarded neither pseudo-class option. Pre-PR that was invisible because the auto-detect path ran unconditionally, so iframe content *was* serialized. With the gate added in commit 2 and nothing forwarded, iframes got **zero** interactive-state serialization in every configuration — including an explicit `enablePseudoClassSerialization: true`.

Measured on a host page with a `srcdoc` iframe carrying a `:hover` rule (injected bytes inside the iframe's serialized `srcdoc`):

| Bundle | default | flag on | snake_case | `pseudoClassEnabledElements` |
|---|---|---|---|---|
| `master` | 231 B | 231 B | 231 B | 231 B |
| commit 2 only | 0 B | **0 B** ❌ | **0 B** ❌ | **0 B** ❌ |
| with commit 3 | 0 B ✅ | 231 B ✅ | 231 B ✅ | 231 B ✅ |

The fix forwards the already-computed parent gate, so the child inherits the decision rather than re-deriving it from raw options:

```js
pseudoClassEnabledElements,
enablePseudoClassSerialization: pseudoClassSerialization
```

`ctx` carries the computed `pseudoClassSerialization`, not the raw `enablePseudoClassSerialization` — forwarding the raw name reads `undefined` and silently keeps iframes dark. Covered by 4 specs.

## Verification — scenario matrix

Ran the real `PercyDOM.serialize()` from built bundles in headless Chrome over six purpose-built pages × five config variants × `master` vs this branch (60 combinations), then re-served each serialized document so relative stylesheet hrefs resolve exactly as the renderer sees them, and read `getComputedStyle()`.

### 1. Grouped-selector cascade — the PER-10588 shape

82 grouped selectors declaring `color:#004b6f`, exactly one carrying `:hover`; a later equal-specificity rule in the **same sheet** declaring `color:#fff`. Live page renders the headings white.

| Bundle / variant | Injected | blue / green / yellow heading | beige |
|---|---|---|---|
| `master` (all variants) | 3,838 B | **`rgb(0, 75, 111)`** ❌ | `rgb(0, 75, 111)` ✅ |
| branch, **default** | **0 B** | **`rgb(255, 255, 255)`** ✅ | `rgb(0, 75, 111)` ✅ |
| branch, flag on | 147 B | `rgb(255, 255, 255)` ✅ | ✅ |
| branch, snake_case | 147 B | `rgb(255, 255, 255)` ✅ | ✅ |
| branch, `pseudoClassEnabledElements` | 147 B | `rgb(255, 255, 255)` ✅ | ✅ |
| branch, flag materialized `false` + elements | 147 B | `rgb(255, 255, 255)` ✅ | ✅ |

3,838 B → 147 B when opted in: only the one pseudo-bearing member is copied instead of all 82. Both the default and the opt-in path now match the live page.

### 2. Selector-list splitting integrity

Byte-for-byte output of the injected block, `master` vs branch:

```
  :is(.alpha, .beta)[data-percy-hover] { … }        both — comma inside :is() preserved
  [data-k="x,y"][data-percy-hover] { … }            both — comma inside quoted attr preserved
  :not(.p, .q)[data-percy-hover] > .child { … }     both — comma inside :not() preserved
  .quoted[title="a, b"][data-percy-hover] { … }     both — comma inside quoted attr preserved
- .plain[data-percy-hover], .other { … }            master: copies the non-pseudo member too
+ .plain[data-percy-hover] { … }                    branch: only the pseudo-bearing member
```

Same 5 hover selectors emitted either way; the only difference is the dropped non-pseudo `.other`. Nothing is shredded.

### 3. Gate routes — opt-in output is unchanged from today

Injected bytes on a page with real `:hover` / `:active` / `:focus` / `:focus-within` rules:

| Variant | `master` | branch |
|---|---|---|
| default | 441 B | **0 B** |
| `enablePseudoClassSerialization: true` | 441 B | 441 B |
| `enable_pseudo_class_serialization: true` | 441 B | 441 B |
| `pseudoClassEnabledElements` only | 441 B | 441 B |
| flag materialized `false` + `pseudoClassEnabledElements` | 441 B | 441 B |

Every opt-in route produces byte-identical output to `master`. The last row is the `||`-vs-`??` case.

### 4. Carve-outs hold with the feature off

| Carve-out | Metric | `master` | branch, default | branch, flag on |
|---|---|---|---|---|
| Open popover | `data-percy-popover-open` stamps | 1 | **1** | 1 |
| Open popover | rendered `display` | `block` | **`block`** | `block` |
| Custom element `:state()` | in-place rewrites | 2 | **2** | 2 |
| Custom element `:state()` | rendered background | `rgb(31, 122, 77)` | **`rgb(31, 122, 77)`** | `rgb(31, 122, 77)` |

### 5. Live DOM is left clean

`data-percy-*` stamps remaining on the live document after serialization: **0** in all 60 combinations. A dedicated probe also confirms **0** leaked `<base>` elements, **0** leftover `style[data-percy-interactive-states]`, and unchanged relative-URL resolution (`new URL('assets/x.webp', document.baseURI)` identical before and after) on both bundles, both variants.

## Verification — Percy builds

Project `test-pranav`. Build #520 is the reference: the same six pages captured with the **`master`** bundle, i.e. today's shipped behavior. #521–#523 run this branch against it, so every diff is exactly what this PR changes.

| Build | Config | Link | Snapshots changed vs #520 |
|---|---|---|---|
| **#520** reference (`master` bundle) | — | https://percy.io/9560f98d/web/test-pranav-8a4f5725/builds/53294971 | baseline |
| **#521** branch, **default** | none | https://percy.io/9560f98d/web/test-pranav-8a4f5725/builds/53294992 | `grouped-cascade`, `interactive-states` |
| **#522** branch, flag on | `enablePseudoClassSerialization: true` | https://percy.io/9560f98d/web/test-pranav-8a4f5725/builds/53294994 | `grouped-cascade` only |
| **#523** branch, legacy opt-in | `pseudoClassEnabledElements` | https://percy.io/9560f98d/web/test-pranav-8a4f5725/builds/53294998 | `grouped-cascade`, `interactive-states` |
| **#524** matrix — all 4 variants side by side | 24 snapshots | https://percy.io/9560f98d/web/test-pranav-8a4f5725/builds/53295014 | n/a (distinct names) |

Reading the results:

- **#521 (the shipped default)** changes exactly two pages. `grouped-cascade` is the PER-10588 correction. `interactive-states` is the intended consequence of turning the feature off — the forced `:focus` styling is no longer injected. `popover`, `custom-state`, `selector-integrity` and `iframe-host` are **unchanged**, which is the carve-out and no-collateral-damage evidence.
- **#522 (opt-in)** changes **only** `grouped-cascade` — the commit-1 correction. `interactive-states` matching the reference is the compatibility result that matters: an opt-in customer's interactive-state rendering is untouched by this PR.
- **#523** additionally moves `interactive-states` because it enables the configured-elements path, which the reference build did not have configured — expected, not a regression.
- **#524** renders all four config variants of all six pages in one build for side-by-side inspection.

Also validated directly against the config schema: accepts `true`/`false`, materializes to `false`, and rejects a non-boolean with `snapshot.enablePseudoClassSerialization: must be a boolean, received a string`.

## Testing

`@percy/dom`, Chrome, same command on both sides, run in a clean worktree rebased on current `master` (`3886c115`):

| | Pass | Fail |
|---|---|---|
| `master` baseline | 457 | 40 |
| this branch | 472 | 40 |

Identical pre-existing failure set on both sides — focus-dependent specs that need a focused browser window; they fail the same way on unmodified `master` in this environment and pass in CI. No new failures.

15 new specs:
- **grouped selector lists** — only pseudo-bearing members copied; no shredding of `:is(.a, .b)` / `[data-k="x,y"]`; all-pseudo lists kept whole
- **opt-in gate** — off by default (no injected block, no stamps); on via the flag; on via the snake_case alias; on via `pseudoClassEnabledElements` alone; **on for configured elements even when the flag is materialized `false`**; popovers still stamped while disabled; `:state()` still rewritten while disabled; no `data-percy-*` left on the live DOM either way
- **iframe propagation** — off by default; on via the flag, the snake_case alias, and `pseudoClassEnabledElements`

The iframe specs build their iframe in their own container and remove it in `afterEach` rather than going through `withExample`, which would create a second same-id iframe inside the shadow-DOM copy and perturb the shared karma document — that leaked a `<base>` into live iframe documents and broke the unrelated `loadAllSrcsetLinks` specs downstream.

Firefox is not installed on the dev machine, so only the Chrome leg ran locally — CI covers the rest.

**`@percy/core` was not runnable locally.** Its suite binds port 8000, which is held on this machine by a pre-existing listener (an ssh tunnel plus an unrelated node process). Unmodified `master` fails the same way — 342 `EADDRINUSE` errors on `master` against 964 on the branch, both runs swamped rather than comparable — so this is environmental, not a signal about the change. The core-side edits are a schema addition plus threading one option through `page.js` and a `debugProp` line; they are covered by the config-schema validation above (accepts `true`/`false`, materializes to `false`, rejects non-boolean with the right message), by the four Percy builds — which exercise the whole `config -> snapshot options -> serializeDOM` path end to end through the real CLI — and by CI.

## Rollout

Snapshots currently distorted by the injected copies — not just this customer's — will diff **once** as they return to their true colors. That diff is the correction and should be approved to re-baseline. Worth a heads-up to CE ahead of the release, since it will land across multiple accounts at once.

## Evidence — original report

| What | Link |
|---|---|
| Affected build (CLI 1.32.3) | https://percy.io/6bc07296/web/Webauftritt-Test-2e8c6ad4/builds/52912661 |
| Affected snapshot | https://percy.io/6bc07296/web/Webauftritt-Test-2e8c6ad4/builds/52912661/changed/2863001336 |
| Baseline build (CLI 1.31.13) | https://percy.io/6bc07296/web/Webauftritt-Test-2e8c6ad4/builds/51540262 |
| Baseline snapshot (correct) | https://percy.io/6bc07296/web/Webauftritt-Test-2e8c6ad4/builds/51540262/changed/2784826354 |
| Comparison | `4793907995`, diff-ratio `0.00227` |
| Head DOM | `GET /api/v1/snapshots/2863001336/assets/head.html` — 698,096 bytes |
| Baseline DOM | `GET /api/v1/snapshots/2784826354/assets/head.html` — 411,417 bytes |
| Head screenshot | https://images.percy.io/1a328cb4f0fd1e496f644893a9e502ae48bb21a62eb296cac7834d75dcc3eeba |
| Baseline screenshot | https://images.percy.io/c0d6fc8cd8e5156b47f972a749231475a194ec89733042410aeed90f9817c80c |
| Honeycomb render pipeline (clean) | https://ui.honeycomb.io/percy/environments/production/datasets/render-pipeline-prod/result/9PUn4uqxfni |
| Honeycomb sidekiq (clean) | https://ui.honeycomb.io/percy/environments/production/datasets/sidekiq-prod/result/z5VsfWHZXPZ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PER-10588]: https://browserstack.atlassian.net/browse/PER-10588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ