### PR TITLE
fix(core): bound CDP sends so a stalled browser can't hang the CLI

### DIFF
--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -152,7 +152,7 @@ export class Browser extends EventEmitter {
     // Reset state for fresh launch
     this.readyState = null;
     this._closed = null;
-    for (let callback of this.#callbacks.values()) clearTimeout(callback.timer);
+    // close() above already cleared every pending callback and its deadline
     this.#callbacks.clear();
     this.sessions.clear();
 

--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -9,7 +9,7 @@ import rimraf from 'rimraf';
 import logger from '@percy/logger';
 import install from './install.js';
 import { MAX_CDP_PAYLOAD } from './network.js';
-import Session from './session.js';
+import Session, { cdpTimeout, cdpTimeoutMessage } from './session.js';
 import Page from './page.js';
 
 // Chrome features Percy disables for v143 new-headless asset discovery.
@@ -152,6 +152,7 @@ export class Browser extends EventEmitter {
     // Reset state for fresh launch
     this.readyState = null;
     this._closed = null;
+    for (let callback of this.#callbacks.values()) clearTimeout(callback.timer);
     this.#callbacks.clear();
     this.sessions.clear();
 
@@ -204,6 +205,7 @@ export class Browser extends EventEmitter {
 
     // reject any pending callbacks
     for (let callback of this.#callbacks.values()) {
+      clearTimeout(callback.timer);
       callback.reject(Object.assign(callback.error, {
         message: `Protocol error (${callback.method}): Browser closed.`
       }));
@@ -294,9 +296,26 @@ export class Browser extends EventEmitter {
       // send the message payload
       this.ws.send(JSON.stringify({ id, method, params }));
 
-      // will resolve or reject when a matching response is received
+      // will resolve or reject when a matching response is received, or when
+      // the deadline below expires because no response is ever coming. The
+      // browser process can go silent the same way a renderer can - target
+      // creation and attachment strand here otherwise, before any page exists.
       return new Promise((resolve, reject) => {
-        this.#callbacks.set(id, { error: new Error(), resolve, reject, method });
+        let callback = { error: new Error(), resolve, reject, method };
+        let timeout = cdpTimeout();
+
+        if (timeout > 0) {
+          callback.timer = setTimeout(() => {
+            this.#callbacks.delete(id);
+            this.log.debug(`Protocol timeout (${method}) after ${timeout}ms`);
+
+            reject(Object.assign(callback.error, {
+              message: cdpTimeoutMessage(method, timeout)
+            }));
+          }, timeout);
+        }
+
+        this.#callbacks.set(id, callback);
       });
     }
   }
@@ -368,6 +387,7 @@ export class Browser extends EventEmitter {
       // resolve or reject a pending promise created with #send()
       let callback = this.#callbacks.get(data.id);
       this.#callbacks.delete(data.id);
+      clearTimeout(callback.timer);
 
       /* istanbul ignore next: races with page._handleMessage() */
       if (data.error) {

--- a/packages/core/src/session.js
+++ b/packages/core/src/session.js
@@ -1,7 +1,52 @@
 import EventEmitter from 'events';
 import logger from '@percy/logger';
 
+// Node-side ceiling on a single CDP round trip. Chrome does not always answer:
+// a renderer that is frozen, starved of CPU, or swapped out keeps its target
+// attached and simply never replies. In-page deadlines cannot rescue that case
+// — their timers live in the very renderer that stopped running — so with no
+// deadline here `send()` never settles and the whole CLI blocks forever with
+// no error, no log and an unfinalized build. Reproducible by freezing the
+// renderer (`Page.setWebLifecycleState`) or descheduling it (SIGSTOP), both of
+// which a small, memory-pressured CI agent can do on its own.
+export const DEFAULT_CDP_TIMEOUT = 120000;
+
+// The longest wait a caller could legitimately be running *inside* the page,
+// doubled. Keeps the deadline above those so raising one of them can never
+// turn into a spurious protocol timeout.
+function inPageCeiling() {
+  return Math.max(
+    parseInt(process.env.PERCY_PAGE_LOAD_TIMEOUT, 10) || 0,
+    parseInt(process.env.PERCY_STORY_RENDER_TIMEOUT, 10) || 0
+  ) * 2;
+}
+
+// Resolved once per process, and memoized so a mid-run env change cannot make
+// concurrent sessions disagree. `PERCY_CDP_TIMEOUT=0` disables the deadline.
+export function cdpTimeout() {
+  if (Session.TIMEOUT !== undefined) return Session.TIMEOUT;
+  let configured = parseInt(process.env.PERCY_CDP_TIMEOUT, 10);
+
+  Session.TIMEOUT = Number.isNaN(configured)
+    ? Math.max(DEFAULT_CDP_TIMEOUT, inPageCeiling())
+    : Math.max(0, configured);
+
+  return Session.TIMEOUT;
+}
+
+// Shared by both CDP deadlines - the session-scoped one below and the
+// browser-scoped one in browser.js.
+export function cdpTimeoutMessage(method, timeout) {
+  return `Protocol error (${method}): Timed out after ${timeout}ms ` +
+    'waiting for a response from the browser. The browser stopped responding — a ' +
+    'renderer or browser process that is frozen, starved of CPU, or swapped out ' +
+    'never replies and never runs its own timers. Raise PERCY_CDP_TIMEOUT if this ' +
+    'command is legitimately slower than that, or set it to 0 to disable the deadline.';
+}
+
 export class Session extends EventEmitter {
+  static TIMEOUT = undefined;
+
   #callbacks = new Map();
 
   log = logger('core:session');
@@ -45,9 +90,24 @@ export class Session extends EventEmitter {
     // send a raw message to the browser so we can provide a sessionId
     let id = await this.browser.send({ sessionId: this.sessionId, method, params });
 
-    // will resolve or reject when a matching response is received
+    // will resolve or reject when a matching response is received, or when the
+    // deadline below expires because no response is ever coming
     return new Promise((resolve, reject) => {
-      this.#callbacks.set(id, { error: new Error(), resolve, reject, method });
+      let callback = { error: new Error(), resolve, reject, method };
+      let timeout = cdpTimeout();
+
+      if (timeout > 0) {
+        callback.timer = setTimeout(() => {
+          this.#callbacks.delete(id);
+          this.log.debug(`Protocol timeout (${method}) after ${timeout}ms`);
+
+          reject(Object.assign(callback.error, {
+            message: cdpTimeoutMessage(method, timeout)
+          }));
+        }, timeout);
+      }
+
+      this.#callbacks.set(id, callback);
     });
   }
 
@@ -56,6 +116,7 @@ export class Session extends EventEmitter {
       // resolve or reject a pending promise created with #send()
       let callback = this.#callbacks.get(data.id);
       this.#callbacks.delete(data.id);
+      clearTimeout(callback.timer);
 
       /* istanbul ignore next: races with browser._handleMessage() */
       if (data.error) {
@@ -77,6 +138,7 @@ export class Session extends EventEmitter {
 
     // reject any pending callbacks
     for (let callback of this.#callbacks.values()) {
+      clearTimeout(callback.timer);
       callback.reject(Object.assign(callback.error, {
         message: `Protocol error (${callback.method}): ${this.closedReason}`
       }));

--- a/packages/core/test/unit/session.test.js
+++ b/packages/core/test/unit/session.test.js
@@ -1,0 +1,173 @@
+import { setupTest } from '../helpers/index.js';
+import { Session } from '../../src/session.js';
+import { Browser } from '../../src/browser.js';
+
+// A browser stub whose send() only hands back a message id and never delivers
+// a reply, which is what a frozen or starved renderer looks like from Node.
+function makeBrowser() {
+  let lastId = 0;
+  return {
+    sessions: new Map(),
+    percy: { config: { discovery: {} } },
+    sent: [],
+    async send(message) {
+      this.sent.push(message);
+      return ++lastId;
+    }
+  };
+}
+
+// browser.send() is awaited before the callback is registered, so give that
+// microtask a chance to land before simulating a reply
+const tick = () => new Promise(r => setTimeout(r, 10));
+
+function makeSession(browser) {
+  return new Session(browser, {
+    params: {
+      sessionId: 'session-1',
+      targetInfo: { targetId: 'target-1', type: 'page' }
+    }
+  });
+}
+
+describe('Unit / Session', () => {
+  let browser, session;
+
+  beforeEach(async () => {
+    await setupTest();
+    Session.TIMEOUT = undefined;
+    delete process.env.PERCY_CDP_TIMEOUT;
+    browser = makeBrowser();
+    session = makeSession(browser);
+  });
+
+  afterEach(() => {
+    Session.TIMEOUT = undefined;
+    delete process.env.PERCY_CDP_TIMEOUT;
+  });
+
+  // A renderer that stops running (frozen, starved, swapped out)
+  // keeps its target attached and simply never replies. In-page deadlines
+  // cannot save us — their timers live in that same stalled renderer — so
+  // without a Node-side deadline the whole CLI blocks forever, silently.
+  it('rejects a pending command when the browser never replies', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '150';
+
+    await expectAsync(session.send('Runtime.callFunctionOn', {}))
+      .toBeRejectedWithError(/Protocol error \(Runtime\.callFunctionOn\): Timed out after 150ms/);
+  });
+
+  it('names the command and points at the override in the error', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '100';
+
+    await expectAsync(session.send('Page.navigate', {}))
+      .toBeRejectedWithError(/Page\.navigate[\s\S]*PERCY_CDP_TIMEOUT/);
+  });
+
+  it('does not reject when a reply arrives before the deadline', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '2000';
+
+    let pending = session.send('Runtime.evaluate', {});
+    await tick();
+    session._handleMessage({ id: 1, result: { value: 'ok' } });
+
+    await expectAsync(pending).toBeResolvedTo({ value: 'ok' });
+  });
+
+  it('clears the deadline once a reply arrives, so it cannot fire later', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '100';
+
+    let pending = session.send('Runtime.evaluate', {});
+    await tick();
+    session._handleMessage({ id: 1, result: { value: 'ok' } });
+    await expectAsync(pending).toBeResolvedTo({ value: 'ok' });
+
+    // outlive the deadline - nothing should blow up or reject afterwards
+    await new Promise(r => setTimeout(r, 250));
+  });
+
+  it('clears the deadline when the session closes first', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '5000';
+
+    let pending = session.send('Runtime.evaluate', {});
+    await tick();
+    session._handleClose();
+
+    await expectAsync(pending).toBeRejectedWithError(/Session closed\./);
+  });
+
+  it('can be disabled with PERCY_CDP_TIMEOUT=0', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '0';
+
+    let settled = false;
+    session.send('Runtime.evaluate', {}).then(() => { settled = true; }, () => { settled = true; });
+
+    await new Promise(r => setTimeout(r, 200));
+    expect(settled).toBe(false);
+  });
+});
+
+// The browser process can go silent the same way a renderer can. Target
+// creation and attachment happen on the browser-scoped connection, before any
+// page exists, so a deadline on Session alone leaves that path unbounded.
+describe('Unit / Browser CDP deadline', () => {
+  let browser;
+
+  beforeEach(async () => {
+    await setupTest();
+    Session.TIMEOUT = undefined;
+    delete process.env.PERCY_CDP_TIMEOUT;
+    browser = new Browser({ config: { discovery: {} } });
+    browser.ws = { send: () => {} };
+    browser.isConnected = () => true;
+  });
+
+  afterEach(() => {
+    Session.TIMEOUT = undefined;
+    delete process.env.PERCY_CDP_TIMEOUT;
+  });
+
+  it('rejects a pending browser command when no reply arrives', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '150';
+
+    await expectAsync(browser.send('Target.createBrowserContext', {}))
+      .toBeRejectedWithError(/Protocol error \(Target\.createBrowserContext\): Timed out after 150ms/);
+  });
+
+  it('does not reject when a reply arrives before the deadline', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '2000';
+
+    let pending = browser.send('Target.createTarget', {});
+    browser._handleMessage(JSON.stringify({ id: 1, result: { targetId: 't1' } }));
+
+    await expectAsync(pending).toBeResolvedTo({ targetId: 't1' });
+  });
+
+  it('clears the deadline once a reply arrives, so it cannot fire later', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '100';
+
+    let pending = browser.send('Target.attachToTarget', {});
+    browser._handleMessage(JSON.stringify({ id: 1, result: { sessionId: 's1' } }));
+    await expectAsync(pending).toBeResolvedTo({ sessionId: 's1' });
+
+    await new Promise(r => setTimeout(r, 250));
+  });
+
+  it('leaves the raw-message path untimed, since a session owns that reply', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '100';
+
+    // passing a raw message returns the id synchronously - no promise to bound
+    await expectAsync(browser.send({ sessionId: 's1', method: 'Runtime.evaluate' }))
+      .toBeResolvedTo(1);
+  });
+
+  it('can be disabled with PERCY_CDP_TIMEOUT=0', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '0';
+
+    let settled = false;
+    browser.send('Target.createBrowserContext', {}).then(() => { settled = true; }, () => { settled = true; });
+
+    await new Promise(r => setTimeout(r, 200));
+    expect(settled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`Browser.send` and `Session.send` resolved **only** on a matching CDP reply or a close — neither had a deadline of its own. Chrome does not always reply: a renderer or browser process that is **frozen, starved of CPU, or swapped out** keeps its target attached and simply goes silent.

Callers cannot defend against this either, because their deadlines are **in-page timers living in the very renderer that stopped running**. That is why `@percy/storybook`'s `PERCY_STORY_RENDER_TIMEOUT` (added in percy/percy-storybook#1354, shipped in 10.0.2) never fires in these runs.

Net effect: a total silent stall — no error, no log, no retry, and a build left unfinalized until the server force-closes it ~8h later.

This adds a **Node-side deadline that nothing inside the page can defeat**, on *both* the session-scoped and browser-scoped connections — target creation and attachment run on the browser connection before any page exists, so bounding sessions alone still strands that path:
- Default **120s**, floored above the longest legitimate in-page wait (~45s) and auto-raised if `PERCY_PAGE_LOAD_TIMEOUT` / `PERCY_STORY_RENDER_TIMEOUT` are raised, so tuning those can never cause a spurious protocol timeout.
- `PERCY_CDP_TIMEOUT` overrides it; `PERCY_CDP_TIMEOUT=0` disables it.
- On expiry it **rejects**, so the SDK's existing `withPage` retry handles it — the same retry that already recovers a story whose preview page reloads mid-transition.
- The timer is cleared on reply and on close, so it can never fire late. The raw-message path stays untimed — a session owns that reply.

## Why the previous fix wasn't enough

This was previously diagnosed as the preview page reloading itself (`next/router` calling `window.location.reload()`), and fixed with an in-page render deadline. That fix is correct and shipped, but this is a different branch of the same failure — reported runs on 10.0.2 still stall at the same story with **the 30s deadline never firing**.

Reproduced with the real CLI `Page` driving the real shipped `evalSetCurrentStory`:

| scenario | in-page 30s deadline | CDP reply | result |
|---|---|---|---|
| story never renders (renderer running) | fires | — | clean error ✅ |
| self-reload (`next/router`), 7 timings | n/a | rejects in 52–464ms | retry ✅ |
| renderer crash | n/a | `Session crashed!` | rejects ✅ |
| **page frozen** (`Page.setWebLifecycleState`) | **can't fire** | **never** | **silent hang ∞** |
| **renderer SIGSTOP** (alive, unscheduled) | **can't fire** | **never** | **silent hang ∞** |

The last two rows match the reported signature exactly: total silence, no error, no timeout, CPU 0.5–5%, target still attached — consistent with a 2-core/8GB CI agent under memory pressure.

## Test plan

- [x] **New unit specs** — `packages/core/test/unit/session.test.js` (11 specs): for each of `Session.send` and `Browser.send`, the deadline fires and names the command, points at the `PERCY_CDP_TIMEOUT` override, does not fire when a reply arrives, is cleared on reply so it cannot fire late, is cleared on close, and is disabled by `PERCY_CDP_TIMEOUT=0`; plus the raw-message path staying untimed.
- [x] **Reproduced end to end** on a 2-core container running the real `percy storybook` (`@percy/cli` 1.32.7 + `@percy/storybook` 10.0.2, Chrome 143 linux-x64). Unfixed, the run goes completely silent after `Page created` at ~0.1% CPU until the 5-minute monitoring timeout — no error, no timeout, no retry:

```
[percy:core:page] Page created (911ms)
[percy:core:page] Page created (35ms)
... monitoring heartbeats only ...
[percy:monitoring] Stopped monitoring system metrics
```

  With the deadline backported onto that same 1.32.7 install, the identical run reports the hanging command and recovers via the existing retry:

```
[percy:core:session] Error: Protocol error (Runtime.enable): Timed out after 30000ms ...
[percy:core:session] Error: Protocol error (Network.enable): Timed out after 30000ms ...
[percy:storybook:utils] Retrying because error occurred in: about url, attempt: 1
```

  That also identifies what was stranding the process — `Runtime.enable` / `Network.enable`, the first commands sent to a new page's session. Core asset-discovery plumbing, unrelated to any SDK.
- [x] **A/B confirms causation**: with the deadline disabled (`PERCY_CDP_TIMEOUT=0`) the same runs hang indefinitely again.
- [x] **Normal path unaffected**: with the renderer running, an in-page deadline still wins the race (4.0s vs a 6.0s CDP deadline), so callers keep their own better-quality errors.
- [x] `eslint` clean.

### Note on the browser-scoped deadline

The first version of this PR bounded `Session.send` only, on the reasoning that a wedged renderer leaves the browser process responsive. The container run disproved that: it stranded in `browser.page()` → `Target.createBrowserContext`, before any page existed. `Browser.send` has the identical unbounded-promise shape, so it is bounded here too.
