### PR TITLE
fix(sdk-utils): drop the CLI major-version gate that blocks 2.x

### DIFF
--- a/packages/sdk-utils/src/percy-enabled.js
+++ b/packages/sdk-utils/src/percy-enabled.js
@@ -22,13 +22,6 @@ export async function isPercyEnabled() {
       error = e;
     }
 
-    // No CLI major-version gate here. The original check (added Oct 2020 with
-    // this package) was `version[0] !== 1`, written to refuse the legacy 0.x
-    // @percy/agent whose protocol predates /percy/healthcheck. Nothing above 1
-    // existed then, so it was meant as a floor but reads as a ceiling: it
-    // silently disables snapshots against any CLI 2.x+. The 0.x agent has been
-    // gone for years, so the guard protects nothing and only blocks the next
-    // major. `percy.version` stays populated for SDKs that want to read it.
     if (!percy.enabled) {
       log.info('Percy is not running, disabling snapshots');
       log.debug(error);

--- a/packages/sdk-utils/src/percy-enabled.js
+++ b/packages/sdk-utils/src/percy-enabled.js
@@ -22,11 +22,14 @@ export async function isPercyEnabled() {
       error = e;
     }
 
-    if (percy.enabled && percy.version.major !== 1) {
-      log.info('Unsupported Percy CLI version, disabling snapshots');
-      log.debug(`Found version: ${percy.version}`);
-      percy.enabled = false;
-    } else if (!percy.enabled) {
+    // No CLI major-version gate here. The original check (added Oct 2020 with
+    // this package) was `version[0] !== 1`, written to refuse the legacy 0.x
+    // @percy/agent whose protocol predates /percy/healthcheck. Nothing above 1
+    // existed then, so it was meant as a floor but reads as a ceiling: it
+    // silently disables snapshots against any CLI 2.x+. The 0.x agent has been
+    // gone for years, so the guard protects nothing and only blocks the next
+    // major. `percy.version` stays populated for SDKs that want to read it.
+    if (!percy.enabled) {
       log.info('Percy is not running, disabling snapshots');
       log.debug(error);
     }

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -104,13 +104,23 @@ describe('SDK Utils', () => {
       ]));
     });
 
-    it('disables snapshots when the API version is unsupported', async () => {
-      await helpers.test('version', '0.1.0');
-      await expectAsync(isPercyEnabled()).toBeResolvedTo(false);
+    it('stays enabled against a next-major CLI', async () => {
+      // Replaces the old `major !== 1` gate, which disabled snapshots against
+      // any CLI 2.x+. This is the regression guard for that: a future major
+      // must not silently turn capture off.
+      await helpers.test('version', '2.0.0');
+      await expectAsync(isPercyEnabled()).toBeResolvedTo(true);
 
-      expect(helpers.logger.stdout).toEqual(jasmine.arrayContaining([
-        '[percy] Unsupported Percy CLI version, disabling snapshots'
+      expect(helpers.logger.stdout).not.toEqual(jasmine.arrayContaining([
+        jasmine.stringMatching(/Unsupported Percy CLI version/)
       ]));
+    });
+
+    it('stays enabled against a 0.x CLI', async () => {
+      // The gate was originally aimed at the legacy 0.x @percy/agent. That
+      // agent is long gone, so 0.x is no longer special-cased either.
+      await helpers.test('version', '0.1.0');
+      await expectAsync(isPercyEnabled()).toBeResolvedTo(true);
     });
 
     it('returns false if the build fails during a snapshot', async () => {

--- a/packages/sdk-utils/test/index.test.js
+++ b/packages/sdk-utils/test/index.test.js
@@ -105,9 +105,6 @@ describe('SDK Utils', () => {
     });
 
     it('stays enabled against a next-major CLI', async () => {
-      // Replaces the old `major !== 1` gate, which disabled snapshots against
-      // any CLI 2.x+. This is the regression guard for that: a future major
-      // must not silently turn capture off.
       await helpers.test('version', '2.0.0');
       await expectAsync(isPercyEnabled()).toBeResolvedTo(true);
 
@@ -117,8 +114,6 @@ describe('SDK Utils', () => {
     });
 
     it('stays enabled against a 0.x CLI', async () => {
-      // The gate was originally aimed at the legacy 0.x @percy/agent. That
-      // agent is long gone, so 0.x is no longer special-cased either.
       await helpers.test('version', '0.1.0');
       await expectAsync(isPercyEnabled()).toBeResolvedTo(true);
     });


### PR DESCRIPTION
Removes the check in `isPercyEnabled()` that disables snapshots unless the CLI's major is exactly `1`.

```js
if (percy.enabled && percy.version.major !== 1) {
  log.info('Unsupported Percy CLI version, disabling snapshots');
```

Against a **2.x CLI this silently stops capture** — the build still passes, with zero snapshots and one `info` log as the only signal. That is the worst possible failure shape for a visual testing tool.

## Why the check existed

Added **2020-10-19** in #63, the commit that created `@percy/sdk-utils`, as `getInfo.version[0] !== 1`. That was the CLI 1.0 cutover from the legacy 0.x `@percy/agent`, whose protocol predates `/percy/healthcheck`. The test it replaced pinned `0.1.0` — the fingerprint of that intent.

So it was written as a **floor** at a time when nothing above 1 existed, and only reads as a **ceiling** because it used `!==` where `>=` was meant. Blocking 2.x was never intended; the case simply was not imaginable in 2020. The 0.x agent has been gone for years, so the guard protects nothing and only blocks the next major.

`percy.version` stays populated for SDKs that read it.

## Tests

Replaces the old spec with two, one of which is the direct regression guard:

- **a 2.x CLI stays enabled** — this is the bug
- a 0.x CLI is no longer special-cased

Verified: **170/170 specs, 100% coverage**, node and karma suites both green.

## This does not make a 2.0.0 CLI safe on its own

Two limits worth being explicit about:

1. **The check runs in the customer's installed copy.** Publishing this changes nothing for anyone whose lockfile predates it — they must upgrade first.
2. **This covers only the nine JS SDKs.** Sixteen non-JS SDK repos each carry their own hardcoded copy of the same `major != 1` comparison:

   `percy-capybara` · `percy-selenium-ruby` · `percy-appium-ruby` · `percy-selenium-python` · `percy-playwright-python` · `percy-appium-python` · `percy-selenium-java` · `percy-playwright-java` · `percy-appium-java` · `percy-espresso-java` · `percy-selenium-dotnet` · `percy-playwright-dotnet` · `percy-appium-dotnet` · `percy-tosca-dotnet` (2 targets) · `app-percy-tosca-dotnet` · `percy-xcui-swift`

So the ordering for any future major is: fix all SDKs → release → wait for adoption → **then** bump the CLI. This PR is step one of that, not a green light.

(Scope caveat: found by searching the exact string `"Unsupported Percy CLI version"`, so treat the count as a floor rather than a verified total.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)