### PR TITLE
fix(core): don't key a resource under Chrome's abandoned https attempt

### DIFF
--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -682,9 +682,29 @@ export function logAssetInstrumentation(log, category, reason, details) {
   );
 }
 
-// Returns the normalized origin URL of a request
-function originURL(request) {
-  return normalizeURL((request.redirectChain[0] || request).url);
+// True when `from` is `to` with an https:// scheme — the abandoned leg of
+// Chrome's HTTPS-upgrade fallback.
+function isHttpsUpgradeFallback(from, to) {
+  return from.startsWith('https://') && to.startsWith('http://') &&
+    from.slice('https:'.length) === to.slice('http:'.length);
+}
+
+// Returns the URL the document referenced — the head of the redirect chain for
+// a real server redirect. Chrome surfaces its HTTPS-upgrade fallback as a
+// redirect hop, so an http:// URL arrives with the abandoned https:// attempt
+// at the head. Keying a resource under that URL hides the snapshot's own root
+// resource and leaks the fetched page to later snapshots through the URL-keyed
+// discovery cache, so skip those hops.
+export function originURL(request) {
+  let chain = request.redirectChain;
+
+  for (let i = 0; i < chain.length; i++) {
+    let url = normalizeURL(chain[i].url);
+    let next = normalizeURL(chain[i + 1]?.url ?? request.url);
+    if (!isHttpsUpgradeFallback(url, next)) return url;
+  }
+
+  return normalizeURL(request.url);
 }
 
 // Convert Fetch event responseHeaders ([{name, value}, …]) to a header object.

--- a/packages/core/src/network.js
+++ b/packages/core/src/network.js
@@ -694,7 +694,9 @@ function isHttpsUpgradeFallback(from, to) {
 // redirect hop, so an http:// URL arrives with the abandoned https:// attempt
 // at the head. Keying a resource under that URL hides the snapshot's own root
 // resource and leaks the fetched page to later snapshots through the URL-keyed
-// discovery cache, so skip those hops.
+// discovery cache, so skip those hops. A genuine same-path https->http server
+// redirect is indistinguishable from the fallback and is skipped too; that is
+// rare enough (misconfigured proxies) to be the better trade.
 export function originURL(request) {
   let chain = request.redirectChain;
 

--- a/packages/core/test/unit/network.test.js
+++ b/packages/core/test/unit/network.test.js
@@ -1,5 +1,5 @@
 import { setupTest, logger } from '../helpers/index.js';
-import { Network, AbortCodes, pickCookieSession, shouldAttachAuth, raceWithTimeout, resolveDirectFetchMime, flattenLookupAddresses, MetadataBlockedError } from '../../src/network.js';
+import { Network, AbortCodes, pickCookieSession, shouldAttachAuth, raceWithTimeout, resolveDirectFetchMime, flattenLookupAddresses, originURL, MetadataBlockedError } from '../../src/network.js';
 import { AbortError } from '../../src/utils.js';
 
 describe('Unit / Network', () => {
@@ -138,6 +138,56 @@ describe('Unit / Network', () => {
   // flattenLookupAddresses — normalizes the dns.lookup callback address argument
   // (Node's http stack passes an array under Happy Eyeballs; others a string) so
   // the direct-fetch choke point can gate on every candidate connection IP.
+  describe('originURL', () => {
+    // The abandoned https leg of Chrome's upgrade fallback must not become the
+    // resource key — that hid the snapshot's own root resource and leaked the
+    // fetched page to later snapshots of the same URL.
+    it('ignores the abandoned https leg of an HTTPS-upgrade fallback', () => {
+      expect(originURL({
+        url: 'http://example.test/page',
+        redirectChain: [{ url: 'https://example.test/page' }]
+      })).toEqual('http://example.test/page');
+    });
+
+    it('still reports the referenced URL for a real server redirect', () => {
+      expect(originURL({
+        url: 'http://example.test/b',
+        redirectChain: [{ url: 'http://example.test/a' }]
+      })).toEqual('http://example.test/a');
+    });
+
+    it('skips the upgrade fallback but keeps a following server redirect', () => {
+      expect(originURL({
+        url: 'http://example.test/b',
+        redirectChain: [
+          { url: 'https://example.test/a' },
+          { url: 'http://example.test/a' }
+        ]
+      })).toEqual('http://example.test/a');
+    });
+
+    it('does not treat a differing path as an upgrade fallback', () => {
+      expect(originURL({
+        url: 'http://example.test/b',
+        redirectChain: [{ url: 'https://example.test/a' }]
+      })).toEqual('https://example.test/a');
+    });
+
+    it('leaves a genuine https request alone', () => {
+      expect(originURL({
+        url: 'https://example.test/page',
+        redirectChain: []
+      })).toEqual('https://example.test/page');
+    });
+
+    it('normalizes away the hash and keeps the query', () => {
+      expect(originURL({
+        url: 'http://example.test/page?a=1#frag',
+        redirectChain: []
+      })).toEqual('http://example.test/page?a=1');
+    });
+  });
+
   describe('flattenLookupAddresses', () => {
     it('flattens the { address, family }[] form used by Node http (all:true)', () => {
       expect(flattenLookupAddresses([

--- a/packages/core/test/unit/network.test.js
+++ b/packages/core/test/unit/network.test.js
@@ -135,9 +135,6 @@ describe('Unit / Network', () => {
     });
   });
 
-  // flattenLookupAddresses — normalizes the dns.lookup callback address argument
-  // (Node's http stack passes an array under Happy Eyeballs; others a string) so
-  // the direct-fetch choke point can gate on every candidate connection IP.
   describe('originURL', () => {
     // The abandoned https leg of Chrome's upgrade fallback must not become the
     // resource key — that hid the snapshot's own root resource and leaked the
@@ -186,8 +183,32 @@ describe('Unit / Network', () => {
         redirectChain: []
       })).toEqual('http://example.test/page?a=1');
     });
+
+    it('treats a default-port https hop as a fallback of the same http URL', () => {
+      expect(originURL({
+        url: 'http://example.test/page',
+        redirectChain: [{ url: 'https://example.test:443/page' }]
+      })).toEqual('http://example.test/page');
+    });
+
+    it('treats matching explicit non-default ports as a fallback', () => {
+      expect(originURL({
+        url: 'http://example.test:8080/page',
+        redirectChain: [{ url: 'https://example.test:8080/page' }]
+      })).toEqual('http://example.test:8080/page');
+    });
+
+    it('does not treat a differing query string as a fallback', () => {
+      expect(originURL({
+        url: 'http://example.test/page?a=2',
+        redirectChain: [{ url: 'https://example.test/page?a=1' }]
+      })).toEqual('https://example.test/page?a=1');
+    });
   });
 
+  // flattenLookupAddresses — normalizes the dns.lookup callback address argument
+  // (Node's http stack passes an array under Happy Eyeballs; others a string) so
+  // the direct-fetch choke point can gate on every candidate connection IP.
   describe('flattenLookupAddresses', () => {
     it('flattens the { address, family }[] form used by Node http (all:true)', () => {
       expect(flattenLookupAddresses([


### PR DESCRIPTION
## Symptom

A Cypress suite takes three snapshots of the same page URL. The first captures all 14 resources; the other two capture **none** — every sub-resource request goes out over `https://` and fails with `net::ERR_CONNECTION_CLOSED`, and the renderer reports `asset not present`, so the snapshots render completely unstyled. Same host, same CI runner, same `discovery.allowedHostnames` as the 36 snapshots that work.

Across all 39 snapshots of the reported build the correlation is exact: the only three that share a `source-url` are the affected ones, the first of them is fine, and the other two are the only two snapshots in the build with any `ERR_CONNECTION_CLOSED`.

## Root cause

`originURL()` returned `request.redirectChain[0].url`.

Chrome attempts an `http://` main-frame navigation over `https://` first and retries it over `http://` once TLS fails. It surfaces that fallback as a redirect hop, so the successful http request arrives with the *abandoned* https attempt at the head of its redirect chain:

```
Handling request: https://host/page   raw=https://host/page  chain=[]
Handling request: https://host/page   raw=http://host/page   chain=["https://host/page"]
                                      ^ logged and keyed as https://
```

So a plain-http snapshot URL got keyed under an `https://` URL nothing ever referenced. Two consequences:

1. **The snapshot's own root resource was never served.** `parseDomResources` registers it at the declared `http://` URL (`createRootResource` → `normalizeURL`), which never matched the request — `- Serving root resource` does not appear anywhere in the reported 39-snapshot build. Asset discovery silently re-fetched and rendered the **live page** instead of the captured DOM snapshot for every snapshot.

2. **The build-wide discovery cache got poisoned.** The fetched document was saved under the `https://` key. `lookupCacheResource` is keyed by URL alone and shared across the whole build, so on the *next* snapshot of the same URL the https attempt was satisfied by `Fetch.fulfillRequest` from that cache. The upgrade therefore **succeeded**, the document committed over `https://`, and every root-relative sub-resource was requested from a port the origin has no TLS listener on → `ERR_CONNECTION_CLOSED` → nothing captured.

That is why it only ever hit the second and later snapshots of a URL, why it needed a real hostname (Chrome exempts `localhost` and IP literals from HTTPS upgrades, so it does not reproduce locally), and why unrelated snapshots on the identical host were unaffected.

Same family as the earlier method-blind cache issue: the discovery cache is keyed by URL alone, so anything that mis-derives that URL leaks across snapshots.

## Fix

Walk the redirect chain and skip hops that are the abandoned leg of an HTTPS-upgrade fallback — a hop that differs from the one after it only by an `https:` scheme — so a request is keyed by the URL that was really fetched. A real server redirect still reports the URL the document referenced, including one that follows an upgrade fallback.

## Testing

Reproduced against a plain-HTTP origin behind a real hostname (`app.localtest.me`, public DNS → `127.0.0.1`, resolver-mapped so both `:80` and `:443` reach the HTTP-only server), taking two snapshots of one URL.

Before — second snapshot loses everything, matching the reported log:

```
Discovering resources: snap-two
Handling request: https://app.localtest.me/page
- Resource cache hit
Handling request: https://app.localtest.me/style.css
Request failed for https://app.localtest.me/style.css: net::ERR_SSL_PROTOCOL_ERROR
Request failed for https://app.localtest.me/img.svg: net::ERR_SSL_PROTOCOL_ERROR
```

After — the root resource is served (it never was before) and sub-resources resolve over http and hit the cache:

```
Discovering resources: snap-two
Handling request: http://app.localtest.me/page
- Serving root resource
Handling request: http://app.localtest.me/style.css
- Resource cache hit
Handling request: http://app.localtest.me/img.svg
- Resource cache hit
```

The origin also stops being hit for the document at all, since the captured DOM snapshot is now used as intended.

Added six unit tests for `originURL` in `packages/core/test/unit/network.test.js` covering the upgrade fallback, a real server redirect, an upgrade fallback followed by a server redirect, a scheme change with a differing path (not a fallback), a genuine https request, and hash/query normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
