### PR TITLE
fix(dom): stop stamping live stylesheet <link>s, duplicating them (PER-10610)

### DIFF
--- a/packages/dom/src/clone-dom.js
+++ b/packages/dom/src/clone-dom.js
@@ -49,7 +49,7 @@ function cloneElementWithoutLifecycle(element) {
 }
 
 export function cloneNodeAndShadow(ctx) {
-  let { dom, disableShadowDOM, forceShadowAsLightDOM, resources, cache, enableJavaScript } = ctx;
+  let { dom, disableShadowDOM, forceShadowAsLightDOM, resources, cache, enableJavaScript, styleSheetClones } = ctx;
   // clones shadow DOM and light DOM for a given node
   let cloneNode = (node, parent) => {
     try {
@@ -72,6 +72,10 @@ export function cloneNodeAndShadow(ctx) {
       markElement(node, disableShadowDOM, forceShadowAsLightDOM);
 
       let clone = cloneElementWithoutLifecycle(node);
+
+      if (styleSheetClones && (node.nodeName === 'LINK' || node.nodeName === 'STYLE')) {
+        styleSheetClones.set(node, clone);
+      }
 
       // Custom-element :state() is captured by the fallback path in
       // serialize-custom-states.js (live el.matches against state names

--- a/packages/dom/src/prepare-dom.js
+++ b/packages/dom/src/prepare-dom.js
@@ -11,15 +11,8 @@ export function markElement(domElement, disableShadowDOM, forceShadowAsLightDOM)
   // Custom elements with ElementInternals or closed shadow roots also get
   // stamped so the post-clone state-fallback can locate their clones.
   let tagName = domElement.tagName?.toLowerCase();
-  // Stylesheet <link>s are stamped so the pseudo-class serializer can locate
-  // the sheet's clone element and anchor its rewritten interactive-state rules
-  // immediately after it — preserving the sheet's original cascade position
-  // instead of appending at the end of <head> (PER-10077).
-  let isStylesheetLink = tagName === 'link' &&
-    /(^|\s)stylesheet(\s|$)/i.test(domElement.getAttribute('rel') || '');
   if (
     ['input', 'textarea', 'select', 'iframe', 'canvas', 'video', 'style', 'dialog'].includes(tagName) ||
-    isStylesheetLink ||
     isCustomElement(domElement)
   ) {
     if (!domElement.getAttribute('data-percy-element-id')) {

--- a/packages/dom/src/serialize-cssom.js
+++ b/packages/dom/src/serialize-cssom.js
@@ -51,7 +51,7 @@ function createStyleResource(styleSheet) {
 }
 
 export function serializeCSSOM(ctx) {
-  let { dom, clone, resources, cache, warnings, ignoreStyleSheetSerializationErrors } = ctx;
+  let { dom, clone, resources, cache, warnings, ignoreStyleSheetSerializationErrors, styleSheetClones } = ctx;
   // in-memory CSSOM into their respective DOM nodes.
   let styleSheets = null;
   // catch error in case styleSheets property is not available (overwritten to throw error)
@@ -81,6 +81,7 @@ export function serializeCSSOM(ctx) {
 
           cloneOwnerNode.parentNode.insertBefore(style, cloneOwnerNode.nextSibling);
           cloneOwnerNode.remove();
+          styleSheetClones?.set(styleSheet.ownerNode, style);
         } catch (err) {
           handleErrors(err, 'Error serializing stylesheet: ', cloneOwnerNode, {
             styleId: styleId

--- a/packages/dom/src/serialize-dom.js
+++ b/packages/dom/src/serialize-dom.js
@@ -112,6 +112,7 @@ export function serializeDOM(options) {
     warnings: new Set(),
     hints: new Set(),
     cache: new Map(),
+    styleSheetClones: new WeakMap(),
     shadowRootElements: [],
     enableJavaScript,
     disableShadowDOM,

--- a/packages/dom/src/serialize-pseudo-classes.js
+++ b/packages/dom/src/serialize-pseudo-classes.js
@@ -510,11 +510,11 @@ function extractPseudoClassRules(ctx) {
     styleElement.textContent = rewrittenRules.join('\n');
 
     if (owner === null) {
-      injectAtSheetPosition(ctx.clone, sheet, styleElement, ctx.clone.head || ctx.clone.querySelector('head'));
+      injectAtSheetPosition(ctx, ctx.clone, sheet, styleElement, ctx.clone.head || ctx.clone.querySelector('head'));
     } else {
       const cloneHost = cloneByPercyId.get(owner.getAttribute('data-percy-element-id'));
       if (cloneHost && cloneHost.shadowRoot) {
-        injectAtSheetPosition(cloneHost.shadowRoot, sheet, styleElement, cloneHost.shadowRoot);
+        injectAtSheetPosition(ctx, cloneHost.shadowRoot, sheet, styleElement, cloneHost.shadowRoot);
       }
     }
   }
@@ -523,13 +523,16 @@ function extractPseudoClassRules(ctx) {
 // Insert an interactive-states <style> immediately AFTER its source sheet's
 // clone element so the copy keeps the sheet's original source-order rank —
 // later stylesheets still win equal-specificity ties, exactly as on the live
-// page (PER-10077). The sheet's ownerNode (<style> / <link rel=stylesheet>) is
-// stamped with a data-percy-element-id, which serialize-cssom preserves on any
-// node it rebuilds in place. Falls back to appending at the scope's end when
-// the sheet has no locatable clone anchor.
-function injectAtSheetPosition(scopeRoot, sheet, styleElement, fallbackTarget) {
-  const anchorId = sheet.ownerNode.getAttribute('data-percy-element-id');
-  const anchor = anchorId ? scopeRoot.querySelector(`[data-percy-element-id="${anchorId}"]`) : null;
+// page (PER-10077).
+function injectAtSheetPosition(ctx, scopeRoot, sheet, styleElement, fallbackTarget) {
+  const ownerNode = sheet.ownerNode;
+  let anchor = ownerNode ? ctx.styleSheetClones?.get(ownerNode) : null;
+
+  if (!anchor?.parentNode && ownerNode) {
+    const anchorId = ownerNode.getAttribute('data-percy-element-id');
+    anchor = anchorId ? scopeRoot.querySelector(`[data-percy-element-id="${anchorId}"]`) : null;
+  }
+
   const anchorParent = anchor ? anchor.parentNode : null;
   if (anchorParent) {
     anchorParent.insertBefore(styleElement, anchor.nextSibling);

--- a/packages/dom/test/assets/hover-anchor.css
+++ b/packages/dom/test/assets/hover-anchor.css
@@ -1,0 +1,1 @@
+.lbtn:hover { color: red }

--- a/packages/dom/test/serialize-dom.test.js
+++ b/packages/dom/test/serialize-dom.test.js
@@ -883,11 +883,18 @@ describe('serializeDOM', () => {
     });
   });
 
-  describe('stylesheet <link> stamping (PER-10077 cascade anchoring)', () => {
-    it('stamps only stylesheet <link>s with a percy element id', () => {
-      // The pseudo-class serializer anchors its rewritten rules after a sheet's
-      // clone element, found via data-percy-element-id — so stylesheet links
-      // need one. Non-stylesheet links (preload, icon, …) do not.
+  describe('stylesheet <link> handling (PER-10610)', () => {
+    it('leaves a live stylesheet <link> equal to what a head manager rendered', () => {
+      withExample('<link rel="stylesheet" href="data:text/css,.lx{color:red}">', { withShadow: false });
+      let link = document.querySelector('link[rel="stylesheet"][href^="data:text/css,.lx"]');
+      let rendered = link.cloneNode();
+
+      serializeDOM();
+
+      expect(link.isEqualNode(rendered)).toBe(true);
+    });
+
+    it('does not stamp stylesheet <link>s in the serialized output', () => {
       withExample(
         '<link rel="stylesheet" href="data:text/css,.lx{color:red}">' +
         '<link rel="preload" as="style" href="data:text/css,.ly{color:red}">' +
@@ -895,9 +902,47 @@ describe('serializeDOM', () => {
         { withShadow: false }
       );
       let $ = parseDOM(serializeDOM().html, 'plain');
-      expect($('link[rel="stylesheet"]')[0].getAttribute('data-percy-element-id')).toBeTruthy();
+      expect($('link[rel="stylesheet"]')[0].getAttribute('data-percy-element-id')).toBeNull();
       expect($('link[rel="preload"]')[0].getAttribute('data-percy-element-id')).toBeNull();
       expect($('link:not([rel])')[0].getAttribute('data-percy-element-id')).toBeNull();
+    });
+
+    it('does not accumulate <link>s when a head manager reconciles between snapshots', () => {
+      withExample('<link rel="stylesheet" href="data:text/css,.lrec{color:red}">', { withShadow: false });
+      let link = document.querySelector('link[rel="stylesheet"][href^="data:text/css,.lrec"]');
+      let rendered = link.cloneNode();
+      let reconcile = () => {
+        if (!link.isEqualNode(rendered)) link.after(rendered.cloneNode());
+      };
+
+      serializeDOM();
+      reconcile();
+      let html = serializeDOM().html;
+
+      expect(html.split('data:text/css,.lrec{').length - 1).toEqual(1);
+    });
+
+    it('still anchors a rewritten copy after its source <link>, not at end of head (PER-10077)', async () => {
+      withExample(
+        '<link rel="stylesheet" href="base/test/assets/hover-anchor.css">' +
+        '<style>.lbtn.later { color: blue }</style>' +
+        '<button class="lbtn later">go</button>',
+        { withShadow: false }
+      );
+      let link = document.querySelector('link[href="base/test/assets/hover-anchor.css"]');
+      await new Promise((resolve, reject) => {
+        if (link.sheet) return resolve();
+        link.addEventListener('load', resolve, { once: true });
+        link.addEventListener('error', () => reject(new Error('hover-anchor.css failed to load')), { once: true });
+      });
+
+      let html = serializeDOM({ enablePseudoClassSerialization: true }).html;
+      let sourceIdx = html.indexOf('hover-anchor.css');
+      let copyIdx = html.indexOf('.lbtn[data-percy-hover]');
+      let laterIdx = html.indexOf('.lbtn.later');
+      expect(copyIdx).toBeGreaterThan(-1);
+      expect(copyIdx).toBeGreaterThan(sourceIdx);
+      expect(copyIdx).toBeLessThan(laterIdx);
     });
   });
 


### PR DESCRIPTION
Fixes #2398 · [PER-10610](https://browserstack.atlassian.net/browse/PER-10610)

## Summary

Since 1.32.6, some archived DOM snapshots contain the same stylesheet `<link>` twice, changing the effective CSS source order so unintended styles win. 1.32.5 emits it once.

`packages/dom` changed in exactly **one** functional commit across 1.32.5 → 1.32.7 — 5c39872a (#2342, PER-10077) — and `packages/dom/src` didn't change at all in 1.32.7, which matches the reporter seeing it in both. That commit added the only write `@percy/dom` has ever made to a live stylesheet link:

> `prepare-dom.js` `markElement()` stamps `data-percy-element-id` on `<link rel=stylesheet>` so `injectAtSheetPosition` can find the sheet's clone and anchor its rewritten interactive-state rules there.

**Nothing in the package emits a second `<link>` for an http(s) sheet** — every `<link>`-creating site was audited (`serialize-cssom`'s blob and adopted branches only; both pre-1.32.6, neither matching the report). The duplicate is created by the page itself.

Unlike the pseudo-class markers, which `stampOnce` records on `ctx._liveMutations` for `cleanupInteractiveStateMarkers` to undo, this `setAttribute` is raw and **never cleaned off the live page**. Head-managing frameworks (next/head's head-manager, react-helmet, vue-meta) reconcile `<head>` children with `isEqualNode()`, so a managed `<link>` carrying an unexpected attribute compares unequal and the manager re-inserts its own copy at the end of `<head>` — a duplicate href in a new cascade position.

Because `markElement` runs inside the synchronous clone walk, the reconcile lands *after* that snapshot: the first is clean and every later one carries the duplicate. That is why only *some* archived DOMs showed it.

## Fix

Fix the cause, not the symptom: don't touch the live page at all. `cloneNodeAndShadow` records a live→clone `WeakMap` (`ctx.styleSheetClones`) for every `<style>`/`<link>` as it clones them, and `injectAtSheetPosition` resolves its anchor by **node identity** through that map.

PER-10077's cascade anchoring is fully preserved (covered by spec). No stylesheet `<link>` is mutated or stamped — on the live page or in the output.

## Design decisions

Recording these here rather than as code comments.

**Why a live→clone map instead of a marker attribute.** The anchor only has to be found *during* serialization, so it never needed to be persisted in the DOM at all. Keying on node identity gives the same O(1) lookup with zero observable effect on the customer's page — which is the actual invariant that was violated. It also makes the anchor lookup shadow-safe by construction, where the previous `scopeRoot.querySelector` could not pierce shadow roots.

**Why `WeakMap`.** Keys are live DOM nodes and the map is never iterated. Weak refs mean a node detached mid-serialization isn't retained for the lifetime of `ctx`.

**Why `<style>` is in the map too, not just `<link>`.** `<style>` is still stamped (unchanged from 1.32.5 — pre-existing behavior, and it isn't the reported regression), so it would work via the fallback. Including it keeps one resolution path for both owner-node kinds instead of branching on tag name.

**Why `serialize-cssom` repoints the map.** It replaces a CSSOM `<style>` clone in place (`insertBefore` + `remove`) and runs *before* `serializePseudoClasses`. Without repointing, the map would hand back a detached node. The `?.set` is a no-op for direct callers that build a `ctx` without the map.

**Fallback chain, in order.** map → `data-percy-element-id` lookup → append at end of `<head>` (the pre-PER-10077 behavior). Each step degrades to something correct rather than throwing, and `anchor.parentNode` is checked so a detached hit falls through instead of being used.

**Why `markElement` keeps the `tagName` local.** #2342 extracted it; it's still used by the `includes()` check, so only the `isStylesheetLink` branch is removed. This leaves `markElement` functionally identical to 1.32.5.

**`sheet.ownerNode` is now null-guarded.** The previous code dereferenced it unconditionally. Not reachable today (`collectStyleSheets` reads only `scope.styleSheets`, which excludes adopted sheets), but an unguarded throw here aborts the entire snapshot, and the guard is free.

**Scope.** Contained to `@percy/dom`: no other package reads `data-percy-element-id` off a `<link>` (core/webdriver-utils reference it only for iframes). Independent of PER-10588, which gates the interactive-state *injection* but leaves `markElement`'s `<link>` stamp unconditional — so it would not have fixed this.

**Rebased onto master (PER-10588, #2399) rather than merged.** The branch was behind and conflicted. The only conflict was positional in `serialize-dom.test.js` — master inserted an `interactive-state serialization opt-in gate (PER-10588)` block immediately above the `stylesheet <link> stamping (PER-10077)` block this PR replaces; git could not tell "new neighbour" from "rewritten block". Master's gate block is kept verbatim and this PR's `stylesheet <link> handling (PER-10610)` block takes the PER-10077 block's place. All five source files merged clean, and the fix is unchanged by the rebase. Rebase over merge keeps the PR one reviewable commit, matching the surrounding history.

**The PER-10077 anchoring spec now passes `enablePseudoClassSerialization: true`.** PER-10588 landed after this branch was cut and made interactive-state serialization opt-in, default off. Without the flag that spec would call `serializeDOM()` with the rewriting disabled, find no `.lbtn[data-percy-hover]` copy, and fail — or worse, pass vacuously if the assertion were loosened. The flag restores what the spec is there to guard. The other three specs deliberately stay on the default path: they assert on `markElement`, which the PER-10588 gate does not touch, so they must hold with the feature off — which is how the reporter hit the bug in the first place.

## Test plan

Four specs in a new `stylesheet <link> handling (PER-10610)` block. **Three fail with the stamp restored and pass without it** — verified in both directions:

| Spec | Fails on buggy code |
|---|---|
| leaves a live stylesheet `<link>` equal to what a head manager rendered (`isEqualNode`) | ✅ |
| does not stamp stylesheet `<link>`s in the serialized output | ✅ |
| does not accumulate `<link>`s when a head manager reconciles between snapshots | ✅ |
| still anchors a rewritten copy after its source `<link>`, not at end of head (PER-10077) | — (guards that the fix doesn't regress #2342) |

The third reproduces the reported symptom end to end: it reconciles a head-managed `<link>` between two `serializeDOM` passes and asserts the href still appears exactly once. `isEqualNode` is used rather than an attribute allowlist because it catches *any* change serialization makes to the live element, and it is the same predicate the real head managers use. The inverted PER-10077 spec that asserted links *are* stamped is replaced.

Re-verified after the rebase, on `ChromeHeadless` against `origin/master` (719021a0) in the same worktree:

| Run | Failing specs |
|---|---|
| master baseline | 80 |
| this branch | 80 — **identical set, 0 new, 0 fixed** (`comm` on the sorted failure names) |
| this branch, stamp restored | 86 — the 80, plus exactly the 3 specs above |

The 80 are pre-existing local failures (readiness font/js_idle, video poster timeouts, focus specs needing real window focus), unrelated to this change and equally present on master. All four PER-10610 specs pass on the fix. Root `yarn lint` is clean. Firefox was not run locally (no binary available); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PER-10610]: https://browserstack.atlassian.net/browse/PER-10610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
