### PR TITLE
test(cli-app): close the branch-coverage gap and add the package to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
           - '@percy/config'
           - '@percy/core'
           - '@percy/cli'
+          - '@percy/cli-app'
           - '@percy/cli-command'
           - '@percy/cli-exec'
           - '@percy/cli-snapshot'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,6 +65,7 @@ jobs:
           - '@percy/config'
           - '@percy/core'
           - '@percy/cli'
+          - '@percy/cli-app'
           - '@percy/cli-command'
           - '@percy/cli-exec'
           - '@percy/cli-snapshot'

--- a/packages/cli-app/test/exec.test.js
+++ b/packages/cli-app/test/exec.test.js
@@ -387,6 +387,25 @@ describe('percy app:exec', () => {
       expect(log.warn).toHaveBeenCalled();
     });
 
+    it('falls back and reports err.message when the error has no code', () => {
+      // The warning interpolates `err.code || err.message`. Every other
+      // fallback spec throws an error carrying a code (EACCES/EROFS/EEXIST),
+      // so the `err.message` arm is never taken and the package sits below
+      // the 100% branch gate.
+      spyOn(fs, 'mkdirSync').and.callFake((dirPath) => {
+        if (dirPath === path.join(process.cwd(), '.percy-out')) {
+          throw new Error('codeless mkdir failure');
+        }
+      });
+      const log = { warn: jasmine.createSpy('warn') };
+      const ctx = ctxFor(['maestro', 'test', 'flow.yaml']);
+      maybeInjectScreenshotDir(ctx, log);
+      const fallback = path.join(os.tmpdir(), `percy-maestro-${process.pid}`);
+      expect(process.env.PERCY_MAESTRO_SCREENSHOT_DIR).toBe(fallback);
+      expect(log.warn).toHaveBeenCalledTimes(1);
+      expect(log.warn.calls.argsFor(0)[0]).toContain('codeless mkdir failure');
+    });
+
     it('skips for `maestro hierarchy` (not a test command)', () => {
       const mkdir = spyOn(fs, 'mkdirSync').and.callFake(() => {});
       const argv = ['maestro', 'hierarchy', '--udid', 'X'];
@@ -762,6 +781,22 @@ describe('percy app:exec', () => {
       });
       expect(ctx.argv).toEqual(argv);
       expect(log.debug).toHaveBeenCalled();
+    });
+
+    it('no-ops (debug) reporting err.message when the throw has no code', async () => {
+      // Same `err.code || err.message` branch as the screenshot-dir fallback:
+      // the ENOENT spec above always supplies a code, so the message arm is
+      // otherwise unreachable.
+      const log = { debug: jasmine.createSpy('debug') };
+      const argv = ['maestro', '--platform=ios', 'test', 'flow.yaml'];
+      const ctx = ctxFor(argv);
+      await maybeInjectDriverHostPort(ctx, log, {
+        execMaestro: () => { throw new Error('codeless spawn failure'); },
+        pickFreePort: () => 9555
+      });
+      expect(ctx.argv).toEqual(argv);
+      expect(log.debug).toHaveBeenCalled();
+      expect(log.debug.calls.argsFor(0)[0]).toContain('codeless spawn failure');
     });
 
     it('no-ops (debug) when execMaestro returns a non-zero status', async () => {


### PR DESCRIPTION
Adds `@percy/cli-app` to CI. It was the only one of 18 packages missing from **both** the `test.yml` and `windows.yml` matrices, so its 81 specs have never run in CI on any platform.

Adding it as-is would have turned CI red — the package sits at **98.44% branch coverage** against the repo's 100% threshold:

```
maestro-inject.js | 100% stmts | 98.44% branch | uncovered: 157, 273
ERROR: Coverage for branches (98.44%) does not meet global threshold (100%)
```

## The uncovered branch is not the one it looks like

Both lines contain a `log?.` optional call, which is the obvious suspect. It isn't that. The gap is **`err.code || err.message`**, interpolated into the warning at `maestro-inject.js:157` and the debug line at `:273`. Every existing spec throws an error carrying a code (`EACCES`, `EROFS`, `EEXIST`, `ENOENT`), so the `err.message` arm is unreachable.

Worth stating explicitly because it is a trap for the next fallback spec: adding another coded-error case moves no coverage at all.

Two specs throw **codeless** errors to cover it, and `cli-app` joins both matrices in the same commit so CI never observes a failing job.

## Verification

Run the way these workflows currently do — Node 14:

```
Executed 83 of 83 specs SUCCESS
All files          | 100 | 100 | 100 | 100
maestro-inject.js  | 100 | 100 | 100 | 100
EXIT=0
```

## Found via, but deliberately separate from, the Node 20 work

Surfaced while auditing package coverage for #2386. It is unrelated to that migration — the gap is version-agnostic and would fail identically on any Node — so it is kept off that branch rather than widening a release-bound PR.

One note for reviewers of #2386: running this same suite on **master + Node 20** reports `All files | 0 | 0 | 0 | 0` and still exits 0. That is the vacuous-coverage failure mode #2386 fixes, reproduced here incidentally. It is why the verification above was run on Node 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)