### PR TITLE
fix(core): unref the CDP deadline so it can't delay process exit

### DIFF
--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -313,6 +313,10 @@ export class Browser extends EventEmitter {
               message: cdpTimeoutMessage(method, timeout)
             }));
           }, timeout);
+
+          // See the note in session.js: the watchdog must not keep the event
+          // loop alive once the real work has finished.
+          callback.timer.unref();
         }
 
         this.#callbacks.set(id, callback);

--- a/packages/core/src/session.js
+++ b/packages/core/src/session.js
@@ -105,6 +105,11 @@ export class Session extends EventEmitter {
             message: cdpTimeoutMessage(method, timeout)
           }));
         }, timeout);
+
+        // A watchdog must never be the reason the process cannot exit: an
+        // orphaned send whose reply is not coming would otherwise hold the
+        // event loop open for the full deadline after the work is finished.
+        callback.timer.unref();
       }
 
       this.#callbacks.set(id, callback);

--- a/packages/core/test/unit/session.test.js
+++ b/packages/core/test/unit/session.test.js
@@ -30,6 +30,28 @@ function makeSession(browser) {
   });
 }
 
+// Captures the timers a block creates, so the deadline itself can be inspected.
+// Waits inside the block must use the real setTimeout handed to the callback,
+// otherwise they are captured too and there is no telling which timer is which.
+async function captureTimers(fn) {
+  let created = [];
+  let realSetTimeout = global.setTimeout;
+
+  global.setTimeout = (handler, ms, ...rest) => {
+    let timer = realSetTimeout(handler, ms, ...rest);
+    created.push(timer);
+    return timer;
+  };
+
+  try {
+    await fn(realSetTimeout);
+  } finally {
+    global.setTimeout = realSetTimeout;
+  }
+
+  return created;
+}
+
 describe('Unit / Session', () => {
   let browser, session;
 
@@ -105,6 +127,25 @@ describe('Unit / Session', () => {
     await new Promise(r => setTimeout(r, 200));
     expect(settled).toBe(false);
   });
+
+  // An orphaned send - one whose reply is never coming - would otherwise keep
+  // the event loop alive for the whole deadline after the real work is done,
+  // so `percy snapshot` can sit idle for two minutes past "Finalized build".
+  it('does not let the deadline hold the event loop open', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '5000';
+
+    let timers = await captureTimers(async realSetTimeout => {
+      // handled up front: _handleClose() below rejects this send, and an
+      // unhandled rejection would surface as a failure in a later spec
+      session.send('Runtime.evaluate', {}).catch(() => {});
+      await new Promise(r => realSetTimeout(r, 10));
+    });
+
+    expect(timers.length).toEqual(1);
+    expect(timers[0].hasRef()).toBe(false);
+
+    session._handleClose();
+  });
 });
 
 // The browser process can go silent the same way a renderer can. Target
@@ -169,5 +210,17 @@ describe('Unit / Browser CDP deadline', () => {
 
     await new Promise(r => setTimeout(r, 200));
     expect(settled).toBe(false);
+  });
+
+  it('does not let the deadline hold the event loop open', async () => {
+    process.env.PERCY_CDP_TIMEOUT = '5000';
+
+    let timers = await captureTimers(async realSetTimeout => {
+      browser.send('Target.createBrowserContext', {}).catch(() => {});
+      await new Promise(r => realSetTimeout(r, 10));
+    });
+
+    expect(timers.length).toEqual(1);
+    expect(timers[0].hasRef()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to the CDP send deadline. The deadline is a watchdog, but its timer was not `unref`'d, so it holds the Node event loop open.

An **orphaned send** — one whose reply is never coming — leaves that timer live for the full deadline. This is not exotic: it happens routinely when a page closes with a `Fetch.continueResponse` still in flight. By then the real work is done, so the CLI sits idle for up to two minutes *after* printing `Finalized build #…` before exiting.

I hit this intermittently (once in four runs) while capturing a real Storybook: the run went quiet after finalizing and exited 116s later, exactly when the deadline fired.

```
[percy:core] Finalized build #10544: https://percy.io/…
[percy:client] Sending Build Events
[percy:core:session] Protocol timeout (Fetch.continueResponse) after 120000ms (116197ms)   <- 116s of idling
```

A watchdog should never be the reason a process cannot exit. `unref()` matches the existing precedent in `server.js`, and the timer still fires normally whenever anything else is keeping the loop alive — which is the case for every send that matters.

## Test plan

- Two new specs (one per send path) capture the created timer and assert `hasRef() === false`, so a future change that re-refs the watchdog fails the suite.
- All 13 specs in `packages/core/test/unit/session.test.js` pass; `eslint` clean.
- Verified in a real process with a probe holding one orphaned send at a 30s deadline:

  | | process exit |
  | --- | --- |
  | unref'd (this PR) | **346ms** |
  | ref'd (before) | **30162ms** |

## Notes

- Deliberately unguarded `.unref()` rather than `.unref?.()`: `server.js:226` already does the same, and an optional call would add a branch whose false arm is unreachable in Node, breaking the 100% branch-coverage gate.
- The new spec helper swaps `global.setTimeout` to capture the deadline, and hands the real `setTimeout` to the callback so its own waits aren't captured — otherwise there's no telling which timer is which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)