### PR TITLE
Release 1.32.10-beta.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "packages": [
     "packages/*"
   ],

--- a/packages/cli-app/package.json
+++ b/packages/cli-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-app",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -33,7 +33,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.32.9",
-    "@percy/cli-exec": "1.32.9"
+    "@percy/cli-command": "1.32.10-beta.0",
+    "@percy/cli-exec": "1.32.10-beta.0"
   }
 }

--- a/packages/cli-build/package.json
+++ b/packages/cli-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-build",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -36,6 +36,6 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.32.9"
+    "@percy/cli-command": "1.32.10-beta.0"
   }
 }

--- a/packages/cli-command/package.json
+++ b/packages/cli-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-command",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "files": [
     "dist",
@@ -37,9 +37,9 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.32.9",
-    "@percy/core": "1.32.9",
-    "@percy/logger": "1.32.9",
+    "@percy/config": "1.32.10-beta.0",
+    "@percy/core": "1.32.10-beta.0",
+    "@percy/logger": "1.32.10-beta.0",
     "glob-to-regexp": "^0.4.1"
   },
   "optionalDependencies": {

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-config",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -33,6 +33,6 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.32.9"
+    "@percy/cli-command": "1.32.10-beta.0"
   }
 }

--- a/packages/cli-doctor/package.json
+++ b/packages/cli-doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-doctor",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -35,13 +35,13 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.32.9",
-    "@percy/client": "1.32.9",
-    "@percy/config": "1.32.9",
-    "@percy/core": "1.32.9",
-    "@percy/env": "1.32.9",
-    "@percy/logger": "1.32.9",
-    "@percy/monitoring": "1.32.9",
+    "@percy/cli-command": "1.32.10-beta.0",
+    "@percy/client": "1.32.10-beta.0",
+    "@percy/config": "1.32.10-beta.0",
+    "@percy/core": "1.32.10-beta.0",
+    "@percy/env": "1.32.10-beta.0",
+    "@percy/logger": "1.32.10-beta.0",
+    "@percy/monitoring": "1.32.10-beta.0",
     "minimatch": "^9.0.0",
     "ws": "^8.17.1"
   }

--- a/packages/cli-exec/package.json
+++ b/packages/cli-exec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-exec",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -34,8 +34,8 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.32.9",
-    "@percy/logger": "1.32.9",
+    "@percy/cli-command": "1.32.10-beta.0",
+    "@percy/logger": "1.32.10-beta.0",
     "cross-spawn": "^7.0.3",
     "which": "^2.0.2"
   }

--- a/packages/cli-snapshot/package.json
+++ b/packages/cli-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-snapshot",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -33,7 +33,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.32.9",
+    "@percy/cli-command": "1.32.10-beta.0",
     "yaml": "^2.0.0"
   }
 }

--- a/packages/cli-upload/package.json
+++ b/packages/cli-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli-upload",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -33,7 +33,7 @@
     ]
   },
   "dependencies": {
-    "@percy/cli-command": "1.32.9",
+    "@percy/cli-command": "1.32.10-beta.0",
     "fast-glob": "^3.2.11",
     "probe-image-size": "^7.3.0"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/cli",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "files": [
     "bin",
@@ -31,15 +31,15 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/cli-app": "1.32.9",
-    "@percy/cli-build": "1.32.9",
-    "@percy/cli-command": "1.32.9",
-    "@percy/cli-config": "1.32.9",
-    "@percy/cli-doctor": "1.32.9",
-    "@percy/cli-exec": "1.32.9",
-    "@percy/cli-snapshot": "1.32.9",
-    "@percy/cli-upload": "1.32.9",
-    "@percy/client": "1.32.9",
-    "@percy/logger": "1.32.9"
+    "@percy/cli-app": "1.32.10-beta.0",
+    "@percy/cli-build": "1.32.10-beta.0",
+    "@percy/cli-command": "1.32.10-beta.0",
+    "@percy/cli-config": "1.32.10-beta.0",
+    "@percy/cli-doctor": "1.32.10-beta.0",
+    "@percy/cli-exec": "1.32.10-beta.0",
+    "@percy/cli-snapshot": "1.32.10-beta.0",
+    "@percy/cli-upload": "1.32.10-beta.0",
+    "@percy/client": "1.32.10-beta.0",
+    "@percy/logger": "1.32.10-beta.0"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/client",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -33,9 +33,9 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.32.9",
-    "@percy/env": "1.32.9",
-    "@percy/logger": "1.32.9",
+    "@percy/config": "1.32.10-beta.0",
+    "@percy/env": "1.32.10-beta.0",
+    "@percy/logger": "1.32.10-beta.0",
     "pac-proxy-agent": "^7.0.2",
     "pako": "^2.1.0"
   }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/config",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -38,7 +38,7 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/logger": "1.32.9",
+    "@percy/logger": "1.32.10-beta.0",
     "ajv": "^8.6.2",
     "cosmiconfig": "^8.0.0",
     "yaml": "^2.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/core",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -46,12 +46,12 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
-    "@percy/client": "1.32.9",
-    "@percy/config": "1.32.9",
-    "@percy/dom": "1.32.9",
-    "@percy/logger": "1.32.9",
-    "@percy/monitoring": "1.32.9",
-    "@percy/webdriver-utils": "1.32.9",
+    "@percy/client": "1.32.10-beta.0",
+    "@percy/config": "1.32.10-beta.0",
+    "@percy/dom": "1.32.10-beta.0",
+    "@percy/logger": "1.32.10-beta.0",
+    "@percy/monitoring": "1.32.10-beta.0",
+    "@percy/webdriver-utils": "1.32.10-beta.0",
     "adm-zip": "^0.6.0",
     "busboy": "^1.6.0",
     "content-disposition": "^0.5.4",
@@ -67,6 +67,6 @@
     "yaml": "^2.4.1"
   },
   "optionalDependencies": {
-    "@percy/cli-doctor": "1.32.9"
+    "@percy/cli-doctor": "1.32.10-beta.0"
   }
 }

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/dom",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "main": "dist/bundle.js",
   "browser": "dist/bundle.js",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/env",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -32,6 +32,6 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/logger": "1.32.9"
+    "@percy/logger": "1.32.10-beta.0"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/logger",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/monitoring",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -29,9 +29,9 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.32.9",
-    "@percy/logger": "1.32.9",
-    "@percy/sdk-utils": "1.32.9",
+    "@percy/config": "1.32.10-beta.0",
+    "@percy/logger": "1.32.10-beta.0",
+    "@percy/sdk-utils": "1.32.10-beta.0",
     "systeminformation": "^5.25.11"
   }
 }

--- a/packages/sdk-utils/package.json
+++ b/packages/sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/sdk-utils",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"

--- a/packages/webdriver-utils/package.json
+++ b/packages/webdriver-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percy/webdriver-utils",
-  "version": "1.32.9",
+  "version": "1.32.10-beta.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "engines": {
     "node": ">=14"
@@ -29,7 +29,7 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
-    "@percy/config": "1.32.9",
-    "@percy/sdk-utils": "1.32.9"
+    "@percy/config": "1.32.10-beta.0",
+    "@percy/sdk-utils": "1.32.10-beta.0"
   }
 }


### PR DESCRIPTION
Version bump to **`1.32.10-beta.0`** (next `prerelease` off `1.32.9`).

- Bumped via `lerna version 1.32.10-beta.0 --exact --no-git-tag-version --no-push` (the `bump-version` script's underlying command), and `publishConfig.tag` set to **`beta`** across all packages.
- 19 files changed: `lerna.json` + all 18 `packages/*/package.json`.
- On publishing a GitHub Release, this will go to npm under dist-tag **`beta`**.

**Next steps:** review & merge, then cut the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)