### PR TITLE
feat(cli): warn that the next major will require Node 20+

### DIFF
--- a/packages/cli/bin/run.cjs
+++ b/packages/cli/bin/run.cjs
@@ -8,6 +8,11 @@ if (parseInt(process.version.split('.')[0].substring(1), 10) < 14) {
   process.exit(1);
 }
 
+// heads up ahead of the next major release, which raises the minimum to Node 20
+console.warn('Heads up! The next major version of @percy/cli will require Node 20+. ' + (
+  'Either pin @percy/cli to its current major version, or make sure your setup runs ' +
+  'on Node 20+, before the next major release.'));
+
 import('../dist/index.js')
   .then(async ({ percy, checkForUpdate }) => {
     await checkForUpdate();


### PR DESCRIPTION
## What

Tells every user that the **next major version of `@percy/cli` will require Node 20+**, so they can pin or get their setup ready before it lands.

```
$ percy exec -- echo
Heads up! The next major version of @percy/cli will require Node 20+. Either pin
@percy/cli to its current major version, or make sure your setup runs on Node 20+,
before the next major release.
```

## Why

Nothing currently announces the upcoming minimum-version bump. Without a heads up, the first signal users get is a broken pipeline the day the major lands.

## How

Five lines in `packages/cli/bin/run.cjs`, after the existing Node < 14 gate (which is untouched):

```js
// heads up ahead of the next major release, which raises the minimum to Node 20
console.warn('Heads up! The next major version of @percy/cli will require Node 20+. ' + (
  'Either pin @percy/cli to its current major version, or make sure your setup runs ' +
  'on Node 20+, before the next major release.'));
```

Shown to everyone, not just users below Node 20 — the announcement matters to anyone who might upgrade across the major, whatever Node they are on today.

## Notes

- **Warning only, nothing breaks.** The current major still supports Node 14+, so `engines` stays `">=14"` — that bump belongs to the major release itself.
- Printed before the `dist/index.js` import, so it fires for every command and never on programmatic use of the package.
- Intentionally has no mute switch. It should be removed when the major ships.

## Testing

Verified by hand on Node v18.20.8 — the warning prints ahead of the command. Lint passes. No unit test: `bin/run.cjs` is the pre-`dist` bootstrap and isn't covered by the jasmine suite, same as the existing `< 14` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)